### PR TITLE
add missing sys/time.h header

### DIFF
--- a/libqalculate/Calculator.h
+++ b/libqalculate/Calculator.h
@@ -14,6 +14,7 @@
 
 #include <libqalculate/includes.h>
 #include <libqalculate/util.h>
+#include <sys/time.h>
 #include <pthread.h>
 
 /** @file */


### PR DESCRIPTION
struct timeval is defined in sys/time.h with a musl toolchain.

Fixes:
In file included from Function.cc:16:0:
Calculator.h:241:17: error: field 't_print_end' has incomplete type 'timeval'
  struct timeval t_print_end;
                 ^~~~~~~~~~~
Calculator.h:241:9: note: forward declaration of 'struct timeval'
  struct timeval t_print_end;
         ^~~~~~~
In file included from Calculator.cc:14:0:
Calculator.h:241:17: error: field 't_print_end' has incomplete type 'timeval'
  struct timeval t_print_end;
                 ^~~~~~~~~~~
Calculator.h:241:9: note: forward declaration of 'struct timeval'
  struct timeval t_print_end;
         ^~~~~~~
In file included from DataSet.cc:17:0:
Calculator.h:241:17: error: field 't_print_end' has incomplete type 'timeval'
  struct timeval t_print_end;
                 ^~~~~~~~~~~
Calculator.h:241:9: note: forward declaration of 'struct timeval'
  struct timeval t_print_end;
         ^~~~~~~
In file included from Variable.cc:16:0:
Calculator.h:241:17: error: field 't_print_end' has incomplete type 'timeval'
  struct timeval t_print_end;
                 ^~~~~~~~~~~