### PR TITLE
Add QalculateDateTime.cc to POTFILES.in

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,6 +9,7 @@ libqalculate/MathStructure.cc
 libqalculate/Function.cc
 libqalculate/Number.cc
 libqalculate/Prefix.cc
+libqalculate/QalculateDateTime.cc
 libqalculate/Unit.cc
 libqalculate/Variable.cc
 libqalculate/util.cc


### PR DESCRIPTION
It contains translatable strings and otherwise make install complains
if it's missing.