### PR TITLE
use std::getline(input, str, delim)

### DIFF
--- a/libqalculate/Calculator.cc
+++ b/libqalculate/Calculator.cc
@@ -1720,14 +1720,8 @@ class UptimeVariable : public DynamicVariable {
 #	ifdef __linux__
 		std::ifstream proc_uptime("/proc/uptime", std::ios::in);
 		if(proc_uptime.is_open()) {
-			char s_uptime[100];
-			proc_uptime.getline(s_uptime, 100);
-			for(size_t i = 0; i < 100; i++) {
-				if(s_uptime[i] == ' ') {
-					s_uptime[i] = (char) 0;
-					break;
-				}
-			}
+			string s_uptime;
+			getline(proc_uptime, s_uptime, ' ');
 			nr.set(s_uptime);
 		} else {
 			struct sysinfo sf;


### PR DESCRIPTION
std::getline() can read a string up to a delimiter directly
no need to read 100 bytes and clip manually