### PR TITLE
Fix compilation on systems that have const in second argument to iconv

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,7 @@ PKG_CHECK_MODULES(LIBXML, [libxml-2.0 >= 2.3.8])
 AC_SUBST(LIBXML_CFLAGS)
 AC_SUBST(LIBXML_LIBS)
 
-AM_ICONV_LINK()
+AM_ICONV()
 
 dnl  --------------------------------
 dnl | check for readline            |-----------------------------------------

--- a/libqalculate/util.cc
+++ b/libqalculate/util.cc
@@ -706,7 +706,7 @@ char *locale_from_utf8(const char *str) {
 	char *dest, *buffer;
 	buffer = dest = (char*) malloc((outlength + 4) * sizeof(char));
 	if(!buffer) return NULL;
-	size_t err = iconv(conv, (char **) &str, &inlength, &buffer, &outlength);
+	size_t err = iconv(conv, (ICONV_CONST char **) &str, &inlength, &buffer, &outlength);
 	if(err != (size_t) -1) err = iconv(conv, NULL, &inlength, &buffer, &outlength);
 	iconv_close(conv);
 	memset(buffer, 0, 4);
@@ -721,7 +721,7 @@ char *locale_to_utf8(const char *str) {
 	char *dest, *buffer;
 	buffer = dest = (char*) malloc((outlength + 4) * sizeof(char));
 	if(!buffer) return NULL;
-	size_t err = iconv(conv, (char**) &str, &inlength, &buffer, &outlength);
+	size_t err = iconv(conv, (ICONV_CONST char**) &str, &inlength, &buffer, &outlength);
 	if(err != (size_t) -1) err = iconv(conv, NULL, &inlength, &buffer, &outlength);
 	iconv_close(conv);
 	memset(buffer, 0, 4 * sizeof(char));


### PR DESCRIPTION
Use ICONV_CONST from iconv.m4 to support compilation on systems that
have const in the second argument to iconv.