### PR TITLE
Add Spanish translation of definitions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -264,7 +264,7 @@ AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE",[The package name for gettext])
 
 dnl Please keep this in alphabetical order
-ALL_LINGUAS="fr nl sv zh_CN"
+ALL_LINGUAS="es fr nl sv zh_CN"
 AM_GNU_GETTEXT(external)
 AM_GNU_GETTEXT_VERSION([0.19.8])
 

--- a/po-defs/es.po
+++ b/po-defs/es.po
@@ -1,0 +1,11108 @@
+# Spanish translations for Qalculate! package.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the Qalculate! package.
+
+msgid ""
+msgstr ""
+"Project-Id-Version: Qalculate!\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-14 19:08-0300\n"
+"PO-Revision-Date: 2020-07-22 22:07-0300\n"
+"Last-Translator: VicSanRoPe\n"
+"Language-Team: none\n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: ../data/currencies.xml.in.h:1
+msgid "Currency"
+msgstr "Divisas"
+
+#: ../data/currencies.xml.in.h:2
+msgid "European Euro"
+msgstr "Euro europeo"
+
+#: ../data/currencies.xml.in.h:3
+msgid "ar:EUR,au:&#x20AC;,euro,p:euros"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:4
+msgid ""
+"Andorra, Austria, Belgium, Cyprus, Estonia, Finland, France, Germany, "
+"Greece, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malta, Netherlands, "
+"Portugal, San Marino, Slovakia, Slovenia, Spain, Vatican City"
+msgstr ""
+"Andorra, Austria, Bélgica, Chipre, Estonia, Finlandia, Francia, Alemania, "
+"Grecia, Irlanda, Italia, Letonia, Lituania, Luxemburgo, Malta, "
+"Países Bajos, Portugal, San Marino, Eslovaquia, Eslovenia, España, "
+"Ciudad del Vaticano"
+
+#: ../data/currencies.xml.in.h:5
+msgid "U.S. Dollar"
+msgstr "Dólar estadounidense"
+
+#: ../data/currencies.xml.in.h:6
+msgid "a:$,ar:USD,dollar,p:dollars"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:7
+msgid ""
+"United States, East Timor, Ecuador, El Salvador, Micronesia, Marshall "
+"Islands, Palau, Zimbabwe"
+msgstr ""
+"Estados Unidos, Timor Oriental, Ecuador, El Salvador, Micronesia, Islas "
+"Marshall, Palaos, Zimbabue"
+
+#: ../data/currencies.xml.in.h:8
+msgid "Japanese Yen"
+msgstr "Yen japonés"
+
+#: ../data/currencies.xml.in.h:9
+msgid "ar:JPY,au:&#xA5;,yen"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:10
+msgid "Japan"
+msgstr "Japón"
+
+#: ../data/currencies.xml.in.h:11
+msgid "Danish Krone"
+msgstr "Corona danesa"
+
+#: ../data/currencies.xml.in.h:12
+msgid "ar:DKK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:13
+msgid "Denmark"
+msgstr "Dinamarca"
+
+#: ../data/currencies.xml.in.h:14
+msgid "British Pound"
+msgstr "Libra esterlina"
+
+#: ../data/currencies.xml.in.h:15
+msgid "ar:GBP,au:&#xA3;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:16
+msgid "United Kingdom"
+msgstr "Reino Unido"
+
+#: ../data/currencies.xml.in.h:17
+msgid "Thai Baht"
+msgstr "Baht tailandés"
+
+#: ../data/currencies.xml.in.h:18
+msgid "ar:THB"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:19
+msgid "Thailand"
+msgstr "Tailandia"
+
+#: ../data/currencies.xml.in.h:20
+msgid "Swedish Krona"
+msgstr "Corona sueca"
+
+#: ../data/currencies.xml.in.h:21
+msgid "ar:SEK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:22
+msgid "Sweden"
+msgstr "Suecia"
+
+#: ../data/currencies.xml.in.h:23
+msgid "Swiss Franc"
+msgstr "Franco suizo"
+
+#: ../data/currencies.xml.in.h:24
+msgid "ar:CHF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:25
+msgid "Switzerland"
+msgstr "Suiza"
+
+#: ../data/currencies.xml.in.h:26
+msgid "Norwegian Krone"
+msgstr "Corona noruega"
+
+#: ../data/currencies.xml.in.h:27
+msgid "ar:NOK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:28
+msgid "Norway"
+msgstr "Noruega"
+
+#: ../data/currencies.xml.in.h:29
+msgid "Bulgarian Lev"
+msgstr "Leva búlgara"
+
+#: ../data/currencies.xml.in.h:30
+msgid "lev,ar:BGN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:31
+msgid "Bulgaria"
+msgstr "Bulgaria"
+
+#: ../data/currencies.xml.in.h:32
+msgid "Russian Ruble"
+msgstr "Rublo ruso"
+
+#: ../data/currencies.xml.in.h:33
+msgid "ar:RUB,au:&#x20BD;,ruble"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:34
+msgid "Russia"
+msgstr "Rusia"
+
+#: ../data/currencies.xml.in.h:35
+msgid "Philippine Peso"
+msgstr "Peso filipino"
+
+#: ../data/currencies.xml.in.h:36
+msgid "ar:PHP,au:&#x20B1;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:37
+msgid "Philippines"
+msgstr "Filipinas"
+
+#: ../data/currencies.xml.in.h:38
+msgid "Malaysian Ringgit"
+msgstr "Ringgit malayo"
+
+#: ../data/currencies.xml.in.h:39
+msgid "ar:MYR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:40
+msgid "Malaysia"
+msgstr "Malasia"
+
+#: ../data/currencies.xml.in.h:41
+msgid "Croatian Kuna"
+msgstr "Kuna croata"
+
+#: ../data/currencies.xml.in.h:42
+msgid "ar:HRK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:43
+msgid "Croatia"
+msgstr "Croacia"
+
+#: ../data/currencies.xml.in.h:44
+msgid "Chinese Yuan Renminbi"
+msgstr "Yuan Renminbi chino"
+
+#: ../data/currencies.xml.in.h:45
+msgid "ar:CNY"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:46
+msgid "China"
+msgstr "China"
+
+#: ../data/currencies.xml.in.h:47
+msgid "Indonesian Rupiah"
+msgstr "Rupia indonesia"
+
+#: ../data/currencies.xml.in.h:48
+msgid "ar:IDR,rupiah"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:49
+msgid "Indonesia"
+msgstr "Indonesia"
+
+#: ../data/currencies.xml.in.h:50
+msgid "Czech Koruna"
+msgstr "Corona checa"
+
+#: ../data/currencies.xml.in.h:51
+msgid "ar:CZK,au-c:K&#x10D;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:52
+msgid "Czech Republic"
+msgstr "República Checa"
+
+#: ../data/currencies.xml.in.h:53
+msgid "Hungarian Forint"
+msgstr "Forinto húngaro"
+
+#: ../data/currencies.xml.in.h:54
+msgid "forint,ar:HUF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:55
+msgid "Hungary"
+msgstr "Hungría"
+
+#: ../data/currencies.xml.in.h:56
+msgid "Polish Zloty"
+msgstr "Esloti polaco"
+
+#: ../data/currencies.xml.in.h:57
+msgid "ar:PLN,au:z&#x0142;,zloty"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:58
+msgid "Poland"
+msgstr "Polonia"
+
+#: ../data/currencies.xml.in.h:59
+msgid "Romanian Leu"
+msgstr "Leu rumano"
+
+#: ../data/currencies.xml.in.h:60
+msgid "ar:RON"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:61
+msgid "Romania"
+msgstr "Rumania"
+
+#: ../data/currencies.xml.in.h:62
+msgid "Turkish New Lira"
+msgstr "Nueva Lira turca"
+
+#: ../data/currencies.xml.in.h:63
+msgid "ar:TRY,au:&#x20BA;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:64
+msgid "Turkey"
+msgstr "Turquía"
+
+#: ../data/currencies.xml.in.h:65
+msgid "Australian Dollar"
+msgstr "Dólar australiano"
+
+#: ../data/currencies.xml.in.h:66
+msgid "ar:AUD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:67
+msgid "Australia"
+msgstr "Australia"
+
+#: ../data/currencies.xml.in.h:68
+msgid "Canadian Dollar"
+msgstr "Dólar canadiense"
+
+#: ../data/currencies.xml.in.h:69
+msgid "ar:CAD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:70
+msgid "Canada"
+msgstr "Canadá"
+
+#: ../data/currencies.xml.in.h:71
+msgid "Hong Kong Dollar"
+msgstr "Dólar hongkonés"
+
+#: ../data/currencies.xml.in.h:72
+msgid "ar:HKD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:73
+msgid "New Zealand Dollar"
+msgstr "Dólar neozelandés"
+
+#: ../data/currencies.xml.in.h:74
+msgid "ar:NZD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:75
+msgid "New Zealand"
+msgstr "Nueva Zelanda"
+
+#: ../data/currencies.xml.in.h:76
+msgid "Singapore Dollar"
+msgstr "Dólar singapurense"
+
+#: ../data/currencies.xml.in.h:77
+msgid "ar:SGD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:78
+msgid "Singapore"
+msgstr "Singapur"
+
+#: ../data/currencies.xml.in.h:79
+msgid "South Korean Won"
+msgstr "Won surcoreano"
+
+#: ../data/currencies.xml.in.h:80
+msgid "ar:KRW,au:&#x20A9;,won"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:81
+msgid "South Korea"
+msgstr "Corea del Sur"
+
+#: ../data/currencies.xml.in.h:82
+msgid "South African Rand"
+msgstr "Rand sudafricano"
+
+#: ../data/currencies.xml.in.h:83
+msgid "ar:ZAR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:84
+msgid "South Africa"
+msgstr "Sudáfrica"
+
+#: ../data/currencies.xml.in.h:85
+msgid "Indian Rupee"
+msgstr "Rupia india"
+
+#: ../data/currencies.xml.in.h:86
+msgid "ar:INR,au:&#x20B9;,rupee"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:87
+msgid "India"
+msgstr "India"
+
+#: ../data/currencies.xml.in.h:88
+msgid "Israeli New Sheqel"
+msgstr "Nuevo séquel israelí"
+
+#: ../data/currencies.xml.in.h:89
+msgid "ar:ILS,au:&#x20AA;,sheqel"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:90
+msgid "Israel"
+msgstr "Israel"
+
+#: ../data/currencies.xml.in.h:91
+msgid "Mexican Peso"
+msgstr "Peso mexicano"
+
+#: ../data/currencies.xml.in.h:92
+msgid "ar:MXN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:93
+msgid "Mexico"
+msgstr "México"
+
+#: ../data/currencies.xml.in.h:94
+msgid "Brazilian Real"
+msgstr "Real brasileño"
+
+#: ../data/currencies.xml.in.h:95
+msgid "ar:BRL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:96
+msgid "Brazil"
+msgstr "Brasil"
+
+#: ../data/currencies.xml.in.h:97
+msgid "Icelandic Krónur"
+msgstr "Corona islandesa"
+
+#: ../data/currencies.xml.in.h:98
+msgid "ar:ISK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:99
+msgid "Iceland"
+msgstr "Islandia"
+
+#: ../data/currencies.xml.in.h:100
+msgid "Bitcoin"
+msgstr "Bitcoin"
+
+#: ../data/currencies.xml.in.h:101
+msgid "ar:BTC,au:&#x20BF;,a:XBT,bitcoin,p:bitcoins"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:102
+msgid "Kenya Shilling"
+msgstr "Chelín keniano"
+
+#: ../data/currencies.xml.in.h:103
+msgid "ar:KES"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:104
+msgid "Kenya"
+msgstr "Kenia"
+
+#: ../data/currencies.xml.in.h:105
+msgid "Afghan Afghani"
+msgstr "Afgani afgano"
+
+#: ../data/currencies.xml.in.h:106
+msgid "ar:AFN,aiu:&#x060B;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:107
+msgid "Afghanistan"
+msgstr "Afganistán"
+
+#: ../data/currencies.xml.in.h:108
+msgid "Albanian Lek"
+msgstr "Lek albanés"
+
+#: ../data/currencies.xml.in.h:109
+msgid "ar:ALL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:110
+msgid "Albania"
+msgstr "Albania"
+
+#: ../data/currencies.xml.in.h:111
+msgid "Algerian Dinar"
+msgstr "Dinar argelino"
+
+#: ../data/currencies.xml.in.h:112
+msgid "ar:DZD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:113
+msgid "Algeria"
+msgstr "Argelia"
+
+#: ../data/currencies.xml.in.h:114
+msgid "Angolan Kwanza"
+msgstr "Kwanza angoleño"
+
+#: ../data/currencies.xml.in.h:115
+msgid "ar:AOA"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:116
+msgid "Angola"
+msgstr "Angola"
+
+#: ../data/currencies.xml.in.h:117
+msgid "Eastern Caribbean Dollar"
+msgstr "Dólar del Caribe Oriental"
+
+#: ../data/currencies.xml.in.h:118
+msgid "ar:XCD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:119
+msgid ""
+"Antigua and Barbuda, Dominica, Grenada, Montserrat, Saint Kitts and Nevis, "
+"Saint Lucia, Saint Vincent and the Grenadines, Anguilla"
+msgstr ""
+"Antigua y Barbuda, Dominica, Granada, Montserrat, San Cristóbal y Nieves, "
+"Santa Lucía, San Vicente y las Granadinas, Anguila"
+
+#: ../data/currencies.xml.in.h:120
+msgid "Argentine Peso"
+msgstr "Peso argentino"
+
+#: ../data/currencies.xml.in.h:121
+msgid "ar:ARS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:122
+msgid "Argentina"
+msgstr "Argentina"
+
+#: ../data/currencies.xml.in.h:123
+msgid "Armenian Dram"
+msgstr "Dram armenio"
+
+#: ../data/currencies.xml.in.h:124
+msgid "ar:AMD,au:&#x058F;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:125
+msgid "Armenia"
+msgstr "Armenia"
+
+#: ../data/currencies.xml.in.h:126
+msgid "Aruban Florin"
+msgstr "Florín arubeño"
+
+#: ../data/currencies.xml.in.h:127
+msgid "ar:AWG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:128
+msgid "Aruba"
+msgstr "Aruba"
+
+#: ../data/currencies.xml.in.h:129
+msgid "Netherlands Antillean Guilder"
+msgstr "Florín antillano neerlandés"
+
+#: ../data/currencies.xml.in.h:130
+msgid "ar:ANG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:131
+msgid "Curaçao, Sint Maarten"
+msgstr "Curazao, San Martín (Países Bajos)"
+
+#: ../data/currencies.xml.in.h:132
+msgid "Azerbaijani Manat"
+msgstr "Manat azerbaiyano"
+
+#: ../data/currencies.xml.in.h:133
+msgid "ar:AZN,au:&#x20BC;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:134
+msgid "Azerbaijan"
+msgstr "Azerbaiyán"
+
+#: ../data/currencies.xml.in.h:135
+msgid "Bahamian Dollar"
+msgstr "Dólar bahameño"
+
+#: ../data/currencies.xml.in.h:136
+msgid "ar:BSD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:137
+msgid "Bahamas"
+msgstr "Bahamas"
+
+#: ../data/currencies.xml.in.h:138
+msgid "Bahraini Dinar"
+msgstr "Dinar bareiní"
+
+#: ../data/currencies.xml.in.h:139
+msgid "ar:BHD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:140
+msgid "Bahrain"
+msgstr "Baréin"
+
+#: ../data/currencies.xml.in.h:141
+msgid "Bangladeshi Taka"
+msgstr "Taka bangladesí"
+
+#: ../data/currencies.xml.in.h:142
+msgid "ar:BDT,au:&#x09F3;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:143
+msgid "Bangladesh"
+msgstr "Bangladés"
+
+#: ../data/currencies.xml.in.h:144
+msgid "Barbadian Dollar"
+msgstr "Dólar barbadense"
+
+#: ../data/currencies.xml.in.h:145
+msgid "ar:BBD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:146
+msgid "Barbados"
+msgstr "Barbados"
+
+#: ../data/currencies.xml.in.h:147
+msgid "Belarusian Ruble"
+msgstr "Rublo bielorruso"
+
+#: ../data/currencies.xml.in.h:148
+msgid "ar:BYN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:149
+msgid "Belarus"
+msgstr "Bielorrusia"
+
+#: ../data/currencies.xml.in.h:150
+msgid "Belarusian Ruble p. (obsolete)"
+msgstr "Segundo Rublo bielorruso (obsoleto)"
+
+#: ../data/currencies.xml.in.h:151
+msgid "ar:BYR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:152
+msgid "Belize Dollar"
+msgstr "Dólar beliceño"
+
+#: ../data/currencies.xml.in.h:153
+msgid "ar:BZD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:154
+msgid "Belize"
+msgstr "Belice"
+
+#: ../data/currencies.xml.in.h:155
+msgid "West African CFA Franc"
+msgstr "Franco CFA de África Occidental"
+
+#: ../data/currencies.xml.in.h:156
+msgid "ar:XOF,a:CFA"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:157
+msgid ""
+"Benin, Burkina Faso, Guinea-Bissau, Ivory Coast, Mali, Niger, Senegal, Togo"
+msgstr ""
+"Benín, Burkina Faso, Guinea-Bisáu, Costa de Marfil, Malí, Níger, Senegal, "
+"Togo"
+
+#: ../data/currencies.xml.in.h:158
+msgid "Bermudian Dollar"
+msgstr "Dólar bermudeño"
+
+#: ../data/currencies.xml.in.h:159
+msgid "ar:BMD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:160
+msgid "Bermuda"
+msgstr "Bermudas"
+
+#: ../data/currencies.xml.in.h:161
+msgid "Bolivian Boliviano Bs"
+msgstr "Boliviano boliviano"
+
+#: ../data/currencies.xml.in.h:162
+msgid "ar:BOB"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:163
+msgid "Bolivia"
+msgstr "Bolivia"
+
+#: ../data/currencies.xml.in.h:164
+msgid "Bosnia and Herzegovina Convertible Mark"
+msgstr "Marco convertible bosnioherzegovino"
+
+#: ../data/currencies.xml.in.h:165
+msgid "ar:BAM"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:166
+msgid "Bosnia and Herzegovina"
+msgstr "Bosnia y Herzegovina"
+
+#: ../data/currencies.xml.in.h:167
+msgid "Botswana Pula"
+msgstr "Pula botsuano"
+
+#: ../data/currencies.xml.in.h:168
+msgid "ar:BWP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:169
+msgid "Botswana"
+msgstr "Botsuana"
+
+#: ../data/currencies.xml.in.h:170
+msgid "Brunei Dollar"
+msgstr "Dólar bruneano"
+
+#: ../data/currencies.xml.in.h:171
+msgid "ar:BND"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:172
+msgid "Brunei"
+msgstr "Brunéi"
+
+#: ../data/currencies.xml.in.h:173
+msgid "Burundian Franc"
+msgstr "Franco burundés"
+
+#: ../data/currencies.xml.in.h:174
+msgid "ar:BIF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:175
+msgid "Burundi"
+msgstr "Burundi"
+
+#: ../data/currencies.xml.in.h:176
+msgid "Cambodian Riel"
+msgstr "Riel camboyano"
+
+#: ../data/currencies.xml.in.h:177
+msgid "ar:KHR,aiu:&#x17DB;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:178
+msgid "Cambodia"
+msgstr "Camboya"
+
+#: ../data/currencies.xml.in.h:179
+msgid "Central African CFA Franc"
+msgstr "Franco CFA de África Central"
+
+#: ../data/currencies.xml.in.h:180
+msgid "ar:XAF,a:FCFA"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:181
+msgid ""
+"Cameroon, Central African Republic, Chad, Republic of the Congo, Equatorial "
+"Guinea, Gabon"
+msgstr ""
+"Camerún, República Centroafricana, Chad, República del Congo, "
+"Guinea Ecuatorial, Gabón"
+
+#: ../data/currencies.xml.in.h:182
+msgid "Cape Verdean Escudo"
+msgstr "Escudo caboverdiano"
+
+#: ../data/currencies.xml.in.h:183
+msgid "ar:CVE"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:184
+msgid "Cape Verde"
+msgstr "Cabo Verde"
+
+#: ../data/currencies.xml.in.h:185
+msgid "Cayman Islands Dollar"
+msgstr "Dólar caimanés"
+
+#: ../data/currencies.xml.in.h:186
+msgid "ar:KYD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:187
+msgid "Cayman Islands"
+msgstr "Islas Caimán"
+
+#: ../data/currencies.xml.in.h:188
+msgid "Chilean Peso"
+msgstr "Peso chileno"
+
+#: ../data/currencies.xml.in.h:189
+msgid "ar:CLP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:190
+msgid "Chile"
+msgstr "Chile"
+
+#: ../data/currencies.xml.in.h:191
+msgid "Colombian Peso"
+msgstr "Peso colombiano"
+
+#: ../data/currencies.xml.in.h:192
+msgid "ar:COP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:193
+msgid "Colombia"
+msgstr "Colombia"
+
+#: ../data/currencies.xml.in.h:194
+msgid "Comorian Franc"
+msgstr "Franco comorano"
+
+#: ../data/currencies.xml.in.h:195
+msgid "ar:KMF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:196
+msgid "Comoros"
+msgstr "Comoras"
+
+#: ../data/currencies.xml.in.h:197
+msgid "Democratic Republic of the Congo (Congolese Franc)"
+msgstr "Franco congoleño"
+
+#: ../data/currencies.xml.in.h:198
+msgid "ar:CDF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:199
+msgid "Democratic Republic of the Congo"
+msgstr "República Democrática del Congo"
+
+#: ../data/currencies.xml.in.h:200
+msgid "Costa Rican colón"
+msgstr "Colón costarricense"
+
+#: ../data/currencies.xml.in.h:201
+msgid "ar:CRC"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:202
+msgid "Costa Rica"
+msgstr "Costa Rica"
+
+#: ../data/currencies.xml.in.h:203
+msgid "Cuban Peso"
+msgstr "Peso cubano"
+
+#: ../data/currencies.xml.in.h:204
+msgid "ar:CUP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:205
+msgid "Cuba"
+msgstr "Cuba"
+
+#: ../data/currencies.xml.in.h:206
+msgid "Djiboutian Franc"
+msgstr "Franco yibutiano"
+
+#: ../data/currencies.xml.in.h:207
+msgid "ar:DJF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:208
+msgid "Djibouti"
+msgstr "Yibuti"
+
+#: ../data/currencies.xml.in.h:209
+msgid "Dominican Peso"
+msgstr "Peso dominicano"
+
+#: ../data/currencies.xml.in.h:210
+msgid "ar:DOP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:211
+msgid "Dominican Republic"
+msgstr "República dominicana"
+
+#: ../data/currencies.xml.in.h:212
+msgid "Egyptian Pound"
+msgstr "Libra egipcia"
+
+#: ../data/currencies.xml.in.h:213
+msgid "ar:EGP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:214
+msgid "Egypt"
+msgstr "Egipto"
+
+#: ../data/currencies.xml.in.h:215
+msgid "El Salvadoran Colon (obsolete)"
+msgstr "Colón salvadoreño"
+
+#: ../data/currencies.xml.in.h:216
+msgid "ar:SVC"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:217
+msgid "Eritrean Nafka"
+msgstr "Nakfa eritreo"
+
+#: ../data/currencies.xml.in.h:218
+msgid "ar:ERN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:219
+msgid "Eritrea"
+msgstr "Eritrea"
+
+#: ../data/currencies.xml.in.h:220
+msgid "Ethiopian Birr"
+msgstr "Birr etíope"
+
+#: ../data/currencies.xml.in.h:221
+msgid "ar:ETB"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:222
+msgid "Ethiopia"
+msgstr "Etiopía"
+
+#: ../data/currencies.xml.in.h:223
+msgid "Falkland Islands Pound"
+msgstr "Libra malvinense"
+
+#: ../data/currencies.xml.in.h:224
+msgid "ar:FKP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:225
+msgid "Falkland Islands"
+msgstr "Islas Malvinas"
+
+#: ../data/currencies.xml.in.h:226
+msgid "Fijian Dollar"
+msgstr "Dólar fiyiano"
+
+#: ../data/currencies.xml.in.h:227
+msgid "ar:FJD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:228
+msgid "Fiji"
+msgstr "Fiyi"
+
+#: ../data/currencies.xml.in.h:229
+msgid "CFP franc"
+msgstr "Franco CFP"
+
+#: ../data/currencies.xml.in.h:230
+msgid "ar:XPF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:231
+msgid "French Polynesia, New Caledonia, Wallis and Futuna"
+msgstr "Polinesia Francesa, Nueva Caledonia, Wallis y Futuna"
+
+#: ../data/currencies.xml.in.h:232
+msgid "Gambian Dalasi"
+msgstr "Dalasi gambiano"
+
+#: ../data/currencies.xml.in.h:233
+msgid "ar:GMD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:234
+msgid "Gambia"
+msgstr "Gambia"
+
+#: ../data/currencies.xml.in.h:235
+msgid "Georgian Lari"
+msgstr "Lari georgiano"
+
+#: ../data/currencies.xml.in.h:236
+msgid "ar:GEL,au:&#x20BE;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:237
+msgid "Georgia"
+msgstr "Georgia"
+
+#: ../data/currencies.xml.in.h:238
+msgid "Ghanaian Cedi"
+msgstr "Cedi ghanés"
+
+#: ../data/currencies.xml.in.h:239
+msgid "ar:GHS,au:&#x20B5;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:240
+msgid "Ghana"
+msgstr "Ghana"
+
+#: ../data/currencies.xml.in.h:241
+msgid "Gibraltar Pound"
+msgstr "Libra gibraltareña"
+
+#: ../data/currencies.xml.in.h:242
+msgid "ar:GIP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:243
+msgid "Gibraltar"
+msgstr "Gibraltar"
+
+#: ../data/currencies.xml.in.h:244
+msgid "Guatemalan Quetzal"
+msgstr "Guatemalan quetzal"
+
+#: ../data/currencies.xml.in.h:245
+msgid "ar:GTQ"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:246
+msgid "Guatemala"
+msgstr "Guatemala"
+
+#: ../data/currencies.xml.in.h:247
+msgid "Guernsey Pound"
+msgstr "Libra de Guernsey"
+
+#: ../data/currencies.xml.in.h:248
+msgid "ar:GGP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:249
+msgid "Guernsey"
+msgstr "Guernsey"
+
+#: ../data/currencies.xml.in.h:250
+msgid "Guinean Franc"
+msgstr "Franco guineano"
+
+#: ../data/currencies.xml.in.h:251
+msgid "ar:GNF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:252
+msgid "Guinea"
+msgstr "Guinea"
+
+#: ../data/currencies.xml.in.h:253
+msgid "Guyanese Dollar"
+msgstr "Dólar guyanés"
+
+#: ../data/currencies.xml.in.h:254
+msgid "ar:GYD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:255
+msgid "Guyana"
+msgstr "Guyana"
+
+#: ../data/currencies.xml.in.h:256
+msgid "Haitian Gourde"
+msgstr "Gourde haitiano"
+
+#: ../data/currencies.xml.in.h:257
+msgid "ar:HTG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:258
+msgid "Haiti"
+msgstr "Haití"
+
+#: ../data/currencies.xml.in.h:259
+msgid "Honduran Lempira"
+msgstr "Lempira Hondureño"
+
+#: ../data/currencies.xml.in.h:260
+msgid "ar:HNL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:261
+msgid "Honduras"
+msgstr "Honduras"
+
+#: ../data/currencies.xml.in.h:262
+msgid "Iranian Rial"
+msgstr "Rial iraní"
+
+#: ../data/currencies.xml.in.h:263
+msgid "ar:IRR,aiu:&#xFDFC;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:264
+msgid "Iran"
+msgstr "Irán"
+
+#: ../data/currencies.xml.in.h:265
+msgid "Iraqi Dinar"
+msgstr "Dinar iraquí"
+
+#: ../data/currencies.xml.in.h:266
+msgid "ar:IQD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:267
+msgid "Iraq"
+msgstr "Irak"
+
+#: ../data/currencies.xml.in.h:268
+msgid "Jamaican Dollar"
+msgstr "Dólar jamaiquino"
+
+#: ../data/currencies.xml.in.h:269
+msgid "ar:JMD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:270
+msgid "Jamaica"
+msgstr "Jamaica"
+
+#: ../data/currencies.xml.in.h:271
+msgid "Jordanian Dinar"
+msgstr "Dinar jordano"
+
+#: ../data/currencies.xml.in.h:272
+msgid "ar:JOD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:273
+msgid "Jordan"
+msgstr "Jordania"
+
+#: ../data/currencies.xml.in.h:274
+msgid "Kazakhstani Tenge"
+msgstr "Tenge kazajo"
+
+#: ../data/currencies.xml.in.h:275
+msgid "ar:KZT,au:&#x20B8;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:276
+msgid "Kazakhstan"
+msgstr "Kazajistán"
+
+#: ../data/currencies.xml.in.h:277
+msgid "North Korean Won"
+msgstr "Won norcoreano"
+
+#: ../data/currencies.xml.in.h:278
+msgid "ar:KPW"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:279
+msgid "North Korea"
+msgstr "Corea del Norte"
+
+#: ../data/currencies.xml.in.h:280
+msgid "Kuwaiti Dinar"
+msgstr "Dinar kuwaití"
+
+#: ../data/currencies.xml.in.h:281
+msgid "ar:KWD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:282
+msgid "Kuwait"
+msgstr "Kuwait"
+
+#: ../data/currencies.xml.in.h:283
+msgid "Kyrgyzstani Som"
+msgstr "Som kirguís"
+
+#: ../data/currencies.xml.in.h:284
+msgid "ar:KGS,au:&#x0441;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:285
+msgid "Kyrgyzstan"
+msgstr "Kirguistán"
+
+#: ../data/currencies.xml.in.h:286
+msgid "Lao Kip"
+msgstr "Kip laosiano"
+
+#: ../data/currencies.xml.in.h:287
+msgid "ar:LAK,au:&#x20AD;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:288
+msgid "Laos"
+msgstr "Laos"
+
+#: ../data/currencies.xml.in.h:289
+msgid "Lebanese Pound"
+msgstr "Libra libanesa"
+
+#: ../data/currencies.xml.in.h:290
+msgid "ar:LBP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:291
+msgid "Lebanon"
+msgstr "Líbano"
+
+#: ../data/currencies.xml.in.h:292
+msgid "Lesotho Loti"
+msgstr "Loti lesotense"
+
+#: ../data/currencies.xml.in.h:293
+msgid "ar:LSL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:294
+msgid "Lesotho"
+msgstr "Lesoto"
+
+#: ../data/currencies.xml.in.h:295
+msgid "Liberian Dollar"
+msgstr "Dólar liberiano"
+
+#: ../data/currencies.xml.in.h:296
+msgid "ar:LRD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:297
+msgid "Liberia"
+msgstr "Liberia"
+
+#: ../data/currencies.xml.in.h:298
+msgid "Libyan Dinar"
+msgstr "Dinar libio"
+
+#: ../data/currencies.xml.in.h:299
+msgid "ar:LYD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:300
+msgid "Libya"
+msgstr "Libia"
+
+#: ../data/currencies.xml.in.h:301
+msgid "Macanese Pataca"
+msgstr "Pataca macaense"
+
+#: ../data/currencies.xml.in.h:302
+msgid "ar:MOP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:303
+msgid "Macau"
+msgstr "Macao"
+
+#: ../data/currencies.xml.in.h:304
+msgid "Macedonian Denar"
+msgstr "Denar normacedonio"
+
+#: ../data/currencies.xml.in.h:305
+msgid "ar:MKD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:306
+msgid "Macedonia"
+msgstr "Macedonia del Norte"
+
+#: ../data/currencies.xml.in.h:307
+msgid "Malagasy Ariary"
+msgstr "Ariary malgache"
+
+#: ../data/currencies.xml.in.h:308
+msgid "ar:MGA"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:309
+msgid "Madagascar"
+msgstr "Madagascar"
+
+#: ../data/currencies.xml.in.h:310
+msgid "Malawian Kwacha"
+msgstr "Kwacha malauí"
+
+#: ../data/currencies.xml.in.h:311
+msgid "ar:MWK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:312
+msgid "Malawi"
+msgstr "Malaui"
+
+#: ../data/currencies.xml.in.h:313
+msgid "Maldivian Rufiyaa"
+msgstr "Rupia maldiva"
+
+#: ../data/currencies.xml.in.h:314
+msgid "ar:MVR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:315
+msgid "Maldives"
+msgstr "Maldivas"
+
+#: ../data/currencies.xml.in.h:316
+msgid "Mauritanian Ouguiya (obsolete)"
+msgstr "Uguiya mauritana (obsoleta)"
+
+#: ../data/currencies.xml.in.h:317
+msgid "ar:MRO"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:318
+msgid "Mauritian Rupee"
+msgstr "Rupia mauriciana"
+
+#: ../data/currencies.xml.in.h:319
+msgid "ar:MUR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:320
+msgid "Mauritius"
+msgstr "Mauricio"
+
+#: ../data/currencies.xml.in.h:321
+msgid "Moldovan Leu"
+msgstr "Leu moldavo"
+
+#: ../data/currencies.xml.in.h:322
+msgid "ar:MDL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:323
+msgid "Moldova"
+msgstr "Moldavia"
+
+#: ../data/currencies.xml.in.h:324
+msgid "Mongolian Tögrög"
+msgstr "Tugrik mongol"
+
+#: ../data/currencies.xml.in.h:325
+msgid "ar:MNT,au:&#x20AE;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:326
+msgid "Mongolia"
+msgstr "Mongolia"
+
+#: ../data/currencies.xml.in.h:327
+msgid "Moroccan Dirham"
+msgstr "Dírham marroquí"
+
+#: ../data/currencies.xml.in.h:328
+msgid "ar:MAD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:329
+msgid "Morocco"
+msgstr "Marruecos"
+
+#: ../data/currencies.xml.in.h:330
+msgid "Mozambican Metical"
+msgstr "Metical mozambiqueño"
+
+#: ../data/currencies.xml.in.h:331
+msgid "ar:MZN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:332
+msgid "Mozambique"
+msgstr "Mozambique"
+
+#: ../data/currencies.xml.in.h:333
+msgid "Myanmar (Burmese Kyat)"
+msgstr "Kyat birmano (myanma)"
+
+#: ../data/currencies.xml.in.h:334
+msgid "ar:MMK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:335
+msgid "Myanmar"
+msgstr "Birmania (Myanmar)"
+
+#: ../data/currencies.xml.in.h:336
+msgid "Namibian Dollar"
+msgstr "Dólar namibio"
+
+#: ../data/currencies.xml.in.h:337
+msgid "ar:NAD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:338
+msgid "Namibia"
+msgstr "Namibia"
+
+#: ../data/currencies.xml.in.h:339
+msgid "Nepalese Rupee"
+msgstr "Rupia nepalí"
+
+#: ../data/currencies.xml.in.h:340
+msgid "ar:NPR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:341
+msgid "Nepal"
+msgstr "Nepal"
+
+#: ../data/currencies.xml.in.h:342
+msgid "Nicaraguan Córdoba"
+msgstr "Córdoba nicaragüense"
+
+#: ../data/currencies.xml.in.h:343
+msgid "ar:NIO"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:344
+msgid "Nicaragua"
+msgstr "Nicaragua"
+
+#: ../data/currencies.xml.in.h:345
+msgid "Nigerian Naira"
+msgstr "Naira nigerina"
+
+#: ../data/currencies.xml.in.h:346
+msgid "ar:NGN,au:&#x20A6;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:347
+msgid "Nigeria"
+msgstr "Nigeria"
+
+#: ../data/currencies.xml.in.h:348
+msgid "Omani Rial"
+msgstr "Rial omaní"
+
+#: ../data/currencies.xml.in.h:349
+msgid "ar:OMR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:350
+msgid "Oman"
+msgstr "Omán"
+
+#: ../data/currencies.xml.in.h:351
+msgid "Pakistani Rupee"
+msgstr "Rupia pakistaní"
+
+#: ../data/currencies.xml.in.h:352
+msgid "ar:PKR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:353
+msgid "Pakistan"
+msgstr "Pakistán"
+
+#: ../data/currencies.xml.in.h:354
+msgid "Panamaian Balboa"
+msgstr "Balboa panameña"
+
+#: ../data/currencies.xml.in.h:355
+msgid "ar:PAB"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:356
+msgid "Panama"
+msgstr "Panamá"
+
+#: ../data/currencies.xml.in.h:357
+msgid "Papua New Guinean Kina"
+msgstr "Kina papú neoguineana"
+
+#: ../data/currencies.xml.in.h:358
+msgid "ar:PGK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:359
+msgid "Papua New Guinea"
+msgstr "Papúa Nueva Guinea"
+
+#: ../data/currencies.xml.in.h:360
+msgid "Paraguayan Guaraní"
+msgstr "Guaraní paraguayo"
+
+#: ../data/currencies.xml.in.h:361
+msgid "ar:PYG,au:&#x20B2;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:362
+msgid "Paraguay"
+msgstr "Paraguay"
+
+#: ../data/currencies.xml.in.h:363
+msgid "Peruvian Sol"
+msgstr "Sol peruano"
+
+#: ../data/currencies.xml.in.h:364
+msgid "ar:PEN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:365
+msgid "Peru"
+msgstr "Perú"
+
+#: ../data/currencies.xml.in.h:366
+msgid "Qatari Riyal"
+msgstr "Riyal catarí"
+
+#: ../data/currencies.xml.in.h:367
+msgid "ar:QAR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:368
+msgid "Qatar"
+msgstr "Catar"
+
+#: ../data/currencies.xml.in.h:369
+msgid "Rwandan Franc"
+msgstr "Franco ruandés"
+
+#: ../data/currencies.xml.in.h:370
+msgid "ar:RWF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:371
+msgid "Rwanda"
+msgstr "Ruanda"
+
+#: ../data/currencies.xml.in.h:372
+msgid "São Tomé and Príncipe Dobra"
+msgstr "Dobra santotomense"
+
+#: ../data/currencies.xml.in.h:373
+msgid "ar:STD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:374
+msgid "Sao Tome and Principe"
+msgstr "Santo Tomé y Príncipe"
+
+#: ../data/currencies.xml.in.h:375
+msgid "Saudi Riyal"
+msgstr "Riyal saudí"
+
+#: ../data/currencies.xml.in.h:376
+msgid "ar:SAR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:377
+msgid "Saudi Arabia"
+msgstr "Arabia Saudita"
+
+#: ../data/currencies.xml.in.h:378
+msgid "Serbian Dinar"
+msgstr "Dinar serbio"
+
+#: ../data/currencies.xml.in.h:379
+msgid "ar:RSD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:380
+msgid "Serbia"
+msgstr "Serbia"
+
+#: ../data/currencies.xml.in.h:381
+msgid "Seychellois Rupee"
+msgstr "Rupia seychelense"
+
+#: ../data/currencies.xml.in.h:382
+msgid "ar:SCR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:383
+msgid "Seychelles"
+msgstr "Seychelles"
+
+#: ../data/currencies.xml.in.h:384
+msgid "Sierra Leonean Leone"
+msgstr "Leone sierraleonés"
+
+#: ../data/currencies.xml.in.h:385
+msgid "ar:SLL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:386
+msgid "Sierra Leone"
+msgstr "Sierra Leona"
+
+#: ../data/currencies.xml.in.h:387
+msgid "Solomon Islands Dollar"
+msgstr "Dólar Salomonense"
+
+#: ../data/currencies.xml.in.h:388
+msgid "ar:SBD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:389
+msgid "Solomon Islands"
+msgstr "Islas Salomón"
+
+#: ../data/currencies.xml.in.h:390
+msgid "Somali Shilling"
+msgstr "Chelín somalí"
+
+#: ../data/currencies.xml.in.h:391
+msgid "ar:SOS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:392
+msgid "Somalia"
+msgstr "Somalia"
+
+#: ../data/currencies.xml.in.h:393
+msgid "Sri Lankan Rupee"
+msgstr "Rupia esrilanqués"
+
+#: ../data/currencies.xml.in.h:394
+msgid "ar:LKR,au:&#x0BF9;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:395
+msgid "Sri Lanka"
+msgstr "Sri Lanka"
+
+#: ../data/currencies.xml.in.h:396
+msgid "Sudanese Pound"
+msgstr "Libra sudanésa"
+
+#: ../data/currencies.xml.in.h:397
+msgid "ar:SDG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:398
+msgid "Sudan"
+msgstr "Sudán"
+
+#: ../data/currencies.xml.in.h:399
+msgid "Surinamese Dollar"
+msgstr "Dólar surinamés"
+
+#: ../data/currencies.xml.in.h:400
+msgid "ar:SRD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:401
+msgid "Suriname"
+msgstr "Surinam"
+
+#: ../data/currencies.xml.in.h:402
+msgid "Swazi Lilangeni"
+msgstr "Lilangeni suazi"
+
+#: ../data/currencies.xml.in.h:403
+msgid "ar:SZL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:404
+msgid "Swaziland"
+msgstr "Suazilandia"
+
+#: ../data/currencies.xml.in.h:405
+msgid "Syrian Pound"
+msgstr "Libra siria"
+
+#: ../data/currencies.xml.in.h:406
+msgid "ar:SYP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:407
+msgid "Syria"
+msgstr "Siria"
+
+#: ../data/currencies.xml.in.h:408
+msgid "New Taiwan Dollar"
+msgstr "Nuevo dólar taiwanés"
+
+#: ../data/currencies.xml.in.h:409
+msgid "ar:TWD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:410
+msgid "Taiwan"
+msgstr "Taiwán"
+
+#: ../data/currencies.xml.in.h:411
+msgid "Tajikistani Somoni"
+msgstr "Somoni tayiko"
+
+#: ../data/currencies.xml.in.h:412
+msgid "ar:TJS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:413
+msgid "Tajikistan"
+msgstr "Tayikistán"
+
+#: ../data/currencies.xml.in.h:414
+msgid "Tanzanian Shilling"
+msgstr "Chelín tanzano"
+
+#: ../data/currencies.xml.in.h:415
+msgid "ar:TZS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:416
+msgid "Tanzania"
+msgstr "Tanzania"
+
+#: ../data/currencies.xml.in.h:417
+msgid "Tongan Paʻanga"
+msgstr "Paʻanga tongana"
+
+#: ../data/currencies.xml.in.h:418
+msgid "ar:TOP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:419
+msgid "Tonga"
+msgstr "Tonga"
+
+#: ../data/currencies.xml.in.h:420
+msgid "Trinidad and Tobago dollar"
+msgstr "Dólar trinitense"
+
+#: ../data/currencies.xml.in.h:421
+msgid "ar:TTD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:422
+msgid "Trinidad and Tobago"
+msgstr "Trinidad y Tobago"
+
+#: ../data/currencies.xml.in.h:423
+msgid "Tunisian Dinar"
+msgstr "Dólar tunecino"
+
+#: ../data/currencies.xml.in.h:424
+msgid "ar:TND"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:425
+msgid "Tunisia"
+msgstr "Túnez"
+
+#: ../data/currencies.xml.in.h:426
+msgid "Turkmenistan Manat"
+msgstr "Manat turcomano"
+
+#: ../data/currencies.xml.in.h:427
+msgid "ar:TMT"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:428
+msgid "Turkmenistan"
+msgstr "Turkmenistán"
+
+#: ../data/currencies.xml.in.h:429
+msgid "Ugandan Shilling"
+msgstr "Chelín ugandés"
+
+#: ../data/currencies.xml.in.h:430
+msgid "ar:UGX"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:431
+msgid "Uganda"
+msgstr "Uganda"
+
+#: ../data/currencies.xml.in.h:432
+msgid "Ukrainian Hryvnia"
+msgstr "Grivna ucraniana"
+
+#: ../data/currencies.xml.in.h:433
+msgid "ar:UAH,au:&#x20B4;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:434
+msgid "Ukraine"
+msgstr "Ucrania"
+
+#: ../data/currencies.xml.in.h:435
+msgid "United Arab Emirates Dirham"
+msgstr "Dírham emiratí"
+
+#: ../data/currencies.xml.in.h:436
+msgid "ar:AED"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:437
+msgid "United Arab Emirates"
+msgstr "Emiratos Árabes Unidos"
+
+#: ../data/currencies.xml.in.h:438
+msgid "Uruguayan Peso"
+msgstr "Peso uruguayo"
+
+#: ../data/currencies.xml.in.h:439
+msgid "ar:UYU"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:440
+msgid "Uruguay"
+msgstr "Uruguay"
+
+#: ../data/currencies.xml.in.h:441
+msgid "Uzbekistan Soʻm"
+msgstr "Som uzbeko"
+
+#: ../data/currencies.xml.in.h:442
+msgid "ar:UZS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:443
+msgid "Uzbekistan"
+msgstr "Uzbekistán"
+
+#: ../data/currencies.xml.in.h:444
+msgid "Vanuatu Vatu"
+msgstr "Vatu vanuatuense"
+
+#: ../data/currencies.xml.in.h:445
+msgid "ar:VUV"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:446
+msgid "Vanuatu"
+msgstr "Vanuatu"
+
+#: ../data/currencies.xml.in.h:447
+msgid "Venezuelan Bolívar (obsolete)"
+msgstr "Bolívar venezolano (obsoleto)"
+
+#: ../data/currencies.xml.in.h:448
+msgid "ar:VEF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:449
+msgid "Vietnamese Đồng"
+msgstr "Đồng vietnamita"
+
+#: ../data/currencies.xml.in.h:450
+msgid "ar:VND,au:&#x20AB;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:451
+msgid "Vietnam"
+msgstr "Vietnam"
+
+#: ../data/currencies.xml.in.h:452
+msgid "Yemeni Rial"
+msgstr "Rial yemení"
+
+#: ../data/currencies.xml.in.h:453
+msgid "ar:YER"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:454
+msgid "Yemen"
+msgstr "Yemen"
+
+#: ../data/currencies.xml.in.h:455
+msgid "Zambian Kwacha (obsolete)"
+msgstr "Kwacha zambiano (obsoleto)"
+
+#: ../data/currencies.xml.in.h:456
+msgid "ar:ZMK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:457
+msgid "Euro Cent"
+msgstr "Céntimo de Euro"
+
+#: ../data/currencies.xml.in.h:458
+msgid "r:eurocent,p:eurocents"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:459
+msgid "Cent (USD)"
+msgstr "Centavo (USD)"
+
+#: ../data/currencies.xml.in.h:460
+msgid "au:&#xA2;,r:cent,p:cents"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:461
+msgid "Belgian Franc (obsolete)"
+msgstr "Franco belga (obsoleto)"
+
+#: ../data/currencies.xml.in.h:462
+msgid "ar:BEF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:463
+msgid "Greek Drachma (obsolete)"
+msgstr "Dracma griega (obsoleta)"
+
+#: ../data/currencies.xml.in.h:464
+msgid "ar:GRD,au:&#x20AF;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:465
+msgid "French Franc (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:466
+msgid "ar:FRF,au:&#x20A3;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:467
+msgid "Italian Lira (obsolete)"
+msgstr "Lira italiana (obsoleta)"
+
+#: ../data/currencies.xml.in.h:468
+msgid "ar:ITL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:469
+msgid "Dutch Guilder (obsolete)"
+msgstr "Florín neerlandés (obsoleto)"
+
+#: ../data/currencies.xml.in.h:470
+msgid "ar:NLG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:471
+msgid "Portuguese Escudo (obsolete)"
+msgstr "Escudo portugués (obsoleto)"
+
+#: ../data/currencies.xml.in.h:472
+msgid "ar:PTE"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:473
+msgid "Deutsche Mark (obsolete)"
+msgstr "Marco alemán (obsoleto)"
+
+#: ../data/currencies.xml.in.h:474
+msgid "ar:DEM"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:475
+msgid "Spanish Peseta (obsolete)"
+msgstr "Peseta española (obsoleta)"
+
+#: ../data/currencies.xml.in.h:476
+msgid "ar:ESP,au:&#x20A7;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:477
+msgid "Irish Pound (obsolete)"
+msgstr "Libra irlandesa"
+
+#: ../data/currencies.xml.in.h:478
+msgid "ar:IEP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:479
+msgid "Luxembourg Franc (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:480
+msgid "ar:LUF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:481
+msgid "Austrian Schilling (obsolete)"
+msgstr "Chelín austriaco (obsoleto)"
+
+#: ../data/currencies.xml.in.h:482
+msgid "ar:ATS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:483
+msgid "Finnish Markka (obsolete)"
+msgstr "Marco finlandés (obsoleto)"
+
+#: ../data/currencies.xml.in.h:484
+msgid "ar:FIM"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:485
+msgid "Slovenian Tolar (obsolete)"
+msgstr "Tólar esloveno"
+
+#: ../data/currencies.xml.in.h:486
+msgid "ar:SIT"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:487
+msgid "Cypriot Pound (obsolete)"
+msgstr "Libra chipriota (obsoleta)"
+
+#: ../data/currencies.xml.in.h:488
+msgid "ar:CYP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:489
+msgid "Estonian Kroon (obsolete)"
+msgstr "Corona estonia (obsoleta)"
+
+#: ../data/currencies.xml.in.h:490
+msgid "ar:EEK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:491
+msgid "Slovak Koruna (obsolete)"
+msgstr "Corona eslovaca (obsoleta)"
+
+#: ../data/currencies.xml.in.h:492
+msgid "ar:SKK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:493
+msgid "Maltese Lira (obsolete)"
+msgstr "Lira maltesa (obsoleta)"
+
+#: ../data/currencies.xml.in.h:494
+msgid "ar:MTL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:495
+msgid "Latvian Lats (obsolete)"
+msgstr "Lats letón (obtoleto)"
+
+#: ../data/currencies.xml.in.h:496
+msgid "ar:LVL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:497
+msgid "Lithuanian Litas (obsolete)"
+msgstr "Litas lituana (obsoleta)"
+
+#: ../data/currencies.xml.in.h:498
+msgid "ar:LTL"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:1
+msgid "Data Sets"
+msgstr "Conjuntos de datos"
+
+#. Data set for chemical elements
+#: ../data/datasets.xml.in.h:3
+msgid "!datasets!Elements"
+msgstr "Elementos"
+
+#: ../data/datasets.xml.in.h:4
+msgid "r:atom"
+msgstr "átomo"
+
+#. Object argument for chemical elements data set
+#: ../data/datasets.xml.in.h:6
+msgid "!datasets!Element"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:7
+msgid "Symbol"
+msgstr "Símbolo"
+
+#: ../data/datasets.xml.in.h:8
+msgid "r:symbol"
+msgstr "símbolo"
+
+#. Chemical elements number
+#: ../data/datasets.xml.in.h:10
+msgid "!datasets!Number"
+msgstr "Número"
+
+#. Chemical elements number
+#: ../data/datasets.xml.in.h:12
+msgid "!datasets!r:number"
+msgstr "número"
+
+#: ../data/datasets.xml.in.h:13 ../data/functions.xml.in.h:738
+msgid "Name"
+msgstr "Nombre"
+
+#: ../data/datasets.xml.in.h:14
+msgid "r:name"
+msgstr "nombre"
+
+#: ../data/datasets.xml.in.h:15
+msgid "Classification"
+msgstr "Clasificación"
+
+#: ../data/datasets.xml.in.h:16
+msgid ""
+"A number representing an element group:&#10;1 Alkali Metal&#10;2 Alkaline-"
+"Earth Metal&#10;3 Lanthanide&#10;4 Actinide&#10;5 Transition Metal&#10;6 "
+"Metal&#10;7 Metalloid&#10;8 Polyatomic Non-Metal&#10;9 Diatomic Non-"
+"Metal&#10;10 Noble Gas&#10;11 Unknown chemical properties"
+msgstr ""
+"El número representando un grupo de elementos:
+"&#10;1 Metal alcalino&#10;2 Metal alcalinotérreo&#10;3 Lantánido"
+"&#10;4 Actínido&#10;5 Metal de transición&#10;6 Metal&#10;7 Semimetal
+"&#10;8 No metal poliatómico&#10;9 No metal diatómico"
+"&#10;10 Gas Noble&#10;11 Propiedades químicas desconocidas"
+
+#: ../data/datasets.xml.in.h:17
+msgid "r:class"
+msgstr "clase"
+
+#: ../data/datasets.xml.in.h:18 ../data/functions.xml.in.h:456
+msgid "Weight"
+msgstr "Peso"
+
+#: ../data/datasets.xml.in.h:19
+msgid "r:weight,mass"
+msgstr "masa"
+
+#: ../data/datasets.xml.in.h:20
+msgid "Boiling Point"
+msgstr "Punto de ebullición"
+
+#: ../data/datasets.xml.in.h:21
+msgid "r:boiling"
+msgstr "hirviendo"
+
+#: ../data/datasets.xml.in.h:22
+msgid "Melting Point"
+msgstr "Punto de fusión"
+
+#: ../data/datasets.xml.in.h:23
+msgid "r:melting"
+msgstr "fundiendo"
+
+#: ../data/datasets.xml.in.h:24 ../data/units.xml.in.h:130
+msgid "Density"
+msgstr "Densidad"
+
+#: ../data/datasets.xml.in.h:25
+msgid "Density at STP (gases) or near room temperature"
+msgstr "Densidad a condiciones estándares (gases) o "
+"cerca de temperatura ambiente"
+
+#: ../data/datasets.xml.in.h:26
+msgid "r:density"
+msgstr "densidad"
+
+#: ../data/datasets.xml.in.h:27
+msgid "X Position"
+msgstr "Posición X"
+
+#: ../data/datasets.xml.in.h:28
+msgid "r:x_pos"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:29
+msgid "Y Position"
+msgstr "Posición Y"
+
+#: ../data/datasets.xml.in.h:30
+msgid "r:y_pos"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:31
+msgid "Planets"
+msgstr "Planetas"
+
+#: ../data/datasets.xml.in.h:32
+msgid "r:planet"
+msgstr "planeta"
+
+#: ../data/datasets.xml.in.h:33
+msgid "Planet"
+msgstr "Planeta"
+
+#: ../data/datasets.xml.in.h:34
+msgid "Orbital Period (Year)"
+msgstr "Periodo orbital (año)"
+
+#. Orbital period for planet
+#: ../data/datasets.xml.in.h:36
+msgid "!datasets!r:year"
+msgstr "año"
+
+#: ../data/datasets.xml.in.h:37
+msgid "Average Orbital Speed"
+msgstr "Velocidad orbital promedio"
+
+#: ../data/datasets.xml.in.h:38
+msgid "r:speed"
+msgstr "velocidad"
+
+#: ../data/datasets.xml.in.h:39
+msgid "Eccentricity"
+msgstr "Excentricidad"
+
+#: ../data/datasets.xml.in.h:40
+msgid "r:eccentricity"
+msgstr "excentricidad"
+
+#: ../data/datasets.xml.in.h:41
+msgid "Inclination (to ecliptic)"
+msgstr "Inclinación (a eclíptica)"
+
+#: ../data/datasets.xml.in.h:42
+msgid "r:inclination"
+msgstr "inclinación"
+
+#: ../data/datasets.xml.in.h:43
+msgid "Number of Satellites"
+msgstr "Número de satélites"
+
+#: ../data/datasets.xml.in.h:44
+msgid "r:satellites"
+msgstr "satélites"
+
+#. Planet mass
+#: ../data/datasets.xml.in.h:46
+msgid "!datasets!Mass"
+msgstr "Masa"
+
+#: ../data/datasets.xml.in.h:47
+msgid "r:mass"
+msgstr "masa"
+
+#: ../data/datasets.xml.in.h:48
+msgid "Mean Density"
+msgstr "Densidad media"
+
+#: ../data/datasets.xml.in.h:49
+msgid "Surface Area"
+msgstr "Área"
+
+#. Surface area of planet
+#: ../data/datasets.xml.in.h:51
+msgid "!datasets!r:area"
+msgstr "área"
+
+#: ../data/datasets.xml.in.h:52
+msgid "Equatorial Gravity"
+msgstr "Gravedad ecuatorial"
+
+#: ../data/datasets.xml.in.h:53
+msgid "r:gravity"
+msgstr "gravedad"
+
+#: ../data/datasets.xml.in.h:54
+msgid "Mean Surface Temperature"
+msgstr "Temperatura superficial media"
+
+#: ../data/datasets.xml.in.h:55
+msgid "r:temperature"
+msgstr "temperatura"
+
+#: ../data/elements.xml.in.h:1
+msgid "Hydrogen"
+msgstr "Hidrógeno"
+
+#: ../data/elements.xml.in.h:2
+msgid "Helium"
+msgstr "Helio"
+
+#: ../data/elements.xml.in.h:3
+msgid "Lithium"
+msgstr "Litio"
+
+#: ../data/elements.xml.in.h:4
+msgid "Beryllium"
+msgstr "Berilio"
+
+#: ../data/elements.xml.in.h:5
+msgid "Boron"
+msgstr "Boro"
+
+#: ../data/elements.xml.in.h:6
+msgid "Carbon"
+msgstr "Carbono"
+
+#: ../data/elements.xml.in.h:7
+msgid "Nitrogen"
+msgstr "Nitrógeno"
+
+#: ../data/elements.xml.in.h:8
+msgid "Oxygen"
+msgstr "Oxígeno"
+
+#: ../data/elements.xml.in.h:9
+msgid "Fluorine"
+msgstr "Flúor"
+
+#: ../data/elements.xml.in.h:10
+msgid "Neon"
+msgstr "Neón"
+
+#: ../data/elements.xml.in.h:11
+msgid "Sodium"
+msgstr "Sodio"
+
+#: ../data/elements.xml.in.h:12
+msgid "Magnesium"
+msgstr "Magnesio"
+
+#: ../data/elements.xml.in.h:13
+msgid "Aluminum"
+msgstr "Aluminio"
+
+#: ../data/elements.xml.in.h:14
+msgid "Silicon"
+msgstr "Silicio"
+
+#: ../data/elements.xml.in.h:15
+msgid "Phosphorus"
+msgstr "Fósforo"
+
+#: ../data/elements.xml.in.h:16
+msgid "Sulfur"
+msgstr "Azufre"
+
+#: ../data/elements.xml.in.h:17
+msgid "Chlorine"
+msgstr "Cloro"
+
+#: ../data/elements.xml.in.h:18
+msgid "Argon"
+msgstr "Argón"
+
+#: ../data/elements.xml.in.h:19
+msgid "Potassium"
+msgstr "Potasio"
+
+#: ../data/elements.xml.in.h:20
+msgid "Calcium"
+msgstr "Calcio"
+
+#: ../data/elements.xml.in.h:21
+msgid "Scandium"
+msgstr "Escandio"
+
+#: ../data/elements.xml.in.h:22
+msgid "Titanium"
+msgstr "Titanio"
+
+#: ../data/elements.xml.in.h:23
+msgid "Vanadium"
+msgstr "Vanadio"
+
+#: ../data/elements.xml.in.h:24
+msgid "Chromium"
+msgstr "Cromo"
+
+#: ../data/elements.xml.in.h:25
+msgid "Manganese"
+msgstr "Manganeso"
+
+#: ../data/elements.xml.in.h:26
+msgid "Iron"
+msgstr "Hierro"
+
+#: ../data/elements.xml.in.h:27
+msgid "Cobalt"
+msgstr "Cobalto"
+
+#: ../data/elements.xml.in.h:28
+msgid "Nickel"
+msgstr "Níquel"
+
+#: ../data/elements.xml.in.h:29
+msgid "Copper"
+msgstr "Cobre"
+
+#: ../data/elements.xml.in.h:30
+msgid "Zinc"
+msgstr "Zinc"
+
+#: ../data/elements.xml.in.h:31
+msgid "Gallium"
+msgstr "Galio"
+
+#: ../data/elements.xml.in.h:32
+msgid "Germanium"
+msgstr "Germanio"
+
+#: ../data/elements.xml.in.h:33
+msgid "Arsenic"
+msgstr "Arsénico"
+
+#: ../data/elements.xml.in.h:34
+msgid "Selenium"
+msgstr "Selenio"
+
+#: ../data/elements.xml.in.h:35
+msgid "Bromine"
+msgstr "Bromo"
+
+#: ../data/elements.xml.in.h:36
+msgid "Krypton"
+msgstr "Kriptón"
+
+#: ../data/elements.xml.in.h:37
+msgid "Rubidium"
+msgstr "Rubidio"
+
+#: ../data/elements.xml.in.h:38
+msgid "Strontium"
+msgstr "Estroncio"
+
+#: ../data/elements.xml.in.h:39
+msgid "Yttrium"
+msgstr "Ytrio"
+
+#: ../data/elements.xml.in.h:40
+msgid "Zirconium"
+msgstr "Zirconio"
+
+#: ../data/elements.xml.in.h:41
+msgid "Niobium"
+msgstr "Niobio"
+
+#: ../data/elements.xml.in.h:42
+msgid "Molybdenum"
+msgstr "Molibdeno"
+
+#: ../data/elements.xml.in.h:43
+msgid "Technetium"
+msgstr "Tecnecio"
+
+#: ../data/elements.xml.in.h:44
+msgid "Ruthenium"
+msgstr "Rutenio"
+
+#: ../data/elements.xml.in.h:45
+msgid "Rhodium"
+msgstr "Rodio"
+
+#: ../data/elements.xml.in.h:46
+msgid "Palladium"
+msgstr "Paladio"
+
+#: ../data/elements.xml.in.h:47
+msgid "Silver"
+msgstr "Plata"
+
+#: ../data/elements.xml.in.h:48
+msgid "Cadmium"
+msgstr "Cadmio"
+
+#: ../data/elements.xml.in.h:49
+msgid "Indium"
+msgstr "Indio"
+
+#: ../data/elements.xml.in.h:50
+msgid "Tin"
+msgstr "Estaño"
+
+#: ../data/elements.xml.in.h:51
+msgid "Antimony"
+msgstr "Antimonio"
+
+#: ../data/elements.xml.in.h:52
+msgid "Tellurium"
+msgstr "Teluro"
+
+#: ../data/elements.xml.in.h:53
+msgid "Iodine"
+msgstr "Yodo"
+
+#: ../data/elements.xml.in.h:54
+msgid "Xenon"
+msgstr "Xenón"
+
+#: ../data/elements.xml.in.h:55
+msgid "Cesium"
+msgstr "Cesio"
+
+#: ../data/elements.xml.in.h:56
+msgid "Barium"
+msgstr "Bario"
+
+#: ../data/elements.xml.in.h:57
+msgid "Lanthanum"
+msgstr "Lantano"
+
+#: ../data/elements.xml.in.h:58
+msgid "Cerium"
+msgstr "Cerio"
+
+#: ../data/elements.xml.in.h:59
+msgid "Praseodymium"
+msgstr "Praseodimio"
+
+#: ../data/elements.xml.in.h:60
+msgid "Neodymium"
+msgstr "Neodimio"
+
+#: ../data/elements.xml.in.h:61
+msgid "Promethium"
+msgstr "Prometio"
+
+#: ../data/elements.xml.in.h:62
+msgid "Samarium"
+msgstr "Samario"
+
+#: ../data/elements.xml.in.h:63
+msgid "Europium"
+msgstr "Europio"
+
+#: ../data/elements.xml.in.h:64
+msgid "Gadolinium"
+msgstr "Gadolinio"
+
+#: ../data/elements.xml.in.h:65
+msgid "Terbium"
+msgstr "Terbio"
+
+#: ../data/elements.xml.in.h:66
+msgid "Dysprosium"
+msgstr "Disprosio"
+
+#: ../data/elements.xml.in.h:67
+msgid "Holmium"
+msgstr "Holmio"
+
+#: ../data/elements.xml.in.h:68
+msgid "Erbium"
+msgstr "Erbio"
+
+#: ../data/elements.xml.in.h:69
+msgid "Thulium"
+msgstr "Tulio"
+
+#: ../data/elements.xml.in.h:70
+msgid "Ytterbium"
+msgstr "Yterbio"
+
+#: ../data/elements.xml.in.h:71
+msgid "Lutetium"
+msgstr "Lutecio"
+
+#: ../data/elements.xml.in.h:72
+msgid "Hafnium"
+msgstr "Hafnio"
+
+#: ../data/elements.xml.in.h:73
+msgid "Tantalum"
+msgstr "Tantalio"
+
+#: ../data/elements.xml.in.h:74
+msgid "Tungsten"
+msgstr "Wolframio"
+
+#: ../data/elements.xml.in.h:75
+msgid "Rhenium"
+msgstr "Renio"
+
+#: ../data/elements.xml.in.h:76
+msgid "Osmium"
+msgstr "Osmio"
+
+#: ../data/elements.xml.in.h:77
+msgid "Iridium"
+msgstr "Iridio"
+
+#: ../data/elements.xml.in.h:78
+msgid "Platinum"
+msgstr "Platino"
+
+#: ../data/elements.xml.in.h:79
+msgid "Gold"
+msgstr "Oro"
+
+#. Chemical element
+#: ../data/elements.xml.in.h:81
+msgid "!elements!Mercury"
+msgstr "Mercurio"
+
+#: ../data/elements.xml.in.h:82
+msgid "Thallium"
+msgstr "Talio"
+
+#: ../data/elements.xml.in.h:83
+msgid "Lead"
+msgstr "Plomo"
+
+#: ../data/elements.xml.in.h:84
+msgid "Bismuth"
+msgstr "Bismuto"
+
+#: ../data/elements.xml.in.h:85
+msgid "Polonium"
+msgstr "Polonio"
+
+#: ../data/elements.xml.in.h:86
+msgid "Astatine"
+msgstr "Astato"
+
+#: ../data/elements.xml.in.h:87
+msgid "Radon"
+msgstr "Radón"
+
+#: ../data/elements.xml.in.h:88
+msgid "Francium"
+msgstr "Francio"
+
+#: ../data/elements.xml.in.h:89
+msgid "Radium"
+msgstr "Radio"
+
+#: ../data/elements.xml.in.h:90
+msgid "Actinium"
+msgstr "Actinio"
+
+#: ../data/elements.xml.in.h:91
+msgid "Thorium"
+msgstr "Torio"
+
+#: ../data/elements.xml.in.h:92
+msgid "Protactinium"
+msgstr "Protactinio"
+
+#: ../data/elements.xml.in.h:93
+msgid "Uranium"
+msgstr "Uranio"
+
+#: ../data/elements.xml.in.h:94
+msgid "Neptunium"
+msgstr "Neptunio"
+
+#: ../data/elements.xml.in.h:95
+msgid "Plutonium"
+msgstr "Plutonio"
+
+#: ../data/elements.xml.in.h:96
+msgid "Americium"
+msgstr "Americio"
+
+#: ../data/elements.xml.in.h:97
+msgid "Curium"
+msgstr "Curio"
+
+#: ../data/elements.xml.in.h:98
+msgid "Berkelium"
+msgstr "Berkelio"
+
+#: ../data/elements.xml.in.h:99
+msgid "Californium"
+msgstr "Californio"
+
+#: ../data/elements.xml.in.h:100
+msgid "Einsteinium"
+msgstr "Einstenio"
+
+#: ../data/elements.xml.in.h:101
+msgid "Fermium"
+msgstr "Fermio"
+
+#: ../data/elements.xml.in.h:102
+msgid "Mendelevium"
+msgstr "Mendelevio"
+
+#: ../data/elements.xml.in.h:103
+msgid "Nobelium"
+msgstr "Nobelio"
+
+#: ../data/elements.xml.in.h:104
+msgid "Lawrencium"
+msgstr "Laurencio"
+
+#: ../data/elements.xml.in.h:105
+msgid "Rutherfordium"
+msgstr "Rutherfordio"
+
+#: ../data/elements.xml.in.h:106
+msgid "Dubnium"
+msgstr "Dubnio"
+
+#: ../data/elements.xml.in.h:107
+msgid "Seaborgium"
+msgstr "Seaborgio"
+
+#: ../data/elements.xml.in.h:108
+msgid "Bohrium"
+msgstr "Bohrio"
+
+#: ../data/elements.xml.in.h:109
+msgid "Hassium"
+msgstr "Hassio"
+
+#: ../data/elements.xml.in.h:110
+msgid "Meitnerium"
+msgstr "Meitnerio"
+
+#: ../data/elements.xml.in.h:111
+msgid "Darmstadtium"
+msgstr "Darmstadtio"
+
+#: ../data/elements.xml.in.h:112
+msgid "Roentgenium"
+msgstr "Roentgenio"
+
+#: ../data/elements.xml.in.h:113
+msgid "Copernicium"
+msgstr "Copernicio"
+
+#: ../data/elements.xml.in.h:114
+msgid "Nihonium"
+msgstr "Nihonio"
+
+#: ../data/elements.xml.in.h:115
+msgid "Flerovium"
+msgstr "Flerovio"
+
+#: ../data/elements.xml.in.h:116
+msgid "Moscovium"
+msgstr "Moscovio"
+
+#: ../data/elements.xml.in.h:117
+msgid "Livermorium"
+msgstr "Livermorio"
+
+#: ../data/elements.xml.in.h:118
+msgid "Tennessine"
+msgstr "Teneso"
+
+#: ../data/elements.xml.in.h:119
+msgid "Oganesson"
+msgstr "Oganesón"
+
+#: ../data/functions.xml.in.h:1
+msgid "Matrices &amp; Vectors"
+msgstr "Matrices y vectores"
+
+#: ../data/functions.xml.in.h:2
+msgid "Construct Vector"
+msgstr "Construir vector"
+
+#: ../data/functions.xml.in.h:3
+msgid "r:vector"
+msgstr "vector"
+
+#: ../data/functions.xml.in.h:4
+msgid "Returns a vector with listed elements."
+msgstr "Devolver un vector con elementos listados."
+
+#. Vector/matrix elements
+#: ../data/functions.xml.in.h:6
+msgid "Elements"
+msgstr "Elementos"
+
+#: ../data/functions.xml.in.h:7
+msgid "Generate Vector"
+msgstr "Generar vector"
+
+#: ../data/functions.xml.in.h:8
+msgid "r:genvector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:9
+msgid ""
+"Returns a vector generated from a function with a variable (default x) "
+"running from min to max. The fourth argument is either the requested number "
+"of elements if the sixth argument is false (default) or the step between "
+"each value of the variable."
+msgstr ""
+"Devuelve un vector generado a partir de una función con una variable "
+"(por defecto x) que se ejecuta de mínimo a máximo. El cuarto argumento "
+"es el número deseado de elementos si el sexto argumento es falso "
+"(predeterminado) o el paso entre cada valor de la variable."
+
+#: ../data/functions.xml.in.h:10
+msgid "Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:11
+msgid "Min"
+msgstr "Mínimo"
+
+#: ../data/functions.xml.in.h:12
+msgid "Max"
+msgstr "Máximo"
+
+#: ../data/functions.xml.in.h:13
+msgid "Dimension / Step size"
+msgstr "Dimensión / Tamaño de paso"
+
+#: ../data/functions.xml.in.h:14
+msgid "Variable"
+msgstr "Variable"
+
+#: ../data/functions.xml.in.h:15
+msgid "Use step size"
+msgstr "Usar tamaño de paso"
+
+#: ../data/functions.xml.in.h:16
+msgid "Sort"
+msgstr "Ordenar"
+
+#: ../data/functions.xml.in.h:17
+msgid "r:sort"
+msgstr "ordenar"
+
+#: ../data/functions.xml.in.h:18
+msgid "Returns a sorted vector."
+msgstr "Devuelve un vector ordenado."
+
+#: ../data/functions.xml.in.h:19
+msgid "Vector"
+msgstr "Vector"
+
+#: ../data/functions.xml.in.h:20
+msgid "Ascending"
+msgstr "Ascendente"
+
+#: ../data/functions.xml.in.h:21
+msgid "Rank"
+msgstr "Rango"
+
+#: ../data/functions.xml.in.h:22
+msgid "r:rank"
+msgstr "rango"
+
+#: ../data/functions.xml.in.h:23
+msgid ""
+"Returns a vector with values of elements replaced with their mutual ranks."
+msgstr ""
+"Devuelve un vector con los valores de los elementos reemplazados por sus "
+"rangos mutuos."
+
+#: ../data/functions.xml.in.h:24
+msgid "Vector Limits"
+msgstr "Límite de vector"
+
+#: ../data/functions.xml.in.h:25
+msgid "r:limits"
+msgstr "límites"
+
+#: ../data/functions.xml.in.h:26
+msgid "Returns a part of a vector between two positions."
+msgstr "Devuelve la parte de un vector entre dos posiciones."
+
+#: ../data/functions.xml.in.h:27
+msgid "Lower limit"
+msgstr "Límite inferior"
+
+#: ../data/functions.xml.in.h:28
+msgid "Upper limit"
+msgstr "Límite superior"
+
+#: ../data/functions.xml.in.h:29
+msgid "Dimension"
+msgstr "Dimensión"
+
+#: ../data/functions.xml.in.h:30
+msgid "r:dimension"
+msgstr "dimensión"
+
+#: ../data/functions.xml.in.h:31
+msgid "Returns the number of elements in a vector."
+msgstr "Devuelve el número de vectores en un vector."
+
+#: ../data/functions.xml.in.h:32
+msgid "Merge Vectors"
+msgstr "Combinar vectores"
+
+#: ../data/functions.xml.in.h:33
+msgid "r:mergevectors"
+msgstr ""
+
+#: ../data/functions.xml.in.h:34
+msgid "Returns a vector with the elements from two vectors."
+msgstr "Devuelve un vector con los elementos de dos vectores."
+
+#: ../data/functions.xml.in.h:35
+msgid "Vector 1"
+msgstr "Vector 1"
+
+#: ../data/functions.xml.in.h:36
+msgid "Vector 2"
+msgstr "Vector 2"
+
+#: ../data/functions.xml.in.h:37
+msgid "Construct Matrix"
+msgstr "Construir matriz"
+
+#: ../data/functions.xml.in.h:38
+msgid "r:matrix"
+msgstr ""
+
+#: ../data/functions.xml.in.h:39
+msgid ""
+"Returns a matrix with specified dimensions and listed elements. Omitted "
+"elements are set to zero."
+msgstr ""
+"Devuelve una matriz con las dimensiones especificadas y elementos "
+"listados. Elementos omitidos son definidos como cero."
+
+#: ../data/functions.xml.in.h:40
+msgid "Rows"
+msgstr "Filas"
+
+#: ../data/functions.xml.in.h:41
+msgid "Columns"
+msgstr "Columnas"
+
+#: ../data/functions.xml.in.h:42
+msgid "Convert Matrix to Vector"
+msgstr "Convertir matriz a vector"
+
+#: ../data/functions.xml.in.h:43
+msgid "r:matrix2vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:44
+msgid "Puts each element of a matrix in vertical order in a vector."
+msgstr "Coloca cada elemento de una matriz en orden vertical en un vector."
+
+#: ../data/functions.xml.in.h:45
+msgid "Matrix"
+msgstr "Matriz"
+
+#: ../data/functions.xml.in.h:46
+msgid "Matrix Area"
+msgstr "Área de matriz"
+
+#. Matrix area
+#: ../data/functions.xml.in.h:48
+msgid "r:area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:49
+msgid "Returns a part of a matrix."
+msgstr "Devuelve una parte de una matriz."
+
+#: ../data/functions.xml.in.h:50
+msgid "Start row"
+msgstr "Fila inicial"
+
+#: ../data/functions.xml.in.h:51
+msgid "Start column"
+msgstr "Columna inicial"
+
+#: ../data/functions.xml.in.h:52
+msgid "End row"
+msgstr "Fila final"
+
+#: ../data/functions.xml.in.h:53
+msgid "End column"
+msgstr "Columna final"
+
+#: ../data/functions.xml.in.h:54
+msgid "r:rows"
+msgstr ""
+
+#: ../data/functions.xml.in.h:55
+msgid "Returns the number of rows in a matrix."
+msgstr "Devuelve el número de filas en una matriz."
+
+#: ../data/functions.xml.in.h:56
+msgid "r:columns"
+msgstr ""
+
+#: ../data/functions.xml.in.h:57
+msgid "Returns the number of columns in a matrix."
+msgstr "Devuelve el número de columnas en una matriz."
+
+#: ../data/functions.xml.in.h:58
+msgid "Extract row as vector"
+msgstr "Extraer fila como vector"
+
+#: ../data/functions.xml.in.h:59
+msgid "r:row"
+msgstr ""
+
+#: ../data/functions.xml.in.h:60
+msgid "Returns a row in a matrix as a vector."
+msgstr "Devuelve una fila en una matriz como un vector."
+
+#: ../data/functions.xml.in.h:61
+msgid "Row"
+msgstr "Fila"
+
+#: ../data/functions.xml.in.h:62
+msgid "Extract Column as Vector"
+msgstr "Extraer columna como vector"
+
+#: ../data/functions.xml.in.h:63
+msgid "r:column"
+msgstr ""
+
+#: ../data/functions.xml.in.h:64
+msgid "Returns a column in a matrix as a vector."
+msgstr "Devuelve una columna en una matriz como un vector."
+
+#: ../data/functions.xml.in.h:65
+msgid "Column"
+msgstr "Columna"
+
+#: ../data/functions.xml.in.h:66
+msgid "r:elements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:67
+msgid "Returns the number of elements in a matrix or vector."
+msgstr "Devuelve el número de elementos en una matriz o vector."
+
+#: ../data/functions.xml.in.h:68
+msgid "Matrix or vector"
+msgstr "Matriz o vector"
+
+#. Vector/matrix element
+#: ../data/functions.xml.in.h:70
+msgid "Element"
+msgstr "Elemento"
+
+#: ../data/functions.xml.in.h:71
+msgid "r:element"
+msgstr ""
+
+#: ../data/functions.xml.in.h:72
+msgid ""
+"Returns the element at specified position in a matrix (row and column) or "
+"vector (index)."
+msgstr ""
+"Devuelve el elemento en la posición especificada en una matriz "
+"(fila y columna) o vector (índice)."
+
+#: ../data/functions.xml.in.h:73
+msgid "Matrix/vector"
+msgstr "Matriz/Vector"
+
+#: ../data/functions.xml.in.h:74
+msgid "Row/index"
+msgstr "Fila/Índice"
+
+#: ../data/functions.xml.in.h:75
+msgid "Transpose"
+msgstr "Transponer"
+
+#: ../data/functions.xml.in.h:76
+msgid "r:transpose"
+msgstr ""
+
+#: ../data/functions.xml.in.h:77
+msgid "Returns the transpose of a matrix."
+msgstr "Devuelve la transposición de una matriz."
+
+#: ../data/functions.xml.in.h:78
+msgid "Identity"
+msgstr "Identidad"
+
+#: ../data/functions.xml.in.h:79
+msgid "r:identity"
+msgstr ""
+
+#: ../data/functions.xml.in.h:80
+msgid ""
+"Returns the identity matrix of a matrix or with specified number of rows/"
+"columns."
+msgstr ""
+"Devuelve la matriz identidad de una matriz o con una cantidad "
+"especificada de filas/columnas."
+
+#: ../data/functions.xml.in.h:81
+msgid "Matrix or rows/columns"
+msgstr "Matriz o filas/columnas"
+
+#: ../data/functions.xml.in.h:82
+msgid "Determinant"
+msgstr "Determinante"
+
+#: ../data/functions.xml.in.h:83
+msgid "r:det"
+msgstr ""
+
+#: ../data/functions.xml.in.h:84
+msgid "Calculates the determinant of a matrix."
+msgstr "Calcula el determinante de una matriz."
+
+#: ../data/functions.xml.in.h:85
+msgid "Permanent"
+msgstr "Permanente"
+
+#: ../data/functions.xml.in.h:86
+msgid "r:permanent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:87
+msgid ""
+"Calculates the permanent of a matrix. The permanent differs from a "
+"determinant in that all signs in the expansion by minors are taken as "
+"positive."
+msgstr ""
+"Calcula la permanente de una matriz. La permanente difiere de el "
+"determinante en que todos los signos en la expansión de menores son "
+"tomados como positivos."
+
+#: ../data/functions.xml.in.h:88
+msgid "Adjugate (Adjoint)"
+msgstr "Adjuntos"
+
+#: ../data/functions.xml.in.h:89
+msgid "r:adj"
+msgstr ""
+
+#: ../data/functions.xml.in.h:90
+msgid "Calculates the adjugate or adjoint of a matrix."
+msgstr "Calcula la matriz de adjuntos de una matriz."
+
+#: ../data/functions.xml.in.h:91
+msgid "Cofactor"
+msgstr "Cofactor"
+
+#: ../data/functions.xml.in.h:92
+msgid "r:cofactor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:93
+msgid "Calculates the cofactor of the element at specified position."
+msgstr "Calcula el cofactor de un elemento en la posición especificada."
+
+#: ../data/functions.xml.in.h:94
+msgid "Matrix Inverse"
+msgstr "Matriz inversa"
+
+#: ../data/functions.xml.in.h:95
+msgid "r:inverse"
+msgstr ""
+
+#: ../data/functions.xml.in.h:96
+msgid ""
+"Calculates the inverse of a matrix. The inverse is the matrix that "
+"multiplied by the original matrix equals the identity matrix (AB = BA = I)."
+msgstr ""
+"Calcula el inverso de una matriz. El inverso es una matriz que "
+"multiplicada por la matriz original es igual a la matriz identidad "
+"(AB = BA = I)."
+
+#: ../data/functions.xml.in.h:97
+msgid "Load CSV File"
+msgstr "Cargar archivo CSV"
+
+#: ../data/functions.xml.in.h:98
+msgid "r:load"
+msgstr ""
+
+#: ../data/functions.xml.in.h:99
+msgid "Returns a matrix imported from a CSV data file."
+msgstr "Devuelve una matriz importada de un archivo de datos CSV.""
+
+#: ../data/functions.xml.in.h:100
+msgid "Filename"
+msgstr "Nombre de archivo"
+
+#: ../data/functions.xml.in.h:101
+msgid "First data row"
+msgstr "Primera fila de datos"
+
+#: ../data/functions.xml.in.h:102
+msgid "Separator"
+msgstr "Separador"
+
+#: ../data/functions.xml.in.h:103
+msgid "Export To CSV File"
+msgstr "Exportar a archivo CSV"
+
+#: ../data/functions.xml.in.h:104
+msgid "r:export"
+msgstr ""
+
+#: ../data/functions.xml.in.h:105
+msgid "Exports a matrix to a CSV data file."
+msgstr "Exporta una matriz a un archivo CSV."
+
+#: ../data/functions.xml.in.h:106
+msgid "Magnitude"
+msgstr "Magnitud"
+
+#: ../data/functions.xml.in.h:107
+msgid "r:magnitude"
+msgstr ""
+
+#: ../data/functions.xml.in.h:108
+msgid ""
+"Calculates the magnitude of a value. This function returns the same value as "
+"abs() for all values except vectors."
+msgstr ""
+"Calcula la magnitud de un valor. Esta función devuelve el mismo valor "
+"que abs() para todos los valores excepto para vectores.
+
+#: ../data/functions.xml.in.h:109
+msgid "Value"
+msgstr "Valor"
+
+#: ../data/functions.xml.in.h:110
+msgid "Hadamard Product"
+msgstr "Producto Hadamard"
+
+#: ../data/functions.xml.in.h:111
+msgid "r:hadamard"
+msgstr ""
+
+#: ../data/functions.xml.in.h:112
+msgid ""
+"Mulitplies each separate element in matrix 1 with the corresponding element "
+"in matrix 2."
+msgstr ""
+"Multiplica por separado cada elemento de la matriz 1 con el elemento "
+"correspondiente de la matriz 2."
+
+#: ../data/functions.xml.in.h:113
+msgid "Matrix 1"
+msgstr "Matriz 1"
+
+#: ../data/functions.xml.in.h:114
+msgid "Matrix 2"
+msgstr "Matriz 2"
+
+#: ../data/functions.xml.in.h:115
+msgid "Entrywise Function"
+msgstr "Función por cada elemento"
+
+#: ../data/functions.xml.in.h:116
+msgid "r:entrywise"
+msgstr ""
+
+#: ../data/functions.xml.in.h:117
+msgid ""
+"Calculates a new matrix or vector using each separate element in matrix/"
+"vector 1 and the corresponding (in the same row and column) elements in "
+"matrix/vector 2. An unlimited number of matrices/vectors can be specified, "
+"with each matrix/vector argument followed by the corresponding variable used "
+"in the function argument."
+msgstr ""
+"Calcula una nueva matriz o vector usando por separado cada elemento en "
+"matriz/vector 1 y el elemento correspondiente (en la misma fila y columna) "
+"en matriz/vector 2. Un número ilimitado de matrices/vectores pueden ser "
+"especificados, con cada matriz/vector seguido por la variable "
+"correspondiente a usar."
+
+#: ../data/functions.xml.in.h:118
+msgid "Matrices/vectors and variables"
+msgstr "Matrices/Vectores y variables"
+
+#: ../data/functions.xml.in.h:119
+msgid "Norm (length)"
+msgstr "Norma (longitud)"
+
+#: ../data/functions.xml.in.h:120
+msgid "r:norm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:121
+msgid "Calculates the norm/length of a vector."
+msgstr "Calcula la norma/longitud de un vector."
+
+#: ../data/functions.xml.in.h:122
+msgid "Cross Product"
+msgstr "Producto cruz"
+
+#: ../data/functions.xml.in.h:123
+msgid "r:cross"
+msgstr ""
+
+#: ../data/functions.xml.in.h:124
+msgid "Calculates the cross product of two 3-dimensional vectors."
+msgstr "Calcula el producto cruz dedos vectores tridimensionales."
+
+#: ../data/functions.xml.in.h:125
+msgid "Combinatorics"
+msgstr "Combinatorias"
+
+#: ../data/functions.xml.in.h:126
+msgid "Factorial"
+msgstr "Factorial"
+
+#: ../data/functions.xml.in.h:127
+msgid ""
+"Calculates the factorial of an integer. Multiplies the argument with every "
+"lesser positive integer (n(n-1)(n-2)...2*1). Can also be entered as a number "
+"followed by one exclamation mark."
+msgstr ""
+"Calcula el factorial de un entero. Multiplica el argumento con cada entero "
+"positivo menor (n*(n-1)*(n-2)...2*1). También puede ser ingresado como un "
+"número seguido de un signo de exclamación."
+
+#: ../data/functions.xml.in.h:128
+msgid "r:factorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:129
+msgid "Double Factorial"
+msgstr "Factorial doble"
+
+#: ../data/functions.xml.in.h:130
+msgid "r:factorial2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:131
+msgid ""
+"Calculates the double factorial of an integer. Multiplies the argument with "
+"every second lesser positive integer (n(n-2)(n-4)...). Can also be entered "
+"as a number followed by two exclamation marks."
+msgstr ""
+"Calcula el factorial doble de un entero. Multiplica el argumento con cada "
+"segundo entero positivo menor (n*(n-2)*(n-4)...). También puede ser "
+"ingresado como un número seguido de dos signos de exclamación."
+
+#: ../data/functions.xml.in.h:132
+msgid "Multifactorial"
+msgstr "Multifactorial"
+
+#: ../data/functions.xml.in.h:133
+msgid "r:multifactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:134
+msgid ""
+"Calculates the multifactorial of an integer. Multiplies the argument with "
+"every x lesser positive integer (n(n-x)(n-2x)...). Can also be entered as a "
+"number followed by three or more exclamation marks."
+msgstr ""
+"Calcula el multifactorial de un entero. Multiplica el argumento con cada x "
+"entero positivo menor (n*(n-1)*(n-2)...2*1). También puede ser ingresado "
+"como un número seguido de tres o más signos de exclamación."
+
+#: ../data/functions.xml.in.h:135
+msgid "Binomial Coefficient"
+msgstr "Coeficiente binomial"
+
+#: ../data/functions.xml.in.h:136
+msgid "r:binomial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:137
+msgid "Hyperfactorial"
+msgstr "Hiperfactorial"
+
+#: ../data/functions.xml.in.h:138
+msgid "r:hyperfactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:139
+msgid ""
+"Calculates the hyperfactorial of an integer. Multiplies the argument raised "
+"by itself with every lesser positive integer raised by themselves (1^1 * "
+"2^2 ... n^n)."
+msgstr ""
+"Calcula el hiperfactorial de un entero. Multiplica el argumento elevado "
+"por si mismo con cada entero positivo menor elevado por si mismo "
+"(1^1*2^2...n^n)."
+
+#: ../data/functions.xml.in.h:140
+msgid "Superfactorial"
+msgstr "Superfactorial"
+
+#: ../data/functions.xml.in.h:141
+msgid "r:superfactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:142
+msgid ""
+"Calculates the superfactorial of an integer. Multiplies the factorial of the "
+"argument with the factorial of every lesser positive integer (1! * 2! ... "
+"n!)."
+msgstr ""
+"Calcula el superfactorial de un entero. Multiplica el factorial del argumento por el factorial de cada entero positivo menor (1!*2!...n!)."
+
+#: ../data/functions.xml.in.h:143
+msgid "Permutations (Variations)"
+msgstr "Permutaciones"
+
+#: ../data/functions.xml.in.h:144
+msgid "r:perm,variations"
+msgstr ""
+
+#: ../data/functions.xml.in.h:145
+msgid ""
+"Returns the number of possible arrangements of an ordered list with a number "
+"of objects to choose from and a list size. If there are three objects (1, 2 "
+"and 3) that is put in a list with two positions, the alternatives are [1, "
+"2], [2, 1], [1, 3], [3, 1], [2, 3] and [3, 2], and thus the number of "
+"permutations is 6."
+msgstr ""
+"Devuelve el número de ordenamientos posibles de una lista ordenada con un "
+"número de objetos para elegir y un tamaño de lista. Si hay tres objetos "
+"(1, 2, y 3) que son colocados en una lista con lugar para dos, las "
+"alternativas son [1, 2], [2, 1], [1, 3], [3, 1], [2, 3], y [3, 2], "
+"por lo que el número de permutaciones es 6."
+
+#: ../data/functions.xml.in.h:146
+msgid "Objects"
+msgstr "Objetos"
+
+#: ../data/functions.xml.in.h:147
+msgid "Size"
+msgstr "Tamaño"
+
+#: ../data/functions.xml.in.h:148
+msgid "Combinations"
+msgstr "Combinaciones"
+
+#: ../data/functions.xml.in.h:149
+msgid "r:comb"
+msgstr ""
+
+#: ../data/functions.xml.in.h:150
+msgid ""
+"Returns the number of possible arrangements of an unordered list with a "
+"number of objects to choose from and a list size. If there are three objects "
+"(1, 2 and 3) that is put in a list with place for two, the alternatives are "
+"[1, 2], [1, 3], and [2, 3], and thus the number of combinations is 3."
+msgstr ""
+"Devuelve el número de ordenamientos posibles de una lista desordenada con "
+"un número de objetos para elegir y un tamaño de lista. Si hay tres objetos "
+"(1, 2, y 3) que son colocados en una lista con lugar para dos, las "
+"alternativas son [1, 2], [1, 3], y [2, 3], "
+"por lo que el número de permutaciones es 6."
+
+#: ../data/functions.xml.in.h:151
+msgid "Derangements"
+msgstr "Desarreglos (subfactorial)"
+
+#: ../data/functions.xml.in.h:152
+msgid "r:derangements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:153
+msgid ""
+"Returns the number of possible rearrangements of an ordered list, of a "
+"certain size, where none of the objects are on their original position. If "
+"the original list is [1, 2, 3], the possible derangements are [2, 3, 1] and "
+"[3, 1, 2], and thus the number of derangements is 2."
+msgstr ""
+"Devuelve el número de reordenamientos posibles de una lista ordenada, de "
+"un determinado tamaño, donde ninguno de los objetos son colocados en su "
+"posición original. Si la lista original es [1, 2, y 3] los posibles "
+"desarreglos son [2, 3, 1], y [3, 1, 2], por lo que el número de "
+"desarreglos es 2."
+
+#: ../data/functions.xml.in.h:154
+msgid "Number of elements"
+msgstr "Número de elementos"
+
+#: ../data/functions.xml.in.h:155
+msgid "Number Theory"
+msgstr "Teoría de números"
+
+#: ../data/functions.xml.in.h:156
+msgid "Absolute Value"
+msgstr "Valor absoluto"
+
+#: ../data/functions.xml.in.h:157
+msgid "r:abs"
+msgstr ""
+
+#: ../data/functions.xml.in.h:158
+msgid "Arithmetic"
+msgstr "Aritmética"
+
+#: ../data/functions.xml.in.h:159
+msgid "Signum"
+msgstr "Signo"
+
+#: ../data/functions.xml.in.h:160
+msgid "r:sgn"
+msgstr ""
+
+#. A numerical value
+#: ../data/functions.xml.in.h:162
+msgid "Number"
+msgstr "Número"
+
+#: ../data/functions.xml.in.h:163
+msgid "Value for zero"
+msgstr "Valor de cero"
+
+#: ../data/functions.xml.in.h:164
+msgid "Numerator"
+msgstr "Numerador"
+
+#: ../data/functions.xml.in.h:165
+msgid "r:numerator"
+msgstr ""
+
+#: ../data/functions.xml.in.h:166
+msgid "Denominator"
+msgstr "Denominador"
+
+#: ../data/functions.xml.in.h:167
+msgid "r:denominator"
+msgstr ""
+
+#: ../data/functions.xml.in.h:168
+msgid "Remainder"
+msgstr "Resto"
+
+#: ../data/functions.xml.in.h:169
+msgid "r:rem"
+msgstr ""
+
+#: ../data/functions.xml.in.h:170
+msgid "Modulus"
+msgstr "Módulo"
+
+#: ../data/functions.xml.in.h:171
+msgid "r:mod"
+msgstr ""
+
+#: ../data/functions.xml.in.h:172
+msgid "Integer Division"
+msgstr "División entera"
+
+#: ../data/functions.xml.in.h:173
+msgid "r:div"
+msgstr ""
+
+#: ../data/functions.xml.in.h:174
+msgid "Negate"
+msgstr "Negar"
+
+#: ../data/functions.xml.in.h:175
+msgid "r:neg"
+msgstr ""
+
+#: ../data/functions.xml.in.h:176
+msgid "Reciprocal"
+msgstr "Inverso"
+
+#: ../data/functions.xml.in.h:177
+msgid "r:inv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:178
+msgid "Multiply"
+msgstr "Multiplicar"
+
+#: ../data/functions.xml.in.h:179
+msgid "r:multiply"
+msgstr ""
+
+#: ../data/functions.xml.in.h:180
+msgid "Factors"
+msgstr "Factores"
+
+#: ../data/functions.xml.in.h:181
+msgid "Add"
+msgstr "Sumar"
+
+#: ../data/functions.xml.in.h:182
+msgid "r:add"
+msgstr ""
+
+#: ../data/functions.xml.in.h:183
+msgid "Terms"
+msgstr "Términos"
+
+#: ../data/functions.xml.in.h:184
+msgid "Subtract"
+msgstr "Restar"
+
+#: ../data/functions.xml.in.h:185
+msgid "r:subtract"
+msgstr ""
+
+#: ../data/functions.xml.in.h:186
+msgid "Divide"
+msgstr "Dividir"
+
+#: ../data/functions.xml.in.h:187
+msgid "r:divide"
+msgstr ""
+
+#: ../data/functions.xml.in.h:188
+msgid "Raise"
+msgstr "Elevar"
+
+#: ../data/functions.xml.in.h:189
+msgid "r:raise"
+msgstr ""
+
+#: ../data/functions.xml.in.h:190
+msgid "Base"
+msgstr "Base"
+
+#: ../data/functions.xml.in.h:191
+msgid "Exponent"
+msgstr "Exponente"
+
+#: ../data/functions.xml.in.h:192
+msgid "Polynomials"
+msgstr "Polinomios"
+
+#: ../data/functions.xml.in.h:193
+msgid "Coefficient"
+msgstr "Coeficiente"
+
+#: ../data/functions.xml.in.h:194
+msgid "r:coeff"
+msgstr ""
+
+#: ../data/functions.xml.in.h:195
+msgid "Polynomial"
+msgstr "Polinomio"
+
+#: ../data/functions.xml.in.h:196
+msgid "Leading Coefficient"
+msgstr "Coeficiente principal"
+
+#: ../data/functions.xml.in.h:197
+msgid "r:lcoeff"
+msgstr ""
+
+#: ../data/functions.xml.in.h:198
+msgid "Trailing Coefficient"
+msgstr "Coeficiente final"
+
+#: ../data/functions.xml.in.h:199
+msgid "r:tcoeff"
+msgstr ""
+
+#: ../data/functions.xml.in.h:200
+msgid "Polynomial Degree"
+msgstr "Grado polinomial"
+
+#: ../data/functions.xml.in.h:201
+msgid "r:degree"
+msgstr ""
+
+#: ../data/functions.xml.in.h:202
+msgid "Lowest Degree (Valuation)"
+msgstr "Grado menor"
+
+#: ../data/functions.xml.in.h:203
+msgid "r:ldegree"
+msgstr ""
+
+#: ../data/functions.xml.in.h:204
+msgid "Content Part"
+msgstr "Parte de contenido"
+
+#: ../data/functions.xml.in.h:205
+msgid "r:pcontent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:206
+msgid "Primitive Part"
+msgstr "Parte primitiva"
+
+#: ../data/functions.xml.in.h:207
+msgid "r:primpart"
+msgstr ""
+
+#: ../data/functions.xml.in.h:208
+msgid "Unit Part"
+msgstr "Parte unitaria"
+
+#: ../data/functions.xml.in.h:209
+msgid "r:punit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:210
+msgid "Greatest Common Divisor"
+msgstr "Máximo común divisor"
+
+#: ../data/functions.xml.in.h:211
+msgid "r:gcd"
+msgstr ""
+
+#: ../data/functions.xml.in.h:212
+msgid "1st value"
+msgstr "1er valor"
+
+#: ../data/functions.xml.in.h:213
+msgid "2nd value"
+msgstr "2do valor"
+
+#: ../data/functions.xml.in.h:214
+msgid "Least Common Multiple"
+msgstr "Mínimo común múltiplo"
+
+#: ../data/functions.xml.in.h:215
+msgid "r:lcm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:216
+msgid "Bernoulli Number/Polynomial"
+msgstr "Polinomio/Número de Bernoulli"
+
+#: ../data/functions.xml.in.h:217
+msgid ""
+"Returns the nth Bernoulli number or polynomial (if the second argument is "
+"non-zero)."
+msgstr ""
+"Devuelve el enésimo número o polinomio de Bernoulli (si el segundo "
+"argumento es distinto de cero)."
+
+#: ../data/functions.xml.in.h:218
+msgid "r:bernoulli"
+msgstr ""
+
+#: ../data/functions.xml.in.h:219
+msgid "Index (n)"
+msgstr "Índice (n)"
+
+#: ../data/functions.xml.in.h:220
+msgid "Fibonacci Number"
+msgstr "Número de Fibonacci"
+
+#: ../data/functions.xml.in.h:221
+msgid "r:fibonacci"
+msgstr ""
+
+#: ../data/functions.xml.in.h:222
+msgid "Returns the n-th term of the Fibonacci sequence."
+msgstr "Devuelve el enésimo elemento de la sucesión de Fibonacci."
+
+#: ../data/functions.xml.in.h:223
+msgid "Rounding"
+msgstr "Redondeo"
+
+#: ../data/functions.xml.in.h:224
+msgid "Round"
+msgstr "Redondear"
+
+#: ../data/functions.xml.in.h:225
+msgid "r:round"
+msgstr ""
+
+#: ../data/functions.xml.in.h:226
+msgid ""
+"Round to nearest integer or decimal. If the second argument is zero, the "
+"value is rounded towards the nearest integer, otherwise the value is rounded "
+"to the corresponding number of digits to the right (if positive) or left (if "
+"negative) of the decimal point. If the third argument is true, halfway "
+"numbers are rounded toward the nearest even integer/digit, otherwise away "
+"from zero."
+msgstr ""
+"Redondear el entero o decimal más cercano. Si el segundo argumento es "
+"cero, el valor es redondeado hacia el entero más cercano, si no, es "
+"redondeado al número correspondiente de dígitos a la derecha (si positivo) "
+"o la izquierda (si negativo) del punto decimal. Si el tercer argumento es "
+"verdadero, los números intermedios son redondeados al entero/dígito par "
+"más cercano, si no, redondea hacia arriba."
+
+#: ../data/functions.xml.in.h:227
+msgid "Number of decimals"
+msgstr "Número de decimales"
+
+#: ../data/functions.xml.in.h:228
+msgid "Round halfway to even"
+msgstr "Redondear intermedios a pares"
+
+#: ../data/functions.xml.in.h:229
+msgid "Round Downwards"
+msgstr "Redondear hacia abajo"
+
+#: ../data/functions.xml.in.h:230
+msgid "r:floor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:231
+msgid "Round Upwards"
+msgstr "Redondear hacia arriba"
+
+#: ../data/functions.xml.in.h:232
+msgid "r:ceil"
+msgstr ""
+
+#: ../data/functions.xml.in.h:233
+msgid "Round Towards Zero"
+msgstr "Redondear hacia cero"
+
+#: ../data/functions.xml.in.h:234
+msgid "r:trunc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:235
+msgid "Integer Part"
+msgstr "Parte entera"
+
+#: ../data/functions.xml.in.h:236
+msgid "r:int"
+msgstr ""
+
+#: ../data/functions.xml.in.h:237
+msgid "Fractional Part"
+msgstr "Parte fraccional"
+
+#: ../data/functions.xml.in.h:238
+msgid "r:frac"
+msgstr ""
+
+#: ../data/functions.xml.in.h:239
+msgid "Number Bases"
+msgstr "Bases numéricas"
+
+#: ../data/functions.xml.in.h:240
+msgid "Number Base"
+msgstr "Base numérica"
+
+#: ../data/functions.xml.in.h:241
+msgid "r:base"
+msgstr ""
+
+#: ../data/functions.xml.in.h:242
+msgid ""
+"Returns a value from an expression using the specified number base (radix). "
+"For bases between -62 and 62 full mathematical expressions (including "
+"operators and functions) are supported, while for other bases the specified "
+"expression is converted to a single number.&#10;&#10;Bases ≤ 36 uses digits "
+"0-9 and A-Z (case insensitive).&#10;&#10;Bases between 37 and 62 uses case "
+"sensitive letters (0-9, A-Z, a-z) as digits ('z' equals 61).&#10;&#10;Bases "
+"over 62 use Unicode characters as digits, with the character code as value "
+"(e.g. '0' equals 48). Escaped characters are in this case supported (e.g. "
+"'\\0' = 0, '\\523' = 523, '\\x7f' = 127).&#10;&#10;Negative bases use the "
+"same digits as the corresponding positive bases and the digits used for non-"
+"integer bases are determined by rounding the base away from zero. Bases that "
+"are not real numbers by default uses digits 0-9 and A-Z.&#10;&#10;The set of "
+"digits used can be selected using the third argument (defaults to 0 for "
+"automatic selection). Set it to 1 for digits 0-9 and A-Z, 2 for 0-9, A-Z and "
+"a-z, and 3 for Unicode digits, or enter a text string with all digits placed "
+"in ascending order (e.g. \"0123456789\"). When the set of digits is manually "
+"selected, the specified expression is always converted to a single number."
+msgstr ""
+"Devuelve el valor de una expresión usando la base numérica especificada. "
+"Para bases entre -62 y 62, expresiones matemáticas completas (incluyendo "
+"operadores y funciones) están soportadas, mientras que para otras bases, "
+"la expresión especificada es convertida a un solo número.&#10;&#10;"
+"Bases menores o iguales a 36 usan los dígitos 0-9 y A-Z "
+(no sensible a mayúsculas y minúsculas)&#10;&#10;"
+"Bases entre 37 y 62 usan letras sensibles a mayúsculas y minúsculas "
+"(0-9, A-Z, a-z) como dígitos ("z" es igual a 61).&#10;&#10;"
+"Bases sobre 62 usan caracteres Unicode como dígitos, con el código de "
+"caracter usado como valor (ej. "0" es igual a 48). Los caracteres "
+escapados están soportados en este caso "
+"(ej. "\\0" = 0, "\\523" = 523, "\\x7f" = 127).&#10;&#10;"
+"Bases negativas usan los mismos dígitos que sus bases positivas "
+"correspondientes y los dígitos usados para bases no enteras son "
+"determinados redondeando la base hacia arriba. Bases que no son números "
+"reales por defecto usan los dígitos 0-9 a A-Z.&#10;&#10;"
+"El conjunto de dígitos usados pueden ser seleccionados usando el tercer "
+"argumento (por defecto 0 para selección automática). Defínelo a 1 para "
+"los dígitos 0-9 y A-Z, 2 para 0-9, A-Z y a-z, y 3 para dígitos Unicode, "
+"o ingrese una cadena de texto con todos los dígitos colocados en orden "
+"ascendente (ej. \"0123456789\"). Cuando el conjunto de dígitos es "
+"seleccionado manualmente, la expresión especificada siempre es convertida "
+"a un solo número."
+
+#: ../data/functions.xml.in.h:243
+msgid "Set of digits"
+msgstr "Conjunto de dígitos"
+
+#: ../data/functions.xml.in.h:244
+msgid "Binary"
+msgstr "Binario"
+
+#: ../data/functions.xml.in.h:245
+msgid "r:bin"
+msgstr ""
+
+#: ../data/functions.xml.in.h:246
+msgid ""
+"Returns a value from a binary expression. If two's complement is true, "
+"numbers beginning with '1' is interpreted as negative binary numbers using "
+"two's complement."
+msgstr ""
+"Devuelve un valor a partir de una expresión binaria. Si complemento a dos "
+"es verdadero, los números que empiecen con \"1\" son interpretados como "
+"números binarios negativos usando complemento a dos".
+
+#: ../data/functions.xml.in.h:247
+msgid "Binary number"
+msgstr "Número binario"
+
+#: ../data/functions.xml.in.h:248
+msgid "Two's complement"
+msgstr "Complemento a dos"
+
+#: ../data/functions.xml.in.h:249
+msgid "Octal"
+msgstr "Octal"
+
+#: ../data/functions.xml.in.h:250
+msgid "r:oct"
+msgstr ""
+
+#: ../data/functions.xml.in.h:251
+msgid "Returns a value from an octal expression."
+msgstr "Devuelve un valor a partir de una expresión octal."
+
+#: ../data/functions.xml.in.h:252
+msgid "Octal number"
+msgstr "Número octal"
+
+#: ../data/functions.xml.in.h:253
+msgid "Decimal"
+msgstr "Decimal"
+
+#: ../data/functions.xml.in.h:254
+msgid "r:dec"
+msgstr ""
+
+#: ../data/functions.xml.in.h:255
+msgid "Returns a value from a decimal expression."
+msgstr "Devuelve un valor a partir de una expresión decimal."
+
+#: ../data/functions.xml.in.h:256
+msgid "Decimal number"
+msgstr "Número decimal"
+
+#: ../data/functions.xml.in.h:257
+msgid "Hexadecimal"
+msgstr "Hexadecimal"
+
+#: ../data/functions.xml.in.h:258
+msgid "r:hex"
+msgstr ""
+
+#: ../data/functions.xml.in.h:259
+msgid ""
+"Returns a value from a hexadecimal expression. If two's complement is true, "
+"numbers beginning with 8 or higher is interpreted as negative hexadecimal "
+"numbers using two's complement."
+msgstr ""
+"Devuelve un valor a partir de una expresión hexadecimal. "
+"Si complemento a dos es verdadero, los números que empiecen con \"8\" o "
+"más son interpretados como números hexadecimales negativos usando "
+"complemento a dos".
+
+#: ../data/functions.xml.in.h:260
+msgid "Hexadecimal number"
+msgstr "Número hexadecimal"
+
+#: ../data/functions.xml.in.h:261
+msgid "Bijective base-26"
+msgstr "Base 26 biyectiva"
+
+#: ../data/functions.xml.in.h:262
+msgid "r:bijective"
+msgstr ""
+
+#: ../data/functions.xml.in.h:263
+msgid ""
+"Returns a value from an expression in bijective base-26. Conversion in the "
+"opposite direction is also supported."
+msgstr ""
+"Devuelve un valor a partir de una expresión en base 26 biyectiva. "
+"Conversión en la dirección opuesta también esta soportada."
+
+#: ../data/functions.xml.in.h:264
+msgid "Bijective base-26 number"
+msgstr "Número en base 26 biyectiva"
+
+#: ../data/functions.xml.in.h:265
+msgid "Integers"
+msgstr "Enteros"
+
+#: ../data/functions.xml.in.h:266
+msgid "Even"
+msgstr "Par"
+
+#: ../data/functions.xml.in.h:267
+msgid "r:even"
+msgstr ""
+
+#: ../data/functions.xml.in.h:268
+msgid "Odd"
+msgstr "Impar"
+
+#: ../data/functions.xml.in.h:269
+msgid "r:odd"
+msgstr ""
+
+#: ../data/functions.xml.in.h:270
+msgid "Special Functions"
+msgstr "Funciones especiales"
+
+#: ../data/functions.xml.in.h:271
+msgid "Gamma Function"
+msgstr "Función gamma"
+
+#: ../data/functions.xml.in.h:272
+msgid "r:gamma"
+msgstr ""
+
+#: ../data/functions.xml.in.h:273
+msgid "Digamma Function"
+msgstr "Función digamma"
+
+#: ../data/functions.xml.in.h:274
+msgid "r:digamma,psi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:275
+msgid "Beta Function"
+msgstr "Función beta"
+
+#: ../data/functions.xml.in.h:276
+msgid "r:beta"
+msgstr ""
+
+#: ../data/functions.xml.in.h:277
+msgid "Error Function"
+msgstr "Función error"
+
+#: ../data/functions.xml.in.h:278
+msgid "r:erf"
+msgstr ""
+
+#: ../data/functions.xml.in.h:279
+msgid "Complementary Error Function"
+msgstr "Función error complementaria"
+
+#: ../data/functions.xml.in.h:280
+msgid "r:erfc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:281
+msgid "Imaginary Error Function"
+msgstr "Función error imaginaria"
+
+#: ../data/functions.xml.in.h:282
+msgid "r:erfi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:283
+msgid "Polylogarithm"
+msgstr "Polilogaritmo"
+
+#: ../data/functions.xml.in.h:284
+msgid "rc:Li,polylog"
+msgstr ""
+
+#: ../data/functions.xml.in.h:285
+msgid "Order"
+msgstr "Orden"
+
+#: ../data/functions.xml.in.h:286
+msgid "Argument"
+msgstr "Argumento"
+
+#: ../data/functions.xml.in.h:287
+msgid "Airy Function"
+msgstr "Función de Airy"
+
+#: ../data/functions.xml.in.h:288
+msgid "r:airy"
+msgstr ""
+
+#: ../data/functions.xml.in.h:289
+msgid "Bessel Function of the First Kind"
+msgstr "Función de Bessel de la primera especie"
+
+#: ../data/functions.xml.in.h:290
+msgid "r:besselj"
+msgstr ""
+
+#: ../data/functions.xml.in.h:291
+msgid "Bessel Function of the Second Kind"
+msgstr "Función de Bessel de la segunda especie"
+
+#: ../data/functions.xml.in.h:292
+msgid "r:bessely"
+msgstr ""
+
+#: ../data/functions.xml.in.h:293
+msgid "Riemann Zeta"
+msgstr "Función zeta de Riemann"
+
+#: ../data/functions.xml.in.h:294
+msgid "Calculates Hurwitz zeta function if the second argument is not 1."
+msgstr "Calcula la función zeta de Hurwitz si el segundo argumento no es 1."
+
+#: ../data/functions.xml.in.h:295
+msgid "r:zeta"
+msgstr ""
+
+#: ../data/functions.xml.in.h:296
+msgid "Integral point"
+msgstr "Punto integral"
+
+#: ../data/functions.xml.in.h:297
+msgid "Hurwitz zeta argument"
+msgstr "Argumento de Hurwitz zeta"
+
+#: ../data/functions.xml.in.h:298
+msgid "Kronecker Delta"
+msgstr "Delta de Kronecker"
+
+#: ../data/functions.xml.in.h:299
+msgid "r:kronecker"
+msgstr ""
+
+#: ../data/functions.xml.in.h:300
+msgid "Returns 0 if i != j and 1 if i = j."
+msgstr "Devuelve 0 si i != j y 1 si i = j."
+
+#: ../data/functions.xml.in.h:301
+msgid "Value 1 (i)"
+msgstr "Valor 1 (i)"
+
+#: ../data/functions.xml.in.h:302
+msgid "Value 2 (j)"
+msgstr "Valor 2 (j)"
+
+#: ../data/functions.xml.in.h:303
+msgid "Logit Transformation"
+msgstr "Transformación logit"
+
+#: ../data/functions.xml.in.h:304
+msgid "r:logit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:305
+msgid "Sigmoid Function"
+msgstr "Función sigmoide"
+
+#: ../data/functions.xml.in.h:306
+msgid "r:sigmoid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:307
+msgid "Step Functions"
+msgstr "Función escalonada"
+
+#: ../data/functions.xml.in.h:308
+msgid "Heaviside Step Function"
+msgstr "Función escalón de Heaviside"
+
+#: ../data/functions.xml.in.h:309
+msgid "r:heaviside,au:&#x03B8;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:310
+msgid ""
+"Discontinuous function also known as \"unit step function\". Returns 0 if x "
+"&lt; 0, 1 if x &gt; 0, and 1/2 if x = 0."
+msgstr ""
+"Función discontinua también conocida como \"función escalón unitario\". "
+"Devuelve 0 si x &lt; 0, 1 si x &gt; 0, y 1/2 si x = 0."
+
+#: ../data/functions.xml.in.h:311
+msgid "Dirac Delta Function"
+msgstr "Función delta de Dirac"
+
+#: ../data/functions.xml.in.h:312
+msgid "r:dirac,au:&#x3B4;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:313
+msgid "Returns 0 if x is non-zero, and infinity if x is zero."
+msgstr "Devuelve 0 si x != 0, o infinito si x != 0."
+
+#: ../data/functions.xml.in.h:314
+msgid "Ramp Function"
+msgstr "Función rampa"
+
+#: ../data/functions.xml.in.h:315
+msgid "r:ramp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:316
+msgid "Rectangular Function"
+msgstr "Función rectangular"
+
+#: ../data/functions.xml.in.h:317
+msgid "r:rectangular"
+msgstr ""
+
+#: ../data/functions.xml.in.h:318
+msgid "Triangular Function"
+msgstr "Función triangular"
+
+#: ../data/functions.xml.in.h:319
+msgid "r:triangular"
+msgstr ""
+
+#: ../data/functions.xml.in.h:320
+msgid "Complex Numbers"
+msgstr "Números complejos"
+
+#: ../data/functions.xml.in.h:321
+msgid "Real Part"
+msgstr "Parte real"
+
+#: ../data/functions.xml.in.h:322
+msgid "r:re,au:&#x211C;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:323
+msgid "Complex number"
+msgstr "Número complejo"
+
+#: ../data/functions.xml.in.h:324
+msgid "Imaginary Part"
+msgstr "Parte imaginaria"
+
+#: ../data/functions.xml.in.h:325
+msgid "r:im,au:&#x2111;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:326
+msgid "Principal Argument"
+msgstr "Argumento principal"
+
+#: ../data/functions.xml.in.h:327
+msgid "r:arg"
+msgstr ""
+
+#: ../data/functions.xml.in.h:328
+msgid "Complex Conjugate"
+msgstr "Conjugado complejo"
+
+#: ../data/functions.xml.in.h:329
+msgid "r:conj"
+msgstr ""
+
+#: ../data/functions.xml.in.h:330
+msgid "Exponents &amp; Logarithms"
+msgstr "Exponentes y logaritmos"
+
+#: ../data/functions.xml.in.h:331
+msgid "Square Root"
+msgstr "Raíz cuadrada"
+
+#: ../data/functions.xml.in.h:332
+msgid "au:&#x221A;,r:sqrt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:333
+msgid ""
+"Returns the principal square root (for positive values the positive root is "
+"returned)."
+msgstr ""
+"Devuelve la raíz cuadrada principal (para valores positivos la raíz "
+"positiva es devuelta)."
+
+#: ../data/functions.xml.in.h:334
+msgid "Cube Root"
+msgstr "Raíz cúbica"
+
+#: ../data/functions.xml.in.h:335
+msgid "au:&#x221B;,r:cbrt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:336
+msgid "Returns the third real root."
+msgstr "Devuelve la tercera raíz real."
+
+#: ../data/functions.xml.in.h:337
+msgid "Nth root"
+msgstr "Enésima raíz"
+
+#: ../data/functions.xml.in.h:338
+msgid "r:root"
+msgstr ""
+
+#: ../data/functions.xml.in.h:339
+msgid ""
+"Returns the real root. For negative values the degree must be odd. Complex "
+"values are not allowed."
+msgstr ""
+"Devuelve la raíz real. Para valores negativos el grado debe ser impar. "
+"Valores complejos no están permitidos."
+
+#: ../data/functions.xml.in.h:340 ../data/units.xml.in.h:65
+msgid "Degree"
+msgstr "Grado"
+
+#: ../data/functions.xml.in.h:341
+msgid "Square"
+msgstr "Cuadrado"
+
+#: ../data/functions.xml.in.h:342
+msgid "r:sq"
+msgstr ""
+
+#: ../data/functions.xml.in.h:343
+msgid "Exponential (e^x)"
+msgstr "Exponencial (e^x)"
+
+#: ../data/functions.xml.in.h:344
+msgid "r:exp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:345
+msgid "Natural Logarithm"
+msgstr "Logaritmo natural"
+
+#: ../data/functions.xml.in.h:346
+msgid "r:ln"
+msgstr ""
+
+#: ../data/functions.xml.in.h:347
+msgid "Base-N Logarithm"
+msgstr "Logaritmo de base N"
+
+#: ../data/functions.xml.in.h:348
+msgid "r:log"
+msgstr ""
+
+#: ../data/functions.xml.in.h:349
+msgid "Lambert W Function (Omega Function, Product Log)"
+msgstr "Función W de Lambert (función Omega; log producto)"
+
+#: ../data/functions.xml.in.h:350
+msgid "r:lambertw,productlog"
+msgstr ""
+
+#: ../data/functions.xml.in.h:351
+msgid ""
+"Returns the inverse function for mx*e^x as ln() does for e^x. Only the "
+"principal branch and real valued results are currently supported."
+msgstr ""
+"Devuelve la función inversa de mx*e^x como ln() es para e^x. Solo la rama "
+"principal y resultados reales están soportados actualmente."
+
+#: ../data/functions.xml.in.h:352
+msgid "Branch"
+msgstr "Rama"
+
+#: ../data/functions.xml.in.h:353
+msgid "Complex Exponential (Cis)"
+msgstr "Exponencial compleja (Cis)"
+
+#: ../data/functions.xml.in.h:354
+msgid "r:cis"
+msgstr ""
+
+#: ../data/functions.xml.in.h:355
+msgid "Base-2 Logarithm"
+msgstr "Logaritmo base 2"
+
+#: ../data/functions.xml.in.h:356
+msgid "rs:log2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:357
+msgid "Returns the base n logarithm."
+msgstr "Devuelve el logaritmo de base N"
+
+#: ../data/functions.xml.in.h:358
+msgid "Base-10 Logarithm"
+msgstr "Logaritmo base 10"
+
+#: ../data/functions.xml.in.h:359
+msgid "rs:log10"
+msgstr ""
+
+#: ../data/functions.xml.in.h:360
+msgid "2 raised to the power X"
+msgstr "2 elevado a la X"
+
+#: ../data/functions.xml.in.h:361
+msgid "rs:exp2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:362
+msgid "10 raised to the power X"
+msgstr "10 elevado a la X"
+
+#: ../data/functions.xml.in.h:363
+msgid "rs:exp10"
+msgstr ""
+
+#: ../data/functions.xml.in.h:364
+msgid "X raised to the power Y"
+msgstr "X elevado a la Y"
+
+#: ../data/functions.xml.in.h:365
+msgid "r:pow"
+msgstr ""
+
+#: ../data/functions.xml.in.h:366
+msgid "Square root (x * pi)"
+msgstr "Raíz cuadrada (x * pi)"
+
+#: ../data/functions.xml.in.h:367
+msgid "r:sqrtpi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:368
+msgid "Returns the non-negative square root of x * pi"
+msgstr "Devuelve la raíz cuadrada no negativa de x * pi"
+
+#: ../data/functions.xml.in.h:369
+msgid "Non-negative value"
+msgstr "Valor no negativo"
+
+#: ../data/functions.xml.in.h:370
+msgid "Trigonometry"
+msgstr "Trigonometría"
+
+#: ../data/functions.xml.in.h:371
+msgid "Sine"
+msgstr "Seno"
+
+#: ../data/functions.xml.in.h:372
+msgid "r:sin"
+msgstr ""
+
+#: ../data/functions.xml.in.h:373
+msgid "Angle"
+msgstr "Ángulo"
+
+#: ../data/functions.xml.in.h:374
+msgid "Cosine"
+msgstr "Coseno"
+
+#: ../data/functions.xml.in.h:375
+msgid "r:cos"
+msgstr ""
+
+#: ../data/functions.xml.in.h:376
+msgid "Tangent"
+msgstr "Tangente"
+
+#: ../data/functions.xml.in.h:377
+msgid "r:tan"
+msgstr ""
+
+#: ../data/functions.xml.in.h:378
+msgid "Inverse Sine"
+msgstr "Arcoseno"
+
+#: ../data/functions.xml.in.h:379
+msgid "r:asin"
+msgstr ""
+
+#: ../data/functions.xml.in.h:380
+msgid "Inverse Cosine"
+msgstr "Arcocoseno"
+
+#: ../data/functions.xml.in.h:381
+msgid "r:acos"
+msgstr ""
+
+#: ../data/functions.xml.in.h:382
+msgid "Inverse Tangent"
+msgstr "Arcotangente"
+
+#: ../data/functions.xml.in.h:383
+msgid "r:atan"
+msgstr ""
+
+#: ../data/functions.xml.in.h:384
+msgid "Hyperbolic Sine"
+msgstr "Seno hiperbólico"
+
+#: ../data/functions.xml.in.h:385
+msgid "r:sinh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:386
+msgid "Hyperbolic Cosine"
+msgstr "Coseno hiperbólico"
+
+#: ../data/functions.xml.in.h:387
+msgid "r:cosh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:388
+msgid "Hyperbolic Tangent"
+msgstr "Tangente hiperbólica"
+
+#: ../data/functions.xml.in.h:389
+msgid "r:tanh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:390
+msgid "Inverse Hyperbolic Sine"
+msgstr "Arcoseno hiperbólico"
+
+#: ../data/functions.xml.in.h:391
+msgid "r:asinh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:392
+msgid "Inverse Hyperbolic Cosine"
+msgstr "Arcocoseno hiperbólico"
+
+#: ../data/functions.xml.in.h:393
+msgid "r:acosh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:394
+msgid "Inverse Hyperbolic Tangent"
+msgstr "Arcotangente hiperbólica"
+
+#: ../data/functions.xml.in.h:395
+msgid "r:atanh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:396
+msgid "Four-quadrant Inverse Tangent"
+msgstr "Arcotangente de dos parámetros"
+
+#: ../data/functions.xml.in.h:397
+msgid "r:atan2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:398
+msgid ""
+"Computes the principal value of the argument function applied to the complex "
+"number x+iy."
+msgstr ""
+"Calcula el valor principal de la función argumento aplicada al número "
+"complejo x + iy."
+
+#: ../data/functions.xml.in.h:399
+msgid "Y"
+msgstr "Y"
+
+#: ../data/functions.xml.in.h:400
+msgid "X"
+msgstr "X"
+
+#: ../data/functions.xml.in.h:401
+msgid "Cardinal Sine (Sinc Function)"
+msgstr "Seno cardinal (función sinc)"
+
+#: ../data/functions.xml.in.h:402
+msgid "r:sinc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:403
+msgid "Radians to Default Angle Unit"
+msgstr "Radianes a unidad de ángulo predefinida"
+
+#: ../data/functions.xml.in.h:404
+msgid "r:radtodef"
+msgstr ""
+
+#: ../data/functions.xml.in.h:405
+msgid "Radians"
+msgstr "Radianes"
+
+#: ../data/functions.xml.in.h:406
+msgid "Secant"
+msgstr "Secante"
+
+#: ../data/functions.xml.in.h:407
+msgid "r:sec"
+msgstr ""
+
+#: ../data/functions.xml.in.h:408
+msgid "Cosecant"
+msgstr "Cosecante"
+
+#: ../data/functions.xml.in.h:409
+msgid "r:csc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:410
+msgid "Cotangent"
+msgstr "Cotangente"
+
+#: ../data/functions.xml.in.h:411
+msgid "r:cot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:412
+msgid "Hyperbolic Secant"
+msgstr "Secante hiperbólica"
+
+#: ../data/functions.xml.in.h:413
+msgid "r:sech"
+msgstr ""
+
+#: ../data/functions.xml.in.h:414
+msgid "Hyperbolic Cosecant"
+msgstr "Cosecante hiperbólica"
+
+#: ../data/functions.xml.in.h:415
+msgid "r:csch"
+msgstr ""
+
+#: ../data/functions.xml.in.h:416
+msgid "Hyperbolic Cotangent"
+msgstr "Cotangente hiperbólica"
+
+#: ../data/functions.xml.in.h:417
+msgid "r:coth"
+msgstr ""
+
+#: ../data/functions.xml.in.h:418
+msgid "Inverse Secant"
+msgstr "Arcosecante"
+
+#: ../data/functions.xml.in.h:419
+msgid "r:asec"
+msgstr ""
+
+#: ../data/functions.xml.in.h:420
+msgid "Inverse Cosecant"
+msgstr "Arcocosecante"
+
+#: ../data/functions.xml.in.h:421
+msgid "r:acsc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:422
+msgid "Inverse Cotangent"
+msgstr "Arcocotangente"
+
+#: ../data/functions.xml.in.h:423
+msgid "r:acot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:424
+msgid "Inverse Hyperbolic Secant"
+msgstr "Arcosecante hiperbólica"
+
+#: ../data/functions.xml.in.h:425
+msgid "r:asech"
+msgstr ""
+
+#: ../data/functions.xml.in.h:426
+msgid "Inverse Hyperbolic Cosecant"
+msgstr "Arcocosecante hiperbólica"
+
+#: ../data/functions.xml.in.h:427
+msgid "r:acsch"
+msgstr ""
+
+#: ../data/functions.xml.in.h:428
+msgid "Inverse Hyperbolic Cotangent"
+msgstr "Arcocotangente hiperbólica"
+
+#: ../data/functions.xml.in.h:429
+msgid "r:acoth"
+msgstr ""
+
+#: ../data/functions.xml.in.h:430
+msgid "Miscellaneous"
+msgstr "Misceláneo"
+
+#: ../data/functions.xml.in.h:431
+msgid "IEEE 754 Floating-Point"
+msgstr "Punto flotante IEEE 754"
+
+#: ../data/functions.xml.in.h:432
+msgid "r:float"
+msgstr ""
+
+#: ../data/functions.xml.in.h:433
+msgid ""
+"Reads a number in a IEEE 754 floating-point format. The number will be read "
+"as a binary number, unless it contains digits other than 1 or 0. If the "
+"third argument (exponent bits) is set to zero, the standard number of "
+"exponent bits will be used (e.g. 8 for 32-bit format)."
+msgstr ""
+"Lee un número en formato de punto flotante IEEE 754. El número será leído "
+"como un número binario, a menos que contenga dígitos que no sean 1 o 0. "
+"Si el tercer argumento (bits de exponente) es cero, el número estándar "
+"de bits de exponente será usado (ej. 8 para formato de 32 bit)."
+
+#: ../data/functions.xml.in.h:434
+msgid "Floating-point number (binary)"
+msgstr "Número de punto flotante (binario)"
+
+#: ../data/functions.xml.in.h:435
+msgid "Number of bits"
+msgstr "Número de bits"
+
+#: ../data/functions.xml.in.h:436
+msgid "Number of exponent bits"
+msgstr "Número de bits de exponente"
+
+#: ../data/functions.xml.in.h:437
+msgid "IEEE 754 Floating-Point Bits"
+msgstr "Bits de punto flotante IEEE 754"
+
+#: ../data/functions.xml.in.h:438
+msgid "r:floatBits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:439
+msgid ""
+"Converts a value to a number in a IEEE 754 floating-point format and returns "
+"the number corresponding to the binary representation. If the third argument "
+"(exponent bits) is set to zero, the standard number of exponent bits will be "
+"used (e.g. 8 for 32-bit format)."
+msgstr ""
+"Convierte un valor a un número en formato de punto flotante IEEE 754 y "
+"devuelve el número correspondiente en representación binaria. "
+"Si el tercer argumento (bits de exponente) es cero, el número estándar "
+"de bits de exponente será usado (ej. 8 para formato de 32 bit)."
+
+#: ../data/functions.xml.in.h:440
+msgid "IEEE 754 Floating-Point Error"
+msgstr "Error de punto flotante IEEE 754"
+
+#: ../data/functions.xml.in.h:441
+msgid "r:floatError"
+msgstr ""
+
+#: ../data/functions.xml.in.h:442
+msgid ""
+"Calculates the error (the difference between the original and the converted "
+"value) when converting a value to a IEEE 754 floating-point format. If the "
+"third argument (exponent bits) is set to zero, the standard number of "
+"exponent bits will be used (e.g. 8 for 32-bit format)."
+msgstr ""
+"Calcula el error (la diferencia entre el valor original y convertido) "
+"al convertir un valor a formato punto flotante IEEE 754."
+"Si el tercer argumento (bits de exponente) es cero, el número estándar "
+"de bits de exponente será usado (ej. 8 para formato de 32 bit)."
+
+#: ../data/functions.xml.in.h:443
+msgid "IEEE 754 Floating-Point Components"
+msgstr "Componentes de punto flotante IEEE 754"
+
+#: ../data/functions.xml.in.h:444
+msgid "r:floatParts"
+msgstr ""
+
+#: ../data/functions.xml.in.h:445
+msgid ""
+"Converts a value to a number in a IEEE 754 floating-point format and returns "
+"sign, exponent, and significand in vector. If the third argument (exponent "
+"bits) is set to zero, the standard number of exponent bits will be used (e."
+"g. 8 for 32-bit format)."
+msgstr ""
+"Convierte un valor a un número en formato de punto flotante IEEE 754 y "
+"devuelve el signo, exponente y significando en un vector. "
+"Si el tercer argumento (bits de exponente) es cero, el número estándar "
+"de bits de exponente será usado (ej. 8 para formato de 32 bit)."
+
+#: ../data/functions.xml.in.h:446
+msgid "IEEE 754 Floating-Point Value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:447
+msgid "r:floatValue"
+msgstr ""
+
+#: ../data/functions.xml.in.h:448
+msgid ""
+"Returns the closest value that can be represented by a IEEE 754 floating-"
+"point format. If the third argument (exponent bits) is set to zero, the "
+"standard number of exponent bits will be used (e.g. 8 for 32-bit format)."
+msgstr ""
+"Devuelve el valor más cercano que puede ser representado por un formato "
+"de punto flotante IEEE 754."
+"Si el tercer argumento (bits de exponente) es cero, el número estándar "
+"de bits de exponente será usado (ej. 8 para formato de 32 bit)."
+
+#: ../data/functions.xml.in.h:449
+msgid "Roman Number"
+msgstr "Número romano"
+
+#: ../data/functions.xml.in.h:450
+msgid "r:roman"
+msgstr ""
+
+#: ../data/functions.xml.in.h:451
+msgid "Returns the value of a roman number."
+msgstr "Devuelve el valor de un número romano."
+
+#: ../data/functions.xml.in.h:452
+msgid "Roman number"
+msgstr "Número romano"
+
+#: ../data/functions.xml.in.h:453
+msgid "Body Mass Index (BMI)"
+msgstr "Índice de masa corporal (IMC)"
+
+#: ../data/functions.xml.in.h:454
+msgid "-r:bmi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:455
+msgid ""
+"Calculates the Body Mass Index. The resulting BMI-value is sometimes "
+"interpreted as follows (although varies with age, sex, etc.):&#10;&#10;"
+"Underweight &lt; 18.5&#10;Normal weight 18.5-25&#10;Overweight 25-30&#10;"
+"Obesity &gt; 30&#10;&#10;Note that you must use units for weight (ex. 59kg) "
+"and length (ex. 174cm)."
+msgstr ""
+"Calcula el Índice de masa corporal. El valor resultante es interpretado "
+"usualmente (aunque varía con la edad, sexo, etc.) como: &#10;&#10;"
+"Bajo peso &lt; 18.5&#10;Normal 18.5-25&#10;"
+"Sobrepeso 25-30&#10;Obesidad &gt; 30&#10;&#10;"
+"Tenga en cuenta que debe usar unidades para peso (ej. 59kg) "
+"y altura (ej. 174cm)."
+
+#: ../data/functions.xml.in.h:457
+msgid "Length"
+msgstr "Altura"
+
+#: ../data/functions.xml.in.h:458
+msgid "RAID Space"
+msgstr "Espacio RAID"
+
+#: ../data/functions.xml.in.h:459
+msgid "r:raid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:460
+msgid ""
+"Calculates RAID array disk capacity usable for data storage. If the "
+"combination of number of disks and RAID level is invalid, zero is returned. "
+"Supported RAID levels are 0, 1, 2, 3, 4, 5, 6, 1+0/10, 0+1, 5+0/50, 6+0/60, "
+"and 1+6. Stripes are optional and only used for nested RAID levels (except "
+"1+0)."
+msgstr ""
+"Calcula la capacidad útil de un grupo RAID para almacenamiento de datos. "
+"Si la combinación de número de discos y nivel RAID es inválida, se "
+"devuelve cero. Los niveles de RAID soportados son 0, 1, 2, 3, 4, 5, 6, "
+"1+0/10, 0+1, 5+0/50, 6+0/60, y 1+6. Las divisiones son opcionales y solo "
+"usadas para niveles RAID anidados (excepto 1+0)."
+
+#: ../data/functions.xml.in.h:461
+msgid "RAID level"
+msgstr "Nivel RAID"
+
+#: ../data/functions.xml.in.h:462
+msgid "Capacity of each disk"
+msgstr "Capacidad de cada disco"
+
+#: ../data/functions.xml.in.h:463
+msgid "Number of disks"
+msgstr "Número de discos"
+
+#: ../data/functions.xml.in.h:464
+msgid "Stripes"
+msgstr "Divisiones"
+
+#: ../data/functions.xml.in.h:465
+msgid "Depth of Field"
+msgstr "Profundidad de campo"
+
+#: ../data/functions.xml.in.h:466
+msgid "r:dof"
+msgstr ""
+
+#: ../data/functions.xml.in.h:467
+msgid ""
+"Returns the estimated distance between the nearest and the farthest objects "
+"that are in acceptably sharp focus in a photo. Enter focal length (e.g. 50 "
+"mm) and distance (e.g. 5 m) with units, and f-stop without unit (2.8, 4.0, "
+"5.6, etc.). Specify either a cicle of confusion diameter limit (e.g. 0.05 "
+"mm) or the sensor size of the camera - 0=\"35mm\", 1=\"APS-H\", 2=\"APS-CN"
+"\" (Nikon, Pentax, Sony), 3=\"APS-C\" (Canon), 4=\"4/3\" (Fourt Thirds "
+"System), or 5='1\"' (Nikon 1, Sony RX10, Sony RX100) - for a diameter based "
+"on d/1500."
+msgstr ""
+"Devuelve la distancia estimada entre los objetos más cercanos y lejanos "
+"que están en un foco aceptable en la foto. Ingrese la longitud focal "
+"(ej. 50mm) y la distancia (ej. 5m) con unidades, y el número f sin unidad "
+"(ej. 2.8, 4.0, 5.6, etc.). Especifique un círculo de confusión máximo "
+"(ej. 0.05mm) o el tamaño del sensor de la cámara (0 = \"35mm\", "
+"1 = \"APS-H\", 2 = \"APS-CN\" (Nikon, Pentax, Sony), 3 = \"APS-C\" "
+"(Canon), 4 = \"4/3\" (Sistema cuatro tercios), o 5 = \"1\"\" "
+"(Nikon 1, Sony RX10, Sony RX100)) para un diámetro basado en d/1500."
+
+#: ../data/functions.xml.in.h:468
+msgid "Focal Length"
+msgstr "longitud focal"
+
+#: ../data/functions.xml.in.h:469
+msgid "F-stop (aperture)"
+msgstr "Número f (apertura)"
+
+#: ../data/functions.xml.in.h:470
+msgid "Distance"
+msgstr "Distancia"
+
+#: ../data/functions.xml.in.h:471
+msgid "Circle of confusion or sensor size"
+msgstr "Círculo de confusión o tamaño del sensor"
+
+#: ../data/functions.xml.in.h:472
+msgid "American Wire Gauge Cross-Section Area"
+msgstr "Área de sección transversal de calibre de alambre estadounidense"
+
+#: ../data/functions.xml.in.h:473
+msgid "r:awg"
+msgstr ""
+
+#: ../data/functions.xml.in.h:474
+msgid ""
+"For gauges larger than 0000 (4/0), please use negative values (00=-1, "
+"000=-2, 0000=-3, 00000=-4, etc). For conversion to AWG, use an equation (e."
+"g. awg(x) = 20 mm^2)."
+msgstr ""
+"Para calibres mayores de 0000 (4/0), por favor use valores negativos "
+"(00 = -1, 000 = -2, 0000 = -3, 00000 = -4, etc). "
+"Para conversión a AWG, use una ecuación (ej. awg(x) = 20mm^2)."
+
+#: ../data/functions.xml.in.h:475
+msgid "American Wire Gauge Diameter"
+msgstr "Diámetro de calibre de alambre estadounidense"
+
+#: ../data/functions.xml.in.h:476
+msgid "r:awgd"
+msgstr ""
+
+#: ../data/functions.xml.in.h:477
+msgid ""
+"For gauges larger than 0000 (4/0), please use negative values (00=-1, "
+"000=-2, 0000=-3, 00000=-4, etc). For conversion to AWG, use an equation (e."
+"g. awgd(x) = 5 mm)."
+msgstr ""
+"Para calibres mayores de 0000 (4/0), por favor use valores negativos "
+"(00 = -1, 000 = -2, 0000 = -3, 00000 = -4, etc). "
+"Para conversión a AWG, use una ecuación (ej. awgd(x) = 5mm)."
+
+#: ../data/functions.xml.in.h:478
+msgid "Statistics"
+msgstr "Estadística"
+
+#: ../data/functions.xml.in.h:479
+msgid "Descriptive Statistics"
+msgstr "Estadística descriptiva"
+
+#: ../data/functions.xml.in.h:480
+msgid "Sum (total)"
+msgstr "Suma (total)"
+
+#: ../data/functions.xml.in.h:481
+msgid "r:total"
+msgstr ""
+
+#: ../data/functions.xml.in.h:482
+msgid "Data"
+msgstr "Datos"
+
+#: ../data/functions.xml.in.h:483
+msgid "Percentile"
+msgstr "Percentil"
+
+#: ../data/functions.xml.in.h:484
+msgid "r:percentile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:486
+#, no-c-format
+msgid "Percentile (%)"
+msgstr "Percentil (%)"
+
+#: ../data/functions.xml.in.h:487
+msgid "Quantile algorithm (as in R)"
+msgstr "Algoritmo cuantil (como en R)"
+
+#: ../data/functions.xml.in.h:488
+msgid "r:min"
+msgstr ""
+
+#: ../data/functions.xml.in.h:489
+msgid "Returns the lowest value."
+msgstr "Devuelve el valor más bajo."
+
+#: ../data/functions.xml.in.h:490
+msgid "r:max"
+msgstr ""
+
+#: ../data/functions.xml.in.h:491
+msgid "Returns the highest value."
+msgstr "Devuelve el valor más alto."
+
+#: ../data/functions.xml.in.h:492
+msgid "Mode"
+msgstr "Moda"
+
+#: ../data/functions.xml.in.h:493
+msgid "r:mode"
+msgstr ""
+
+#: ../data/functions.xml.in.h:494
+msgid "Returns the most frequently occurring value."
+msgstr "Devuelve el valor más frecuente."
+
+#: ../data/functions.xml.in.h:495
+msgid "Range"
+msgstr "Rango"
+
+#: ../data/functions.xml.in.h:496
+msgid "r:range"
+msgstr ""
+
+#: ../data/functions.xml.in.h:497
+msgid "Calculates the difference between the min and max value."
+msgstr "Calcula la diferencia entre el valor mínimo y máximo"
+
+#: ../data/functions.xml.in.h:498
+msgid "Median"
+msgstr "Mediana"
+
+#: ../data/functions.xml.in.h:499
+msgid "r:median"
+msgstr ""
+
+#: ../data/functions.xml.in.h:500
+msgid "Quartile"
+msgstr "Cuartil"
+
+#: ../data/functions.xml.in.h:501
+msgid "r:quartile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:502
+msgid "Quantile Algorithm (as in R)"
+msgstr "Algoritmo cuantil (como en R)"
+
+#: ../data/functions.xml.in.h:503
+msgid "Decile"
+msgstr "Decil"
+
+#: ../data/functions.xml.in.h:504
+msgid "r:decile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:505
+msgid "Interquartile Range"
+msgstr "Rango intercuartílico"
+
+#: ../data/functions.xml.in.h:506
+msgid "r:iqr"
+msgstr ""
+
+#: ../data/functions.xml.in.h:507
+msgid "Calculates the difference between the first and third quartile."
+msgstr "Calcula la diferencia entre el primer y tercer cuartil."
+
+#: ../data/functions.xml.in.h:508
+msgid "Number of Samples"
+msgstr "Número de muestras"
+
+#. Number of samples
+#: ../data/functions.xml.in.h:510
+msgid "r:number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:511
+msgid "Returns the number of samples."
+msgstr "Devuelve el número de muestras"
+
+#: ../data/functions.xml.in.h:512
+msgid "Random Numbers"
+msgstr "Números aleatorios"
+
+#: ../data/functions.xml.in.h:513
+msgid "Random Number"
+msgstr "Número aleatorio"
+
+#: ../data/functions.xml.in.h:514
+msgid "r:rand"
+msgstr ""
+
+#: ../data/functions.xml.in.h:515
+msgid ""
+"Generates a pseudo-random number. Returns a real number between 0 and 1, if "
+"ceil is zero (default), or an integer between 1 and (including) ceil."
+msgstr ""
+"Genera un número pseudoaleatorios. Devuelve un número real entre 0 y 1, "
+"si máximo es cero (por defecto), o un entero entre 1 y máximo inclusive."
+
+#: ../data/functions.xml.in.h:516
+msgid "Ceil"
+msgstr "Máximo"
+
+#: ../data/functions.xml.in.h:517
+msgid "Number of values"
+msgstr "Número de valores"
+
+#: ../data/functions.xml.in.h:518
+msgid "Normally Distributed Random Number"
+msgstr "Número aleatorio normalmente distributivo"
+
+#: ../data/functions.xml.in.h:519
+msgid "r:randnorm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:520
+msgid "Mean"
+msgstr "Media"
+
+#: ../data/functions.xml.in.h:521
+msgid "Standard deviation"
+msgstr "Desviación estándar"
+
+#: ../data/functions.xml.in.h:522
+msgid "Poisson Distributed Random Number"
+msgstr "Número aleatorio distribuido de Poisson"
+
+#: ../data/functions.xml.in.h:523
+msgid "r:randpoisson"
+msgstr ""
+
+#: ../data/functions.xml.in.h:524
+msgid "Uniformly Distributed Random Number"
+msgstr "Número aleatorio distribuido uniformemente"
+
+#: ../data/functions.xml.in.h:525
+msgid "r:randuniform"
+msgstr ""
+
+#: ../data/functions.xml.in.h:526
+msgid "Random Number Between Limits"
+msgstr "Número aleatorio entre límites"
+
+#: ../data/functions.xml.in.h:527
+msgid "r:randbetween"
+msgstr ""
+
+#: ../data/functions.xml.in.h:528
+msgid "Returns an integer between (including) bottom and top."
+msgstr "Devuelve un entero entre mínimo y máximo inclusive."
+
+#: ../data/functions.xml.in.h:529
+msgid "Bottom"
+msgstr "Mínimo"
+
+#: ../data/functions.xml.in.h:530
+msgid "Top"
+msgstr "Máximo"
+
+#: ../data/functions.xml.in.h:531
+msgid "Exponential Random Number"
+msgstr "Número aleatorio exponencial"
+
+#: ../data/functions.xml.in.h:532
+msgid "r:randexp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:533
+msgid "Rate parameter"
+msgstr "Parámetro de medida"
+
+#: ../data/functions.xml.in.h:534
+msgid "Rayleigh Distributed Random Number"
+msgstr "Número aleatorio distribuido de Rayleigh"
+
+#: ../data/functions.xml.in.h:535
+msgid "r:randrayleigh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:536
+msgid "Sigma"
+msgstr "Sigma"
+
+#: ../data/functions.xml.in.h:537
+msgid "Means"
+msgstr "Medias"
+
+#: ../data/functions.xml.in.h:538
+msgid "r:mean,average,au:x&#x0304;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:539
+msgid "Harmonic Mean"
+msgstr "Media armónica"
+
+#: ../data/functions.xml.in.h:540
+msgid "r:harmmean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:541
+msgid "Geometric Mean"
+msgstr "Media geométrica"
+
+#: ../data/functions.xml.in.h:542
+msgid "r:geomean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:543
+msgid "Trimmed Mean"
+msgstr "Media truncada"
+
+#: ../data/functions.xml.in.h:544
+msgid "r:trimmean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:545
+msgid "Trimmed percentage (at each end)"
+msgstr "Porcentaje truncado (de cada extremo)"
+
+#: ../data/functions.xml.in.h:546
+msgid "Winsorized Mean"
+msgstr "Media winsorizada"
+
+#: ../data/functions.xml.in.h:547
+msgid "r:winsormean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:548
+msgid "Winsorized percentage (at each end)"
+msgstr "Porcentaje winsorizado (de cada extremo)"
+
+#: ../data/functions.xml.in.h:549
+msgid "Weighted Mean"
+msgstr "Media ponderada"
+
+#: ../data/functions.xml.in.h:550
+msgid "r:weighmean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:551
+msgid "Weights"
+msgstr "Pesos"
+
+#: ../data/functions.xml.in.h:552
+msgid "Quadratic Mean (RMS)"
+msgstr "Media cuadrática (RMS)"
+
+#: ../data/functions.xml.in.h:553
+msgid "r:rms"
+msgstr ""
+
+#: ../data/functions.xml.in.h:554
+msgid "Moments"
+msgstr ""
+
+#: ../data/functions.xml.in.h:555
+msgid "Standard Deviation (entire population)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:556
+msgid "r:stdevp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:557
+msgid "Standard Deviation (random sampling)"
+msgstr "Desviación estándar (muestreado aleatorio)"
+
+#: ../data/functions.xml.in.h:558
+msgid "r:stdev"
+msgstr ""
+
+#: ../data/functions.xml.in.h:559
+msgid "Variance (entire population)"
+msgstr "Varianza (población entera)"
+
+#: ../data/functions.xml.in.h:560
+msgid "r:varp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:561
+msgid "Variance (random sampling)"
+msgstr "Varianza (muestreado aleatorio)"
+
+#: ../data/functions.xml.in.h:562
+msgid "r:var"
+msgstr ""
+
+#: ../data/functions.xml.in.h:563
+msgid "Standard Error"
+msgstr "Error estándar"
+
+#: ../data/functions.xml.in.h:564
+msgid "r:stderr"
+msgstr ""
+
+#: ../data/functions.xml.in.h:565
+msgid "Mean Deviation"
+msgstr "Desviación media"
+
+#: ../data/functions.xml.in.h:566
+msgid "r:meandev"
+msgstr ""
+
+#: ../data/functions.xml.in.h:567
+msgid "Covariance"
+msgstr "Covarianza"
+
+#: ../data/functions.xml.in.h:568
+msgid "r:cov,r:covar"
+msgstr ""
+
+#: ../data/functions.xml.in.h:569
+msgid "Data 1"
+msgstr "Dato 1"
+
+#: ../data/functions.xml.in.h:570
+msgid "Data 2"
+msgstr "Dato 2"
+
+#: ../data/functions.xml.in.h:571
+msgid "Pooled Variance"
+msgstr "Varianza agrupada"
+
+#: ../data/functions.xml.in.h:572
+msgid "r:poolvar"
+msgstr ""
+
+#: ../data/functions.xml.in.h:573
+msgid "Regression"
+msgstr "Regresión"
+
+#: ../data/functions.xml.in.h:574
+msgid "Statistical Correlation"
+msgstr "Correlación estadística"
+
+#: ../data/functions.xml.in.h:575
+msgid "r:cor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:576
+msgid "Pearson's Correlation Coefficient"
+msgstr "Coeficiente de correlación de Pearson"
+
+#: ../data/functions.xml.in.h:577
+msgid "r:pearson,r:correl"
+msgstr ""
+
+#: ../data/functions.xml.in.h:578
+msgid "Spearman's Rho"
+msgstr "Coeficiente de correlación de Spearman"
+
+#: ../data/functions.xml.in.h:579
+msgid "r:spearman"
+msgstr ""
+
+#: ../data/functions.xml.in.h:580
+msgid "Statistical Tests"
+msgstr "Pruebas estadísticas"
+
+#: ../data/functions.xml.in.h:581
+msgid "Unpaired T-Test"
+msgstr "Prueba t de Student no emparejada"
+
+#: ../data/functions.xml.in.h:582
+msgid "r:ttest"
+msgstr ""
+
+#: ../data/functions.xml.in.h:583
+msgid "Paired T-Test"
+msgstr "Prueba t de Student emparejada"
+
+#: ../data/functions.xml.in.h:584
+msgid "r:pttest"
+msgstr ""
+
+#: ../data/functions.xml.in.h:585
+msgid "Distribution"
+msgstr "Distribución"
+
+#: ../data/functions.xml.in.h:586
+msgid "Binomial Distribution"
+msgstr "Distribución binomial"
+
+#: ../data/functions.xml.in.h:587
+msgid "r:binomdist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:588
+msgid ""
+"Returns the probability mass or cumulative distribution function of the "
+"binomial distribution."
+msgstr ""
+"Devuelve la masa de probabilidad o la función de distribución acumulativa "
+"de la distribución binomial."
+
+#: ../data/functions.xml.in.h:589
+msgid "Number of successes"
+msgstr "Número de éxitos"
+
+#: ../data/functions.xml.in.h:590
+msgid "Number of trials"
+msgstr "Número de intentos"
+
+#: ../data/functions.xml.in.h:591
+msgid "Probability"
+msgstr "Probabilidad"
+
+#: ../data/functions.xml.in.h:592
+msgid "Cumulative"
+msgstr "Acumulativo"
+
+#: ../data/functions.xml.in.h:593
+msgid "Exponential Distribution"
+msgstr "Distribución exponencial"
+
+#: ../data/functions.xml.in.h:594
+msgid "r:expondist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:595
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"exponential distribution."
+msgstr ""
+"Devuelve la densidad de probabilidad o la función de distribución "
+"acumulativa de una distribución exponencial."
+
+#: ../data/functions.xml.in.h:596
+msgid "Logistic Distribution"
+msgstr "Distribución logística"
+
+#: ../data/functions.xml.in.h:597
+msgid "r:logistic"
+msgstr ""
+
+#: ../data/functions.xml.in.h:598
+msgid ""
+"Returns the probability density p(x) at x for a logistic distribution with "
+"scale parameter. (from Gnumeric)"
+msgstr ""
+"Devuelve la densidad de probabilidad p(x) en x para una distribución "
+"logística con parámetro de escala. (de Gnumeric)"
+
+#: ../data/functions.xml.in.h:599
+msgid "Scale"
+msgstr "Escala"
+
+#: ../data/functions.xml.in.h:600
+msgid "Normal Distribution"
+msgstr "Distribución normal"
+
+#: ../data/functions.xml.in.h:601
+msgid "r:normdist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:602
+msgid ""
+"Returns the probability density or cumulative distribution function of a "
+"normal distribution."
+msgstr ""
+"Devuelve la densidad de probabilidad o la función de distribución "
+"acumulativa de una distribución normal."
+
+#: ../data/functions.xml.in.h:603
+msgid "Pareto Distribution"
+msgstr "Distribución de Pareto"
+
+#: ../data/functions.xml.in.h:604
+msgid "r:pareto"
+msgstr ""
+
+#: ../data/functions.xml.in.h:605
+msgid ""
+"Returns the probability density p(x) at x for a Pareto distribution with "
+"exponent and scale. (from Gnumeric)"
+msgstr ""
+"Devuelve la densidad de probabilidad p(x) en x para una distribución de"
+"Pareto con parámetros de exponente y escala. (de Gnumeric)"
+
+#: ../data/functions.xml.in.h:606
+msgid "Poisson Distribution"
+msgstr "Distribución de Poisson"
+
+#: ../data/functions.xml.in.h:607
+msgid "r:poisson"
+msgstr ""
+
+#: ../data/functions.xml.in.h:608
+msgid ""
+"Returns the probability mass or cumulative distribution of the Poisson "
+"distribution."
+msgstr ""
+"Devuelve la densidad de probabilidad o la función de distribución "
+"acumulativa de una distribución de Poisson."
+
+#: ../data/functions.xml.in.h:609
+msgid "Number of events (x)"
+msgstr "Número de eventos (x)"
+
+#: ../data/functions.xml.in.h:610
+msgid "Rayleigh Distribution"
+msgstr "Distribución de Rayleigh"
+
+#: ../data/functions.xml.in.h:611
+msgid "r:rayleigh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:612
+msgid ""
+"Returns the probability density p(x) at x for a Rayleigh distribution with "
+"scale parameter sigma. (from Gnumeric)"
+msgstr ""
+"Devuelve la densidad de probabilidad p(x) en x para una distribución de "
+"Rayleigh con parámetro de escala sigma. (de Gnumeric)"
+
+#: ../data/functions.xml.in.h:613
+msgid "Rayleigh Tail Distribution"
+msgstr "Distribución de cola de Rayleigh"
+
+#: ../data/functions.xml.in.h:614
+msgid "r:rayleightail"
+msgstr ""
+
+#: ../data/functions.xml.in.h:615
+msgid ""
+"Returns the probability density p(x) at x for a Rayleigh tail distribution "
+"with scale parameter sigma and a lower limit. (from Gnumeric)"
+msgstr ""
+"Devuelve la densidad de probabilidad p(x) en x para una distribución de "
+"cola de Rayleigh con parámetro de escala sigma y un límite inferior. "
+"(de Gnumeric)"
+
+#: ../data/functions.xml.in.h:616 ../data/variables.xml.in.h:205
+msgid "Date &amp; Time"
+msgstr "Fecha y tiempo"
+
+#: ../data/functions.xml.in.h:617
+msgid "Construct Date"
+msgstr "Construir fecha"
+
+#: ../data/functions.xml.in.h:618
+msgid "r:date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:619
+msgid ""
+"Returns a date. Available calendars gregorian (1), hebrew (2), islamic (3), "
+"persian (4), indian (5), chinese (6), julian (7), milankovic (8), coptic "
+"(9), ethiopian (10), egyptian (11). The Chinese year uses an epoch of 2697 "
+"BEC and chinese leap months are indicated by adding 12 to the month number "
+"(e.g. leap month 4 = 16)."
+msgstr ""
+"Devuelve una fecha. Los calendarios disponibles son gregoriano (1), "
+"hebreo (2), musulmán (3), persa (4), hindú (5), chino (6), juliano (7), "
+"milankovic (8), cóptico (9), etíope (10), egipcio (11). El año chino usa "
+"una época de 2697 AC, y los meses bisiestos son indicados al sumarle 12 "
+"al número del mes (ej. mes bisiesto 4 = 16)."
+
+#: ../data/functions.xml.in.h:620
+msgid "Year"
+msgstr "Año"
+
+#: ../data/functions.xml.in.h:621 ../data/units.xml.in.h:153
+msgid "Month"
+msgstr "Mes"
+
+#: ../data/functions.xml.in.h:622 ../data/units.xml.in.h:145
+msgid "Day"
+msgstr "Día"
+
+#: ../data/functions.xml.in.h:623
+msgid "Calendar"
+msgstr "Calendario"
+
+#: ../data/functions.xml.in.h:624
+msgid "Construct Date and Time"
+msgstr "Construir fecha y tiempo"
+
+#: ../data/functions.xml.in.h:625
+msgid "r:datetime"
+msgstr ""
+
+#: ../data/functions.xml.in.h:626 ../data/units.xml.in.h:143
+msgid "Hour"
+msgstr "Hora"
+
+#: ../data/functions.xml.in.h:627 ../data/units.xml.in.h:141
+msgid "Minute"
+msgstr "Minuto"
+
+#: ../data/functions.xml.in.h:628 ../data/units.xml.in.h:139
+msgid "Second"
+msgstr "Segundo"
+
+#: ../data/functions.xml.in.h:629
+msgid "Days between two dates"
+msgstr "Días entre dos fechas"
+
+#: ../data/functions.xml.in.h:630
+msgid "r:days"
+msgstr ""
+
+#: ../data/functions.xml.in.h:631
+msgid ""
+"Returns the number of days between two dates.&#10;&#10;Basis is the type of "
+"day counting you want to use: 0: US 30/360, 1: real days (default), 2: real "
+"days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Devuelve el número de días entre dos fechas.&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense, 1: días reales (predeterminado), "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo."
+
+#: ../data/functions.xml.in.h:632
+msgid "First date"
+msgstr "Primera fecha"
+
+#: ../data/functions.xml.in.h:633
+msgid "Second date"
+msgstr "Segunda fecha"
+
+#: ../data/functions.xml.in.h:634
+msgid "Day counting basis"
+msgstr "Base de contado de días"
+
+#: ../data/functions.xml.in.h:635
+msgid "Financial function mode"
+msgstr "Modo de función financiera"
+
+#: ../data/functions.xml.in.h:636
+msgid "Years between two dates"
+msgstr "Años entre dos fechas"
+
+#: ../data/functions.xml.in.h:637
+msgid "r:yearfrac"
+msgstr ""
+
+#: ../data/functions.xml.in.h:638
+msgid ""
+"Returns the number of years (fractional) between two dates.&#10;&#10;Basis "
+"is the type of day counting you want to use: 0: US 30/360, 1: real days "
+"(default), 2: real days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Devuelve el número de años (fraccional) entre dos fechas.&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense, 1: días reales (predeterminado), "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo."
+
+#: ../data/functions.xml.in.h:639
+msgid "Week of Year"
+msgstr "Semana del año"
+
+#: ../data/functions.xml.in.h:640
+msgid "r:week"
+msgstr ""
+
+#: ../data/functions.xml.in.h:641
+msgid "Date"
+msgstr "Fecha"
+
+#: ../data/functions.xml.in.h:642
+msgid "Week begins on Sunday"
+msgstr "Semana empieza en Domingo"
+
+#: ../data/functions.xml.in.h:643
+msgid "Day of Week"
+msgstr "Día de la semana"
+
+#: ../data/functions.xml.in.h:644
+msgid "r:weekday"
+msgstr ""
+
+#: ../data/functions.xml.in.h:645
+msgid "r:month"
+msgstr ""
+
+#: ../data/functions.xml.in.h:646
+msgid "Day of Month"
+msgstr "Día del mes"
+
+#: ../data/functions.xml.in.h:647
+msgid "r:day"
+msgstr ""
+
+#: ../data/functions.xml.in.h:648
+msgid "r:year"
+msgstr ""
+
+#: ../data/functions.xml.in.h:649
+msgid "Day of Year"
+msgstr "Día del año"
+
+#: ../data/functions.xml.in.h:650
+msgid "r:yearday"
+msgstr ""
+
+#: ../data/functions.xml.in.h:651
+msgid "Current Time"
+msgstr "Tiempo actual"
+
+#: ../data/functions.xml.in.h:652
+msgid "r:time"
+msgstr ""
+
+#: ../data/functions.xml.in.h:653
+msgid "Time Value"
+msgstr "Valor de tiempo"
+
+#: ../data/functions.xml.in.h:654
+msgid "r:timevalue"
+msgstr ""
+
+#: ../data/functions.xml.in.h:655
+msgid "Returns the time part, in fractional hours, of a date and time value."
+msgstr "Devuelve la parte de tiempo, en horas fraccionarias, de unos "
+"valores de fecha y tiempo"
+
+#: ../data/functions.xml.in.h:656
+msgid "Date to Unix Timestamp"
+msgstr "Fecha a marca de tiempo Unix"
+
+#: ../data/functions.xml.in.h:657
+msgid "r:timestamp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:658
+msgid "Unix Timestamp to Date"
+msgstr "Marca de tiempo Unix a fecha"
+
+#: ../data/functions.xml.in.h:659
+msgid "r:stamptodate,unix2date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:660
+msgid ""
+"Returns the local date and time represented by the specified Unix timestamp "
+"(seconds, excluding leap seconds, since 1970-01-01). Supports time units."
+msgstr ""
+"Devuelve la fecha y tiempo local representados por la merca de tiempo Unix "
+"especificada (segundos, excluyendo segundos bisiestos, desde 1970-01-01). "
+"Soporta unidades de tiempo."
+
+#: ../data/functions.xml.in.h:661
+msgid "Timestamp"
+msgstr "Marca de tiempo"
+
+#: ../data/functions.xml.in.h:662
+msgid "Add Days"
+msgstr "Sumar días"
+
+#: ../data/functions.xml.in.h:663
+msgid "r:addDays"
+msgstr ""
+
+#: ../data/functions.xml.in.h:664
+msgid "Days"
+msgstr "Días"
+
+#: ../data/functions.xml.in.h:665
+msgid "Add Months"
+msgstr "Sumar meses"
+
+#: ../data/functions.xml.in.h:666
+msgid "r:addMonths"
+msgstr ""
+
+#: ../data/functions.xml.in.h:667
+msgid "Months"
+msgstr "Meses"
+
+#: ../data/functions.xml.in.h:668
+msgid "Add Years"
+msgstr "Sumar años"
+
+#: ../data/functions.xml.in.h:669
+msgid "r:addYears"
+msgstr ""
+
+#: ../data/functions.xml.in.h:670
+msgid "Years"
+msgstr "Años"
+
+#: ../data/functions.xml.in.h:671
+msgid "Add Time"
+msgstr "Sumar tiempo"
+
+#: ../data/functions.xml.in.h:672
+msgid "r:addTime"
+msgstr ""
+
+#: ../data/functions.xml.in.h:673
+msgid ""
+"Adds a time value to a date. The value can be positive or negative, but must "
+"use a unit based on seconds (such as day and year). Fractions of days are "
+"truncated."
+msgstr ""
+"Suma un valor de tiempo a una fecha. El valor puede ser positivo o "
+"negativo, pero debe ser una unidad basada en segundos (como día y año). "
+"Fracciones de días son truncadas."
+
+#: ../data/functions.xml.in.h:674 ../data/units.xml.in.h:138
+msgid "Time"
+msgstr "Tiempo"
+
+#: ../data/functions.xml.in.h:675
+msgid "Lunar Phase"
+msgstr "Fase lunar"
+
+#: ../data/functions.xml.in.h:676
+msgid "r:lunarphase"
+msgstr ""
+
+#: ../data/functions.xml.in.h:677
+msgid ""
+"Returns the lunar phase, as a number between 0 and 1, for the specified "
+"date. This value corrresponds to an angle between 0 and 360 degrees. 0 "
+"represents new moon, 0.5 full moon, and 0.25 and 0.75 quarter moons."
+msgstr ""
+"Devuelve la fase lunar, como un número entre 0 y 1, para la fecha "
+"especificada. El valor corresponde a un ángulo entre 0 y 360 grados. "
+"0 representa luna nueva, 0.5 luna llena, 0.25 cuarto creciente, "
+"y 0.75 cuarto menguante."
+
+#: ../data/functions.xml.in.h:678
+msgid "Find Lunar Phase"
+msgstr "Buscar fase lunar"
+
+#: ../data/functions.xml.in.h:679
+msgid "r:nextlunarphase"
+msgstr ""
+
+#: ../data/functions.xml.in.h:680
+msgid ""
+"Returns the date when the specified lunar phase occurs. The function "
+"searches forward beginning at the specified date. The lunar phase are "
+"specified as a number between 0 and 1, where 0 represents new moon, 0.5 full "
+"moon, and 0.25 and 0.75 quarter moons. Angle values are also allowed (e.g. π "
+"rad = 180° which corresponds to a value of 0.5). Values above 1, without "
+"unit, are interpreted as degrees."
+msgstr ""
+"Devuelve la fecha en la que la fase lunar especificada ocurre. "
+"La función busca hacia adelante empezando en la fecha especificada. "
+"La fase lunar es especificada como un número entre 0 y 1, donde 0 "
+"representa luna nueva, 0.5 luna llena, 0.25 cuarto creciente, y 0.75 "
+"cuarto menguante. Valores de ángulos también están permitidos "
+"(ej. πrad = 180° corresponde a 0.5). "
+"Valores mayores a 1 sin unidad son interpretados como grados."
+
+#: ../data/functions.xml.in.h:681
+msgid "Start Date"
+msgstr "Fecha inicial"
+
+#: ../data/functions.xml.in.h:682 ../data/variables.xml.in.h:198
+msgid "Utilities"
+msgstr "Utilidades"
+
+#: ../data/functions.xml.in.h:683
+msgid "Plot Functions and Vectors"
+msgstr "Graficar funciones y vectores"
+
+#: ../data/functions.xml.in.h:684
+msgid "r:plot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:685
+msgid "Expression or vector"
+msgstr "Expresión o vector"
+
+#: ../data/functions.xml.in.h:686
+msgid "Minimum x value"
+msgstr "Valor x mínimo"
+
+#: ../data/functions.xml.in.h:687
+msgid "Maximum x value"
+msgstr "Valor x máximo"
+
+#: ../data/functions.xml.in.h:688
+msgid "Number of samples / Step size"
+msgstr "Número de muestras / Tamaño de paso"
+
+#: ../data/functions.xml.in.h:689
+msgid "X variable"
+msgstr "Variable x"
+
+#: ../data/functions.xml.in.h:690
+msgid "Persistent"
+msgstr "Persistente"
+
+#: ../data/functions.xml.in.h:691
+msgid ""
+"Plots one or more expressions or vectors. Use a vector for the first "
+"argument to plot multiple series. Only the first argument is used for vector "
+"series. It is also possible to plot a matrix where each row is a pair of x "
+"and y values."
+msgstr ""
+"Grafica una o más expresiones o vectores. Use un vector para el primer "
+"argumento para graficar múltiples series. Solo el primer argumento es "
+"usado para series vectoriales. También es posible graficar una matriz "
+"donde cada fila es un par de valores x e y."
+
+#: ../data/functions.xml.in.h:692
+msgid "Unicode Value"
+msgstr "Valor Unicode"
+
+#: ../data/functions.xml.in.h:693
+msgid "r:code"
+msgstr ""
+
+#: ../data/functions.xml.in.h:694
+msgid "Character"
+msgstr "Carácter"
+
+#: ../data/functions.xml.in.h:695
+msgid "Unicode Character"
+msgstr "Carácter Unicode"
+
+#: ../data/functions.xml.in.h:696
+msgid "r:char"
+msgstr ""
+
+#: ../data/functions.xml.in.h:697
+msgid "Length of string"
+msgstr "Largo de cadena de texto"
+
+#: ../data/functions.xml.in.h:698
+msgid "r:len"
+msgstr ""
+
+#: ../data/functions.xml.in.h:699
+msgid "Text"
+msgstr "Texto"
+
+#: ../data/functions.xml.in.h:700
+msgid "Concatenate Strings"
+msgstr "Concatenar cadena de texto"
+
+#: ../data/functions.xml.in.h:701
+msgid "r:concatenate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:702
+msgid "Text string 1"
+msgstr "Cadena de texto 1"
+
+#: ../data/functions.xml.in.h:703
+msgid "Text string 2"
+msgstr "Cadena de texto 2"
+
+#: ../data/functions.xml.in.h:704
+msgid "Replace"
+msgstr "Reemplazar"
+
+#: ../data/functions.xml.in.h:705
+msgid "r:replace"
+msgstr ""
+
+#: ../data/functions.xml.in.h:706
+msgid ""
+"Replaces a certain value in an expression with a new value. The expression "
+"is calculated before the replacement if the fourth argument is true."
+msgstr ""
+"Reemplaza un cierto valor en una expresión con un nuevo valor. "
+"La expresión es calculada antes del reemplazo si el cuarto argumento "
+"es verdadero."
+
+#: ../data/functions.xml.in.h:707
+msgid "Expression"
+msgstr "Expresión"
+
+#: ../data/functions.xml.in.h:708
+msgid "Original value"
+msgstr "Valor original"
+
+#: ../data/functions.xml.in.h:709
+msgid "New value"
+msgstr "Nuevo valor"
+
+#: ../data/functions.xml.in.h:710
+msgid "Precalculate expression"
+msgstr "Precalcular expresión"
+
+#: ../data/functions.xml.in.h:711
+msgid "Strip Units"
+msgstr "Eliminar unidades"
+
+#: ../data/functions.xml.in.h:712
+msgid "r:nounit,strip_units"
+msgstr ""
+
+#: ../data/functions.xml.in.h:713
+msgid ""
+"Removes all units from an expression. The expression is calculated before "
+"the removal."
+msgstr ""
+"Elimina todas las unidades de una expresión. "
+"La expresión es calculada antes de la eliminación."
+
+#: ../data/functions.xml.in.h:714
+msgid "Process Vector Elements"
+msgstr "Procesar elementos de vector"
+
+#: ../data/functions.xml.in.h:715
+msgid "r:process"
+msgstr ""
+
+#: ../data/functions.xml.in.h:716
+msgid "Element variable"
+msgstr "Variable de elemento"
+
+#: ../data/functions.xml.in.h:717
+msgid "Index variable"
+msgstr "Variable de índice"
+
+#: ../data/functions.xml.in.h:718
+msgid "Vector variable"
+msgstr "Variable de vector"
+
+#: ../data/functions.xml.in.h:719
+msgid "Process Matrix Elements"
+msgstr "Procesar elementos de matriz"
+
+#: ../data/functions.xml.in.h:720
+msgid "r:processm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:721
+msgid "Row variable"
+msgstr "Variable de fila"
+
+#: ../data/functions.xml.in.h:722
+msgid "Column variable"
+msgstr "Variable de columna"
+
+#: ../data/functions.xml.in.h:723
+msgid "Matrix variable"
+msgstr "Variable de matriz"
+
+#: ../data/functions.xml.in.h:724
+msgid "Custom Sum of Elements"
+msgstr "Suma de elementos personalizada"
+
+#: ../data/functions.xml.in.h:725
+msgid "r:csum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:726
+msgid "First element"
+msgstr "Primer elemento"
+
+#: ../data/functions.xml.in.h:727
+msgid "Last element"
+msgstr "Último elemento"
+
+#: ../data/functions.xml.in.h:728
+msgid "Initial value"
+msgstr "Valor inicial"
+
+#: ../data/functions.xml.in.h:729
+msgid "Value variable"
+msgstr "Variable de valor"
+
+#: ../data/functions.xml.in.h:730
+msgid "Select Vector Elements"
+msgstr "Seleccionar elementos de vector"
+
+#: ../data/functions.xml.in.h:731
+msgid "r:select"
+msgstr ""
+
+#: ../data/functions.xml.in.h:732
+msgid "Condition"
+msgstr "Condición"
+
+#: ../data/functions.xml.in.h:733
+msgid "Select first match"
+msgstr "Seleccionar primera coincidencia"
+
+#: ../data/functions.xml.in.h:734
+msgid "r:function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:735
+msgid "Arguments"
+msgstr "Argumentos"
+
+#: ../data/functions.xml.in.h:736
+msgid "Title"
+msgstr "Título"
+
+#: ../data/functions.xml.in.h:737
+msgid "r:title"
+msgstr ""
+
+#: ../data/functions.xml.in.h:739
+msgid "Display Error"
+msgstr "Mostrar error"
+
+#: ../data/functions.xml.in.h:740
+msgid "r:error"
+msgstr ""
+
+#: ../data/functions.xml.in.h:741
+msgid "Message"
+msgstr "Mensaje"
+
+#: ../data/functions.xml.in.h:742
+msgid "Display Warning"
+msgstr "Mostrar advertencia"
+
+#: ../data/functions.xml.in.h:743
+msgid "r:warning"
+msgstr ""
+
+#: ../data/functions.xml.in.h:744
+msgid "Display Message"
+msgstr "Mostrar mensaje"
+
+#: ../data/functions.xml.in.h:745
+msgid "r:message"
+msgstr ""
+
+#: ../data/functions.xml.in.h:746
+msgid "Save as Variable"
+msgstr "Guardar como variable"
+
+#: ../data/functions.xml.in.h:747
+msgid "r:save"
+msgstr ""
+
+#: ../data/functions.xml.in.h:748
+msgid "Category"
+msgstr "Categoría"
+
+#: ../data/functions.xml.in.h:749
+msgid "RPN Stack Register"
+msgstr "Registro de pila RPN"
+
+#: ../data/functions.xml.in.h:750
+msgid "r:register"
+msgstr ""
+
+#: ../data/functions.xml.in.h:751
+msgid "Returns the value of a RPN stack register."
+msgstr "Devuelve el valor de un registro de pila RPN."
+
+#: ../data/functions.xml.in.h:752
+msgid "Index"
+msgstr "Índice"
+
+#: ../data/functions.xml.in.h:753
+msgid "RPN Stack Vector"
+msgstr "Vector de pila RPN"
+
+#: ../data/functions.xml.in.h:754
+msgid "r:stack"
+msgstr ""
+
+#: ../data/functions.xml.in.h:755
+msgid "Returns the RPN stack as a vector."
+msgstr "Devuelve la pila RPN como un vector."
+
+#: ../data/functions.xml.in.h:756
+msgid "Is Number"
+msgstr "Es número"
+
+#: ../data/functions.xml.in.h:757
+msgid "r:isNumber"
+msgstr ""
+
+#: ../data/functions.xml.in.h:758
+msgid "Is Real"
+msgstr "Es real"
+
+#: ../data/functions.xml.in.h:759
+msgid "r:isReal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:760
+msgid "Is Rational"
+msgstr "Es racional"
+
+#: ../data/functions.xml.in.h:761
+msgid "r:isRational"
+msgstr ""
+
+#: ../data/functions.xml.in.h:762
+msgid "Is Integer"
+msgstr "Es entero"
+
+#: ../data/functions.xml.in.h:763
+msgid "r:isInteger"
+msgstr ""
+
+#: ../data/functions.xml.in.h:764
+msgid "Represents Number"
+msgstr "Representa número"
+
+#: ../data/functions.xml.in.h:765
+msgid "r:representsNumber"
+msgstr ""
+
+#: ../data/functions.xml.in.h:766
+msgid "Represents Real"
+msgstr "Representa real"
+
+#: ../data/functions.xml.in.h:767
+msgid "r:representsReal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:768
+msgid "Represents Rational"
+msgstr "Representa racional"
+
+#: ../data/functions.xml.in.h:769
+msgid "r:representsRational"
+msgstr ""
+
+#: ../data/functions.xml.in.h:770
+msgid "Represents Integer"
+msgstr "Representa entero"
+
+#: ../data/functions.xml.in.h:771
+msgid "r:representsInteger"
+msgstr ""
+
+#: ../data/functions.xml.in.h:772
+msgid "Interval"
+msgstr "Intervalo"
+
+#: ../data/functions.xml.in.h:773
+msgid "r:interval"
+msgstr ""
+
+#: ../data/functions.xml.in.h:774
+msgid "Lower endpoint"
+msgstr "Punto final inferior"
+
+#: ../data/functions.xml.in.h:775
+msgid "Upper endpoint"
+msgstr "Punto final superior"
+
+#: ../data/functions.xml.in.h:776
+msgid "Uncertainty"
+msgstr "Incertidumbre"
+
+#: ../data/functions.xml.in.h:777
+msgid "r:uncertainty"
+msgstr ""
+
+#: ../data/functions.xml.in.h:778
+msgid "Uncertainty is relative"
+msgstr "Incertidumbre es relativa"
+
+#: ../data/functions.xml.in.h:779
+msgid "Logical"
+msgstr "Lógica"
+
+#: ../data/functions.xml.in.h:780
+msgid "For...Do"
+msgstr "Bucle"
+
+#: ../data/functions.xml.in.h:781
+msgid "r:for"
+msgstr ""
+
+#: ../data/functions.xml.in.h:782
+msgid "Initial value of counter"
+msgstr "Valor inicial del contador"
+
+#: ../data/functions.xml.in.h:783
+msgid "Counter variable"
+msgstr "Variable de contador"
+
+#: ../data/functions.xml.in.h:784
+msgid "For condition"
+msgstr "Condición del bucle"
+
+#: ../data/functions.xml.in.h:785
+msgid "Counter update function"
+msgstr "Función de actualización del contador"
+
+#: ../data/functions.xml.in.h:786
+msgid "Do function"
+msgstr "Función del bucle"
+
+#: ../data/functions.xml.in.h:787
+msgid "If...Then...Else"
+msgstr "Condicional"
+
+#: ../data/functions.xml.in.h:788
+msgid "r:if"
+msgstr ""
+
+#: ../data/functions.xml.in.h:789
+msgid ""
+"Tests a condition and returns a value depending on the result. Vectors can "
+"be used for argument 1 and 2, instead of nested functions."
+msgstr ""
+"Prueba una condición y devuelve un valor dependiendo del resultado. "
+"Se pueden usar vectores para el argumento 1 y 2, en lugar de funciones "
+"anidadas."
+
+#: ../data/functions.xml.in.h:790
+msgid "Expression if condition is met"
+msgstr "Expresión si se cumple la condición"
+
+#: ../data/functions.xml.in.h:791
+msgid "Expression if condition is NOT met"
+msgstr "Expresión si NO se cumple la condición"
+
+#: ../data/functions.xml.in.h:792
+msgid "Assume false if not true"
+msgstr "Asumir falso si no es verdadero"
+
+#: ../data/functions.xml.in.h:793
+msgid "Bitwise Exclusive OR"
+msgstr "OR exclusivo bit a bit"
+
+#: ../data/functions.xml.in.h:794
+msgid "r:xor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:795
+msgid "Value 1"
+msgstr "Valor 1"
+
+#: ../data/functions.xml.in.h:796
+msgid "Value 2"
+msgstr "Valor 2"
+
+#: ../data/functions.xml.in.h:797
+msgid "Logical Exclusive OR"
+msgstr "OR exclusivo lógico"
+
+#: ../data/functions.xml.in.h:798
+msgid "r:lxor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:799
+msgid "Bitwise Shift"
+msgstr "Desplazamiento bit a bit"
+
+#: ../data/functions.xml.in.h:800
+msgid ""
+"Applies logical or arithmetic bitwise shift to an integer. The second "
+"argument specifies the number of steps that each binary bit is shifted to "
+"the left (use negative values for right shift)."
+msgstr ""
+"Aplica un desplazamiento lógico o de bit a bit a un entero. "
+"El segundo argumento especifica el número de pasos que cada bit es "
+"desplazado a la izquierda (use valores negativos para desplazamiento "
+"a la derecha)."
+
+#: ../data/functions.xml.in.h:801
+msgid "r:shift"
+msgstr ""
+
+#: ../data/functions.xml.in.h:802
+msgid "Steps"
+msgstr "Pasos"
+
+#: ../data/functions.xml.in.h:803
+msgid "Arithmetic shift using two's complement"
+msgstr "Desplazamiento aritmético usando complemento a dos"
+
+#: ../data/functions.xml.in.h:804
+msgid "Bitwise Complement (Not)"
+msgstr "Complemento bit a bit (NOT)"
+
+#: ../data/functions.xml.in.h:805
+msgid ""
+"Applies bitwise NOT to an integer of specified bit width and signedness (use "
+"1 for signed and 0 for unsigned). If bit width is zero, the smallest "
+"necessary number of bits (of 8, 16, 32, 64, 128, ...) will be used."
+msgstr ""
+"Aplica un NOT bit a bit a un entero de cantidad de bits especificada "
+"(el tercer argumento especifica si el número utiliza signo). "
+"Si cantidad de bits es cero, el número mínimo de bits necesarios "
+"(de 8, 16, 32, 64, 128, ...) serán usados."
+
+#: ../data/functions.xml.in.h:806
+msgid "r:bitcmp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:807
+msgid "Bit Width"
+msgstr "Cantidad de bits"
+
+#: ../data/functions.xml.in.h:808
+msgid "Signed Integer"
+msgstr "Entero con signo"
+
+#: ../data/functions.xml.in.h:809
+msgid "Bit Rotation"
+msgstr "Rotación de bits"
+
+#: ../data/functions.xml.in.h:810
+msgid ""
+"Applies circular bitwise shift to an integer of specified bit width and "
+"signedness (use 1 for signed and 0 for unsigned). The second argument "
+"specifies the number of steps that each binary bit is shifted to the left "
+"(use negative values for right shift). If bit width is zero, the smallest "
+"necessary number of bits (of 8, 16, 32, 64, 128, ...) will be used."
+msgstr ""
+"Aplica un desplazamiento bit a bit circular a un entero con una cantidad "
+"de bits especificada (el cuarto argumento especifica si el número utiliza "
+"signo). El segundo argumento especifica el número de pasos que cada bit "
+"es desplazado a la izquierda (use valores negativos para desplazamiento "
+"a la derecha). Si cantidad de bits es cero, el número mínimo de bits "
+"necesarios (de 8, 16, 32, 64, 128, ...) serán usados."
+
+#: ../data/functions.xml.in.h:811
+msgid "r:bitrot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:812
+msgid "Algebra"
+msgstr "Álgebra"
+
+#: ../data/functions.xml.in.h:813
+msgid "Summation"
+msgstr "Sumatorio"
+
+#: ../data/functions.xml.in.h:814
+msgid "au:&#x3A3;,au:&#x2211;,r:sum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:815
+msgid ""
+"Corresponds to the summation symbol. Adds terms for each x ranging from the "
+"lower to the upper limit."
+msgstr ""
+"Corresponde al símbolo de sumatorio. Suma términos para cada x desde el "
+"límite inferior hasta el límite superior."
+
+#: ../data/functions.xml.in.h:816
+msgid "Term expression"
+msgstr "Expresión de término"
+
+#: ../data/functions.xml.in.h:817
+msgid "Lower limit (i)"
+msgstr "Límite inferior (i)"
+
+#: ../data/functions.xml.in.h:818
+msgid "Upper limit (n)"
+msgstr "Límite superior (n)"
+
+#: ../data/functions.xml.in.h:819
+msgid "Product of a sequence"
+msgstr "Productorio"
+
+#: ../data/functions.xml.in.h:820
+msgid "au:&#x3A0;,r:product"
+msgstr ""
+
+#: ../data/functions.xml.in.h:821
+msgid ""
+"Corresponds to the product symbol. Multiplies factors for each x ranging "
+"from the lower to the upper limit."
+msgstr ""
+"Corresponde al símbolo de productorio. Multiplica factores para cada x "
+"desde el límite inferior hasta el límite superior."
+
+#: ../data/functions.xml.in.h:822
+msgid "Factor expression"
+msgstr "Expresión de factor"
+
+#: ../data/functions.xml.in.h:823
+msgid "Solve for multiple variables"
+msgstr "Resolver para múltiples variables"
+
+#: ../data/functions.xml.in.h:824
+msgid "r:multisolve"
+msgstr ""
+
+#: ../data/functions.xml.in.h:825
+msgid "Equation vector"
+msgstr "Vector de ecuaciones"
+
+#: ../data/functions.xml.in.h:826
+msgid "Variable vector"
+msgstr "Vector de variables"
+
+#: ../data/functions.xml.in.h:827
+msgid "Solve equation"
+msgstr "Resolver ecuación"
+
+#: ../data/functions.xml.in.h:828
+msgid "r:solve"
+msgstr ""
+
+#: ../data/functions.xml.in.h:829
+msgid "Equation"
+msgstr "Ecuación"
+
+#: ../data/functions.xml.in.h:830
+msgid "With respect to"
+msgstr "Con respecto a"
+
+#: ../data/functions.xml.in.h:831
+msgid "Solve differential equation"
+msgstr "Resolver ecuación diferencial"
+
+#: ../data/functions.xml.in.h:832
+msgid "r:dsolve"
+msgstr ""
+
+#: ../data/functions.xml.in.h:833
+msgid "Initial condition: function value (y)"
+msgstr "Condición inicial: valor de función (y)"
+
+#: ../data/functions.xml.in.h:834
+msgid "Initial condition: argument value (x)"
+msgstr "Condición inicial: valor de argumento (x)"
+
+#: ../data/functions.xml.in.h:835
+msgid ""
+"Solves a differential equation and returns the value of y(x). The derivative "
+"in the equation should be in the format diff(y, x). Only first-order "
+"differential equations are currently supported."
+msgstr ""
+"Resuelve una ecuación diferencial y devuelve el valor de y(x). La "
+"derivada en la ecuación debe estar en el formato diff(y, x). Solo "
+"ecuaciones diferenciales de primer orden están soportadas actualmente."
+
+#: ../data/functions.xml.in.h:836
+msgid "Solve for two variables"
+msgstr "Resolver para dos variables"
+
+#: ../data/functions.xml.in.h:837
+msgid "r:solve2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:838
+msgid ""
+"Solves two equations with two unknown variables. Returns the value of the "
+"first variable."
+msgstr ""
+"Resuelve dos ecuaciones con dos incógnitas. "
+"Devuelve el valor de la primer variable."
+
+#: ../data/functions.xml.in.h:839
+msgid "Equation 1"
+msgstr "Ecuación 1"
+
+#: ../data/functions.xml.in.h:840
+msgid "Equation 2"
+msgstr "Ecuación 2"
+
+#: ../data/functions.xml.in.h:841
+msgid "Variable 1"
+msgstr "Variable 1"
+
+#: ../data/functions.xml.in.h:842
+msgid "Variable 2"
+msgstr "Variable 2"
+
+#: ../data/functions.xml.in.h:843
+msgid "Find Linear Function"
+msgstr "Buscar función lineal"
+
+#: ../data/functions.xml.in.h:844
+msgid "r:linearfunction"
+msgstr ""
+
+#: ../data/functions.xml.in.h:845
+msgid ""
+"Finds the linear function for the straight line between two distinct points."
+msgstr ""
+"Halla la función lineal para la línea recta entre dos puntos distintos."
+
+#: ../data/functions.xml.in.h:846
+msgid "x1"
+msgstr "x1"
+
+#: ../data/functions.xml.in.h:847
+msgid "y1"
+msgstr "y1"
+
+#: ../data/functions.xml.in.h:848
+msgid "x2"
+msgstr "x2"
+
+#: ../data/functions.xml.in.h:849
+msgid "y2"
+msgstr "y2"
+
+#: ../data/functions.xml.in.h:850
+msgid "Calculus"
+msgstr "Cálculo"
+
+#: ../data/functions.xml.in.h:851
+msgid "Differentiate"
+msgstr "Derivar"
+
+#: ../data/functions.xml.in.h:852
+msgid "r:diff,derivative"
+msgstr ""
+
+#: ../data/functions.xml.in.h:853
+msgid "Variable value"
+msgstr "Valor de variable"
+
+#: ../data/functions.xml.in.h:854
+msgid "Integrate"
+msgstr "Integrar"
+
+#: ../data/functions.xml.in.h:855
+msgid "r:integrate,integral,au:&#x222B;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:856
+msgid "Variable of integration"
+msgstr "Variable de integración"
+
+#: ../data/functions.xml.in.h:857
+msgid "Force numerical integration"
+msgstr "Forzar integración numérica"
+
+#: ../data/functions.xml.in.h:858
+msgid "Romberg Integration"
+msgstr "Integración de Romberg"
+
+#: ../data/functions.xml.in.h:859
+msgid "r:romberg"
+msgstr ""
+
+#: ../data/functions.xml.in.h:860
+msgid "Min iterations"
+msgstr "Iteraciones mínimas"
+
+#: ../data/functions.xml.in.h:861
+msgid "Max iterations"
+msgstr "Iteraciones máximas"
+
+#: ../data/functions.xml.in.h:862
+msgid "Monte Carlo Integration"
+msgstr "Integración de Monte Carlo"
+
+#: ../data/functions.xml.in.h:863
+msgid "r:montecarlo"
+msgstr ""
+
+#: ../data/functions.xml.in.h:864
+msgid "Number of samples"
+msgstr "Número de muestras"
+
+#: ../data/functions.xml.in.h:865
+msgid "Limit"
+msgstr "Límite"
+
+#: ../data/functions.xml.in.h:866
+msgid ""
+"Returns the two-sided limit of the function if direction is zero, limit from "
+"left (below) if direction is -1, or limit from right (above) if direction is "
+"+1."
+msgstr ""
+"Devuelve el límite de la función si la dirección es cero, "
+"el límite por la izquierda si dirección es -1, "
+"o el límite por la derecha si dirección es +1."
+
+#: ../data/functions.xml.in.h:867
+msgid "r:limit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:868
+msgid "Value to approach"
+msgstr "Valor al que acercarse"
+
+#: ../data/functions.xml.in.h:869
+msgid "Direction"
+msgstr "Dirección"
+
+#: ../data/functions.xml.in.h:870
+msgid "Extreme Values"
+msgstr "Extremos de una función"
+
+#: ../data/functions.xml.in.h:871
+msgid "r:extremum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:872
+msgid "Named Integrals"
+msgstr ""
+
+#: ../data/functions.xml.in.h:873
+msgid "Logarithmic Integral"
+msgstr "Integrales nombradas"
+
+#: ../data/functions.xml.in.h:874
+msgid "rc:li,logint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:875
+msgid "The integral of 1/ln(x)."
+msgstr "La integral de 1/ln(x)."
+
+#: ../data/functions.xml.in.h:876
+msgid "Exponential Integral"
+msgstr "Integral exponencial"
+
+#: ../data/functions.xml.in.h:877
+msgid "rc:Ei,expint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:878
+msgid "The integral of e^x/x."
+msgstr "La integral de e^x/x."
+
+#: ../data/functions.xml.in.h:879
+msgid "Sine Integral"
+msgstr "Integral seno"
+
+#: ../data/functions.xml.in.h:880
+msgid "rc:Si,sinint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:881
+msgid "The integral of sin(x)/x."
+msgstr "La integral de sin(x)/x"
+
+#: ../data/functions.xml.in.h:882
+msgid "Cosine Integral"
+msgstr "Integral coseno"
+
+#: ../data/functions.xml.in.h:883
+msgid "rc:Ci,cosint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:884
+msgid "The integral of cos(x)/x."
+msgstr "La integral de cos(x)/x"
+
+#: ../data/functions.xml.in.h:885
+msgid "Hyperbolic Sine Integral"
+msgstr "Integral seno hiperbólico"
+
+#: ../data/functions.xml.in.h:886
+msgid "rc:Shi,sinhint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:887
+msgid "The integral of sinh(x)/x."
+msgstr "La integral de sinh(x)/x."
+
+#: ../data/functions.xml.in.h:888
+msgid "Hyperbolic Cosine Integral"
+msgstr "Integral coseno hiperbólico"
+
+#: ../data/functions.xml.in.h:889
+msgid "rc:Chi,coshint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:890
+msgid "The integral of cosh(x)/x."
+msgstr "La integral de cosh(x)/x."
+
+#: ../data/functions.xml.in.h:891
+msgid "Fresnel Integral S"
+msgstr "Integral Fresnel S"
+
+#: ../data/functions.xml.in.h:892
+msgid "r:fresnels"
+msgstr ""
+
+#: ../data/functions.xml.in.h:893
+msgid "The integral of sin(pi*x^2/2)."
+msgstr "La integral de sin(pi*x^2/2)."
+
+#: ../data/functions.xml.in.h:894
+msgid "Fresnel Integral C"
+msgstr "Integral Fresnel C"
+
+#: ../data/functions.xml.in.h:895
+msgid "r:fresnelc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:896
+msgid "The integral of cos(pi*x^2/2)."
+msgstr "La integral de cos(pi*x^2/2)."
+
+#: ../data/functions.xml.in.h:897
+msgid "Upper Incomplete Gamma Function"
+msgstr "Función gamma incompleta superior"
+
+#: ../data/functions.xml.in.h:898
+msgid "r:igamma"
+msgstr ""
+
+#: ../data/functions.xml.in.h:899
+msgid "Lower Incomplete Gamma Function"
+msgstr "Función gamma incompleta inferior"
+
+#: ../data/functions.xml.in.h:900
+msgid "r:gammainc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:901
+msgid "Geometry"
+msgstr "Geometría"
+
+#: ../data/functions.xml.in.h:902
+msgid "Triangle"
+msgstr "Triángulo"
+
+#: ../data/functions.xml.in.h:903
+msgid "Hypotenuse"
+msgstr "Hipotenusa"
+
+#: ../data/functions.xml.in.h:904
+msgid "r:hypot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:905
+msgid "Side A"
+msgstr "Lado A"
+
+#: ../data/functions.xml.in.h:906
+msgid "Side B"
+msgstr "Lado B"
+
+#: ../data/functions.xml.in.h:907
+msgid "Triangle Area"
+msgstr "Área de un triángulo"
+
+#: ../data/functions.xml.in.h:908
+msgid "r:triangle"
+msgstr ""
+
+#: ../data/functions.xml.in.h:909
+msgid "Height"
+msgstr "Altura"
+
+#: ../data/functions.xml.in.h:910
+msgid "Triangle Perimeter"
+msgstr "Perímetro de un triángulo"
+
+#: ../data/functions.xml.in.h:911
+msgid "r:triangle_perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:912
+msgid "Side C"
+msgstr "Lado C"
+
+#: ../data/functions.xml.in.h:913
+msgid "Circle"
+msgstr "Círculo"
+
+#: ../data/functions.xml.in.h:914
+msgid "Circle Area"
+msgstr "Área de un círculo"
+
+#: ../data/functions.xml.in.h:915
+msgid "r:circle"
+msgstr ""
+
+#: ../data/functions.xml.in.h:916
+msgid "Calculates the area of a circle using the radius"
+msgstr "Calcula el área de un círculo usando el radio"
+
+#: ../data/functions.xml.in.h:917
+msgid "Radius"
+msgstr "Radio"
+
+#: ../data/functions.xml.in.h:918
+msgid "Circle Circumference"
+msgstr "Circunferencia de un círculo"
+
+#: ../data/functions.xml.in.h:919
+msgid "r:circumference"
+msgstr ""
+
+#: ../data/functions.xml.in.h:920
+msgid "Cylinder"
+msgstr "Cilindro"
+
+#: ../data/functions.xml.in.h:921
+msgid "Cylinder Volume"
+msgstr "Volumen de un cilindro"
+
+#: ../data/functions.xml.in.h:922
+msgid "r:cylinder"
+msgstr ""
+
+#: ../data/functions.xml.in.h:923
+msgid "Surface Area of Cylinder"
+msgstr "Área de un cilindro"
+
+#: ../data/functions.xml.in.h:924
+msgid "r:cylinder_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:925
+msgid "Cone"
+msgstr "Cono"
+
+#: ../data/functions.xml.in.h:926
+msgid "Cone Volume"
+msgstr "Volumen de un cono"
+
+#: ../data/functions.xml.in.h:927
+msgid "r:cone"
+msgstr ""
+
+#: ../data/functions.xml.in.h:928
+msgid "Surface Area of Cone"
+msgstr "Área de un cono"
+
+#: ../data/functions.xml.in.h:929
+msgid "r:cone_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:930
+msgid "Sphere"
+msgstr "Esfera"
+
+#: ../data/functions.xml.in.h:931
+msgid "Sphere Volume"
+msgstr "Volumen de una esfera"
+
+#: ../data/functions.xml.in.h:932
+msgid "r:sphere"
+msgstr ""
+
+#: ../data/functions.xml.in.h:933
+msgid "Surface Area of Sphere"
+msgstr "Área de la esfera"
+
+#: ../data/functions.xml.in.h:934
+msgid "r:sphere_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:935
+msgid "Square Area"
+msgstr "Área de un cuadrado"
+
+#: ../data/functions.xml.in.h:936
+msgid "r:square"
+msgstr ""
+
+#: ../data/functions.xml.in.h:937
+msgid "Length of side"
+msgstr "Longitud del lado"
+
+#: ../data/functions.xml.in.h:938
+msgid "Square Perimeter"
+msgstr "Perímetro de un cuadrado"
+
+#: ../data/functions.xml.in.h:939
+msgid "r:square_perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:940
+msgid "Cube"
+msgstr "Cubo"
+
+#: ../data/functions.xml.in.h:941
+msgid "Cube Volume"
+msgstr "Volumen de un cubo"
+
+#: ../data/functions.xml.in.h:942
+msgid "r:cube"
+msgstr ""
+
+#: ../data/functions.xml.in.h:943
+msgid "Surface Area of Cube"
+msgstr "Área de un cubo"
+
+#: ../data/functions.xml.in.h:944
+msgid "r:cube_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:945
+msgid "Rectangle"
+msgstr "Rectángulo"
+
+#: ../data/functions.xml.in.h:946
+msgid "Rectangle Area"
+msgstr "Área de un rectángulo"
+
+#: ../data/functions.xml.in.h:947
+msgid "r:rect"
+msgstr ""
+
+#: ../data/functions.xml.in.h:948
+msgid "Width"
+msgstr "Ancho"
+
+#: ../data/functions.xml.in.h:949
+msgid "Rectangle Perimeter"
+msgstr "Perímetro de un rectángulo"
+
+#: ../data/functions.xml.in.h:950
+msgid "r:rect_perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:951
+msgid "Prism"
+msgstr "Prisma"
+
+#: ../data/functions.xml.in.h:952
+msgid "Volume of Rectangular Prism"
+msgstr "Volumen de un prisma rectangular"
+
+#: ../data/functions.xml.in.h:953
+msgid "r:rectprism"
+msgstr ""
+
+#: ../data/functions.xml.in.h:954
+msgid "Calculates the volume of a prism with rectangular base."
+msgstr "Calcula el volumen de un prisma de base rectangular."
+
+#: ../data/functions.xml.in.h:955
+msgid "Surface Area of Rectangular Prism"
+msgstr "Área de un prisma rectangular"
+
+#: ../data/functions.xml.in.h:956
+msgid "r:rectprism_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:957
+msgid "Calculates the surface area of a prism with rectangular base."
+msgstr "Calcula el área del prisma de base rectangular."
+
+#: ../data/functions.xml.in.h:958
+msgid "Volume of Triangular Prism"
+msgstr "Volumen de un prisma triangular"
+
+#: ../data/functions.xml.in.h:959
+msgid "r:triangleprism"
+msgstr ""
+
+#: ../data/functions.xml.in.h:960
+msgid "Calculates the volume of a prism with triangular base."
+msgstr "Calcula el volumen de un prisma de base triangular."
+
+#: ../data/functions.xml.in.h:961
+msgid "Pyramid"
+msgstr "Pirámide"
+
+#: ../data/functions.xml.in.h:962
+msgid "Pyramid Volume"
+msgstr "Volumen de una pirámide"
+
+#: ../data/functions.xml.in.h:963
+msgid "r:pyramid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:964
+msgid ""
+"Calculates the volume of a 3-dimensional shape standing on a rectangular "
+"base and terminating in a point at the top."
+msgstr ""
+"Calcula el volumen de una figura tridimensional con base rectangular y "
+"que termina en un punto en la cima."
+
+#: ../data/functions.xml.in.h:965
+msgid "Length of base"
+msgstr "Largo de la base"
+
+#: ../data/functions.xml.in.h:966
+msgid "Width of base"
+msgstr "Ancho de la base"
+
+#: ../data/functions.xml.in.h:967
+msgid "Volume of Regular Tetrahedron"
+msgstr "Volumen de un tetraedro regular"
+
+#: ../data/functions.xml.in.h:968
+msgid "r:tetrahedron"
+msgstr ""
+
+#: ../data/functions.xml.in.h:969
+msgid "Surface Area of Regular Tetrahedron"
+msgstr "Área de un tetraedro regular"
+
+#: ../data/functions.xml.in.h:970
+msgid "r:tetrahedron_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:971
+msgid "Height of Regular Tetrahedron"
+msgstr "Altura de un tetraedro regular"
+
+#: ../data/functions.xml.in.h:972
+msgid "r:tetrahedron_height"
+msgstr ""
+
+#: ../data/functions.xml.in.h:973
+msgid "Volume of Square Pyramid"
+msgstr "Volumen de una pirámide cuadrada"
+
+#: ../data/functions.xml.in.h:974
+msgid "r:sqpyramid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:975
+msgid "Surface Area of Square Pyramid"
+msgstr "Área de una pirámide cuadrada"
+
+#: ../data/functions.xml.in.h:976
+msgid "r:sqpyramid_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:977
+msgid "Height of Square Pyramid"
+msgstr "Altura de una pirámide cuadrada"
+
+#: ../data/functions.xml.in.h:978
+msgid "r:sqpyramid_height"
+msgstr ""
+
+#: ../data/functions.xml.in.h:979
+msgid "Parallelogram"
+msgstr "Paralelogramo"
+
+#: ../data/functions.xml.in.h:980
+msgid "Parallelogram Area"
+msgstr "Área de un paralelogramo"
+
+#: ../data/functions.xml.in.h:981
+msgid "r:parallelogram"
+msgstr ""
+
+#: ../data/functions.xml.in.h:982
+msgid ""
+"Calculates the area of a four-sided figure whose opposite sides are both "
+"parallel and equal in length."
+msgstr ""
+"Calcula el área de una figura de cuatro lados cuyos lados opuestos "
+"son paralelos y de igual longitud."
+
+#: ../data/functions.xml.in.h:983
+msgid "Parallelogram Perimeter"
+msgstr "Perímetro de un paralelogramo"
+
+#: ../data/functions.xml.in.h:984
+msgid "r:parallelogram_perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:985
+msgid ""
+"Calculates the perimeter of a four-sided figure whose opposite sides are "
+"both parallel and equal in length."
+msgstr ""
+"Calcula el perímetro de una figura de cuatro lados cuyos lados opuestos "
+"son paralelos y de igual longitud."
+
+#: ../data/functions.xml.in.h:986
+msgid "Trapezoid"
+msgstr "Trapecio"
+
+#: ../data/functions.xml.in.h:987
+msgid "Trapezoid Area"
+msgstr "Área de un trapecio"
+
+#: ../data/functions.xml.in.h:988
+msgid "r:trapezoid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:989
+msgid "Calculates the area of a four-sided figure with two parallel sides."
+msgstr "Calcula el área de una figura de cuatro lados con "
+"dos lados paralelos."
+
+#: ../data/functions.xml.in.h:990
+msgid "Economics"
+msgstr "Economía"
+
+#: ../data/functions.xml.in.h:991
+msgid "Microeconomics"
+msgstr "Microeconomía"
+
+#: ../data/functions.xml.in.h:992
+msgid "Elasticity"
+msgstr "Elasticidad"
+
+#: ../data/functions.xml.in.h:993
+msgid "r:elasticity"
+msgstr ""
+
+#: ../data/functions.xml.in.h:994
+msgid ""
+"Calculates the demand elasticity. Also works for supply elasticity, income "
+"elasticity, cross-price elasticity, etc. Just replace demand with supply, or "
+"price with income...&#10;&#10;eg. elasticity(100-x^2, 3) calculates the "
+"demand elasticity when the price is 3 for the function \"Q = 100 - x^2\" "
+"where x is the default price variable."
+msgstr ""
+"Calcula la elasticidad de la demanda. "
+"También funciona para la elasticidad de la oferta, "
+"elasticidad de ingresos, elasticidad de precio cruzado, etc. "
+"Solo reemplace demanda con oferta o precio con ingresos...&#10;&#10;"
+"Ej. elasticity(100-x^2, 3) calcula la elasticidad de la demanda cuando "
+"el precio es 3 para la función \"Q = 100 - x^2\" donde x es la variable "
+"de precio predeterminada."
+
+#: ../data/functions.xml.in.h:995
+msgid "Demand function"
+msgstr "Función de demanda"
+
+#: ../data/functions.xml.in.h:996
+msgid "Price"
+msgstr "Precio"
+
+#: ../data/functions.xml.in.h:997
+msgid "Price variable"
+msgstr "Variable de precio"
+
+#: ../data/functions.xml.in.h:998
+msgid "Sum-of-Years Digits Depreciation"
+msgstr "Depreciación de la suma de los dígitos de los años"
+
+#: ../data/functions.xml.in.h:999
+msgid "r:syd"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1000
+msgid ""
+"Calculates the sum-of-years digits depreciation for an asset based on its "
+"cost, salvage value, anticipated life, and a particular period. This method "
+"accelerates the rate of the depreciation, so that more depreciation expense "
+"occurs in earlier periods than in later ones. The depreciable cost is the "
+"actual cost minus the salvage value. The useful life is the number of "
+"periods (typically years) over which the asset is depreciated."
+msgstr ""
+"Calcula la depreciación de la suma de los dígitos de los años para un "
+"activo basado en su costo, valor de rescate, vida útil, y un período "
+"particular. Este método acelera la tasa de depreciación, para que ocurra "
+"más gasto de depreciación en períodos anteriores que en períodos "
+"posteriores. El costo depreciable es el costo real menos el costo de "
+"rescate. La vida útil es el número de períodos (típicamente años) en los "
+"que el activo es depreciado."
+
+#: ../data/functions.xml.in.h:1001
+msgid "Cost"
+msgstr "Costo"
+
+#: ../data/functions.xml.in.h:1002
+msgid "Salvage value"
+msgstr "Valor de rescate"
+
+#: ../data/functions.xml.in.h:1003
+msgid "Life"
+msgstr "Vida"
+
+#: ../data/functions.xml.in.h:1004
+msgid "Period"
+msgstr "Período"
+
+#: ../data/functions.xml.in.h:1005
+msgid "Straight Line Depreciation"
+msgstr "Depreciación fija"
+
+#: ../data/functions.xml.in.h:1006
+msgid "r:sln"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1007
+msgid ""
+"Determines the straight line depreciation of an asset for a single period."
+"&#10;&#10;Cost is the amount you paid for the asset. Salvage is the value of "
+"the asset at the end of the period. Life is the number of periods over which "
+"the asset is depreciated. SLN divides the cost evenly over the life of an "
+"asset."
+msgstr ""
+"Determina la depreciación fija de un activa para un solo período.&#10;&#10;"
+"Costo el la cantidad que pagó por el activo. Valor de rescate es el valor "
+"del activo al final del período. Vida es el número de períodos en los que "
+"el activo es depreciado. La depreciación fija divide el costo "
+"uniformemente entre la vida de un activo."
+
+#: ../data/functions.xml.in.h:1008
+msgid "Present Value"
+msgstr "Valor actual"
+
+#: ../data/functions.xml.in.h:1009
+msgid "r:pv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1010
+msgid ""
+"Returns the present value of an investment.&#10;&#10;If type = 1 then the "
+"payment is made at the beginning of the period, If type = 0 (or omitted) it "
+"is made at the end of each period."
+msgstr ""
+"Devuelve el valor actual de una inversión.&#10;&#10;"
+"Si tipo es verdadero, el pago es hecho al inicio del período, "
+"si tipo es falso (o omitido), es hecho al final de cada período."
+
+#: ../data/functions.xml.in.h:1011
+msgid "Interest rate"
+msgstr "Tasa de interés"
+
+#: ../data/functions.xml.in.h:1012
+msgid "Number of periods"
+msgstr "Número de períodos"
+
+#: ../data/functions.xml.in.h:1013
+msgid "Payment made each period"
+msgstr "Pago hecho cada período"
+
+#: ../data/functions.xml.in.h:1014
+msgid "Future value"
+msgstr "Valor futuro"
+
+#: ../data/functions.xml.in.h:1015
+msgid "Type"
+msgstr "Tipo"
+
+#: ../data/functions.xml.in.h:1016
+msgid "Nominal Interest Rate"
+msgstr "Tasa de interés nominal"
+
+#: ../data/functions.xml.in.h:1017
+msgid "r:nominal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1018
+msgid ""
+"Calculates the nominal interest rate from a given effective interest rate "
+"compounded at given intervals."
+msgstr ""
+"Calcula la tasa de interés nominal a partir de una tasa de interés "
+"efectiva dada compuesta en intervalos dados."
+
+#: ../data/functions.xml.in.h:1019
+msgid "Effective interest rate"
+msgstr "Tasa de interés efectiva"
+
+#: ../data/functions.xml.in.h:1020
+msgid "Periods"
+msgstr "Períodos"
+
+#: ../data/functions.xml.in.h:1021
+msgid "Zero Coupon"
+msgstr "Bono cupón cero"
+
+#: ../data/functions.xml.in.h:1022
+msgid "r:zero_coupon"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1023
+msgid "Calculates the value of a zero-coupon (pure discount) bond."
+msgstr "Calcula el valor de un bono cupón cero (descuento puro)."
+
+#: ../data/functions.xml.in.h:1024
+msgid "Face value"
+msgstr "Valor nominal"
+
+#: ../data/functions.xml.in.h:1025
+msgid "Treasury Bill Yield"
+msgstr "Rendimiento de billete de tesorería"
+
+#: ../data/functions.xml.in.h:1026
+msgid "r:tbillyield"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1027
+msgid "Returns the yield for a treasury bill."
+msgstr "Devuelve el rendimiento de un billete de tesorería"
+
+#: ../data/functions.xml.in.h:1028
+msgid "Settlement date"
+msgstr "Fecha de liquidación"
+
+#: ../data/functions.xml.in.h:1029
+msgid "Maturity date"
+msgstr "Fecha de vencimiento"
+
+#: ../data/functions.xml.in.h:1030
+msgid "Price per $100 face value"
+msgstr "Precio por $100 de valor nominal"
+
+#: ../data/functions.xml.in.h:1031
+msgid "Treasury Bill Price"
+msgstr "Precio de billete de tesorería"
+
+#: ../data/functions.xml.in.h:1032
+msgid "r:tbillprice"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1033
+msgid "Returns the price per $100 value for a treasury bill."
+msgstr "Devuelve el precio por $100 de valor nominal para un billete "
+"de tesorería."
+
+#: ../data/functions.xml.in.h:1034
+msgid "Discount rate"
+msgstr "Tasa de descuento"
+
+#: ../data/functions.xml.in.h:1035
+msgid "Treasury Bill Equivalent"
+msgstr "Equivalente de billete de tesorería"
+
+#: ../data/functions.xml.in.h:1036
+msgid "r:tbilleq"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1037
+msgid "Returns the bond equivalent for a treasury bill."
+msgstr "Devuelve el equivalente de bono para un billete de tesorería."
+
+#: ../data/functions.xml.in.h:1038
+msgid "Interest paid on a given period of an investment (ISPMT)"
+msgstr "Interés pagado en un período de inversión dado"
+
+#: ../data/functions.xml.in.h:1039
+msgid "r:ispmt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1040
+msgid "Calculates the interest paid on a given period of an investment."
+msgstr "Calcula el interés pagado en un período de inversión dado."
+
+#: ../data/functions.xml.in.h:1041
+msgid "Periodic interest rate"
+msgstr "Tasa de interés periódica"
+
+#: ../data/functions.xml.in.h:1042
+msgid "Amortizement period"
+msgstr "Periodo amortizado"
+
+#: ../data/functions.xml.in.h:1043
+msgid "Present value"
+msgstr "Valor actual"
+
+#: ../data/functions.xml.in.h:1044
+msgid "Payment for a loan"
+msgstr "Pago de un préstamo"
+
+#: ../data/functions.xml.in.h:1045
+msgid "r:pmt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1046
+msgid ""
+"Returns the amount of payment (negative) each period for a loan based on a "
+"constant interest rate and constant payments (each payment is equal amount)."
+"&#10;&#10;If type = 1 then the payment is made at the beginning of the "
+"period, If type = 0 (or omitted) it is made at the end of each period.&#10;"
+"&#10;Note that the interest rate here refers to the rate for each period and "
+"if you calculate with an annual rate, each period will be interpreted as a "
+"whole year. To get monthly payments divide the annual interest rate by 12 "
+"and enter the total number of months (12 times number of year) in the "
+"periods field."
+msgstr ""
+"Devuelve el monto de un pago (negativo) por cada período de un préstamo "
+"basado en una tasa de interés constante y pagos constantes "
+"(cada pago es de igual monto).&#10;&#10;"
+"Si tipo es verdadero, el pago es hecho al inicio del período, "
+"si tipo es falso (o omitido), es hecho al final de cada período. "
+"Tenga en cuenta que la tasa de interés aquí refiere a la tasa por cada "
+"período y si calcula con una tasa anual, cada período será interpretado "
+"como todo un año. Para obtener pagos mensuales divida el interés anual "
+"entre 12 e ingrese el número total de meses (12 por el número de años) "
+"en el campo de períodos."
+
+#: ../data/functions.xml.in.h:1047
+msgid "Rate"
+msgstr "Tasa"
+
+#: ../data/functions.xml.in.h:1048
+msgid "Periods of an investment"
+msgstr "Períodos de una inversión"
+
+#: ../data/functions.xml.in.h:1049
+msgid "r:nper"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1050
+msgid ""
+"Calculates number of periods of an investment based on periodic constant "
+"payments and a constant interest rate.&#10;&#10;Type defines the due date. 1 "
+"for payment at the beginning of a period and 0 (default) for payment at the "
+"end of a period."
+msgstr ""
+"Calcula el número de períodos de una inversión basado en pagos constantes "
+"periódicos y en una tasa de interés constante.&#10;&#10;"
+"Tipo define la fecha de vencimiento: 1 para pago al comienzo de un período "
+"y cero (predeterminado) para pago al final de un período."
+
+#: ../data/functions.xml.in.h:1051
+msgid "Periods for investment to attain desired value"
+msgstr "Períodos de inversión para alcanzar el valor deseado."
+
+#: ../data/functions.xml.in.h:1052
+msgid "r:g_duration"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1053
+msgid ""
+"Returns the number of periods needed for an investment to attain a desired "
+"value."
+msgstr ""
+"Devuelve el número de períodos necesarios para que una inversión alcance "
+"un valor deseado."
+
+#: ../data/functions.xml.in.h:1054
+msgid "Payment of an annuity going towards principal (PPMT)"
+msgstr "Pago de una anualidad destinada al capital"
+
+#: ../data/functions.xml.in.h:1055
+msgid "r:ppmt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1056
+msgid ""
+"Calculates the amount of a payment of an annuity going towards principal."
+"&#10;&#10;Type defines the due date. 1 for payment at the beginning of a "
+"period and 0 (default) for payment at the end of a period."
+msgstr ""
+"Calcula el monto de un pago de una anualidad destinada al capital."
+"&#10;&#10;Tipo define la fecha de vencimiento: 1 para pago al comienzo de "
+"un período y cero (predeterminado) para pago al final de un período."
+
+#: ../data/functions.xml.in.h:1057
+msgid "Desired future value"
+msgstr "Valor futuro deseado"
+
+#: ../data/functions.xml.in.h:1058
+msgid "Effective Interest Rate"
+msgstr "Tasa de interés efectiva"
+
+#: ../data/functions.xml.in.h:1059
+msgid "r:effect"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1060
+msgid "Calculates the effective interest for a given nominal rate."
+msgstr "Calcula el interés efectivo para una tasa nominal dada."
+
+#: ../data/functions.xml.in.h:1061
+msgid "Nominal interest rate"
+msgstr "Tasa de interés nominal"
+
+#: ../data/functions.xml.in.h:1062
+msgid "Future Value"
+msgstr "Valor futuro"
+
+#: ../data/functions.xml.in.h:1063
+msgid "r:fv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1064
+msgid ""
+"Computes the future value of an investment. This is based on periodic, "
+"constant payments and a constant interest rate.&#10;&#10;If type = 1 then "
+"the payment is made at the beginning of the period, If type = 0 (or omitted) "
+"it is made at the end of each period."
+msgstr ""
+"Calcula el valor futuro de una inversión. Esto se basa en pagos constantes "
+"periódicos y en una tasa de interés constante.&#10;&#10;"
+"Tipo define la fecha de vencimiento: 1 para pago al comienzo de un período "
+"y cero (predeterminado) para pago al final de un período."
+
+#: ../data/functions.xml.in.h:1065
+msgid "Return on continuously compounded interest"
+msgstr "Retorno en interés compuesto continuo"
+
+#: ../data/functions.xml.in.h:1066
+msgid "r:continuous"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1067
+msgid ""
+"Calculates the return on continuously compounded interest, given the "
+"principal, nominal rate and time in years."
+msgstr ""
+"Calcula el retorno en interés compuesto continuo, dados el principal, "
+"la tasa de interés nominal, y el tiempo en años."
+
+#: ../data/functions.xml.in.h:1068
+msgid "Principal"
+msgstr "Principal"
+
+#: ../data/functions.xml.in.h:1069
+msgid "Compound"
+msgstr "Compuesto"
+
+#: ../data/functions.xml.in.h:1070
+msgid "r:compound"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1071
+msgid ""
+"Returns the value of an investment, given the principal, nominal interest "
+"rate, compounding frequency and time."
+msgstr ""
+"Devuelve el valor de una inversión, dados el principal, la tasa de interés "
+"nominal, frecuencia de composición y tiempo."
+
+#: ../data/functions.xml.in.h:1072
+msgid "Periods per year"
+msgstr "Períodos por año"
+
+#: ../data/functions.xml.in.h:1073
+msgid "Payment of an annuity going towards interest (IPMT)"
+msgstr "Pago de una anualidad destinada a intereses"
+
+#: ../data/functions.xml.in.h:1074
+msgid "r:ipmt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1075
+msgid ""
+"Calculates the amount of a payment of an annuity going towards interest.&#10;"
+"&#10;Type defines the due date. 1 for payment at the beginning of a period "
+"and 0 (default) for payment at the end of a period."
+msgstr ""
+"Calcula el monto de un pago de una anualidad destinada a intereses."
+"&#10;&#10;Tipo define la fecha de vencimiento: 1 para pago al comienzo de "
+"un período y cero (predeterminado) para pago al final de un período."
+
+#: ../data/functions.xml.in.h:1076
+msgid "Interest rate for a fully invested security"
+msgstr "Tasa de interés para una seguridad totalmente invertida"
+
+#: ../data/functions.xml.in.h:1077
+msgid "r:intrate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1078
+msgid ""
+"Returns the interest rate for a fully invested security.&#10;&#10;Basis is "
+"the type of day counting you want to use: 0: US 30/360 (default), 1: real "
+"days, 2: real days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Devuelve la tasa de interés para una seguridad totalmente "
+"invertida.&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense (predeterminado), 1: días reales, "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo."
+
+#: ../data/functions.xml.in.h:1079
+msgid "Investment"
+msgstr "Inversión"
+
+#: ../data/functions.xml.in.h:1080
+msgid "Redemption"
+msgstr "Redención"
+
+#: ../data/functions.xml.in.h:1081
+msgid "Dollar Fraction"
+msgstr "Fracción de dólar"
+
+#: ../data/functions.xml.in.h:1082
+msgid "r:dollarfr"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1083
+msgid ""
+"Converts a decimal dollar price into a dollar price expressed as a fraction."
+msgstr ""
+"Convierte un precio en dólares decimales a un precio expresado en una "
+"fracción de dólar."
+
+#: ../data/functions.xml.in.h:1084
+msgid "Decimal dollar"
+msgstr "Dólar decimal"
+
+#: ../data/functions.xml.in.h:1085
+msgid "Denominator of fraction"
+msgstr "Denominador de fracción"
+
+#: ../data/functions.xml.in.h:1086
+msgid "Dollar Decimal"
+msgstr "Dólar decimal"
+
+#: ../data/functions.xml.in.h:1087
+msgid "r:dollarde"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1088
+msgid ""
+"Converts a dollar price expressed as a fraction into a dollar price "
+"expressed as a decimal number."
+msgstr ""
+"Convierte un precio expresado en una fracción de dólar a un precio "
+"expresado en un número decimal."
+
+#: ../data/functions.xml.in.h:1089
+msgid "Fractional dollar"
+msgstr "Dólar fraccionario"
+
+#: ../data/functions.xml.in.h:1090
+msgid "Amount received at maturity for a security bond"
+msgstr "Monto recibido al vencimiento por un bono de seguridad"
+
+#: ../data/functions.xml.in.h:1091
+msgid "r:received"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1092
+msgid ""
+"Returns the amount received at the maturity date for an invested security."
+"&#10;&#10;Basis is the type of day counting you want to use: 0: US 30/360 "
+"(default), 1: real days, 2: real days/360, 3: real days/365 or 4: European "
+"30/360. The settlement date must be before maturity date."
+msgstr ""
+"Devuelve el monto recibido al vencimiento por una seguridad invertida"
+"&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense (predeterminado), 1: días reales, "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo. "
+"La fecha de liquidación debe ser anterior a la fecha de vencimiento."
+
+#: ../data/functions.xml.in.h:1093
+msgid "Discount rate for a security"
+msgstr "Tasa de descuento por una seguridad"
+
+#: ../data/functions.xml.in.h:1094
+msgid "r:disc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1095
+msgid ""
+"Returns the discount rate for a security.&#10;&#10;Basis is the type of day "
+"counting you want to use: 0: US 30/360 (default), 1: real days, 2: real "
+"days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Devuelve la tasa de descuento por una seguridad.&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense (predeterminado), 1: días reales, "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo. "
+"La fecha de liquidación debe ser anterior a la fecha de vencimiento."
+
+#: ../data/functions.xml.in.h:1096
+msgid "Accrued interest of security paying at maturity"
+msgstr "Interés acumulado por una seguridad que paga en vencimiento"
+
+#: ../data/functions.xml.in.h:1097
+msgid "r:accrintm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1098
+msgid ""
+"Returns the accrued interest for a security which pays interest at maturity "
+"date.&#10;&#10;Basis is the type of day counting you want to use: 0: US "
+"30/360 (default), 1: real days, 2: real days/360, 3: real days/365 or 4: "
+"European 30/360."
+msgstr ""
+"Devuelve el interés acumulado por una seguridad que paga interés en una "
+"fecha de vencimiento.&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense (predeterminado), 1: días reales, "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo. "
+"La fecha de liquidación debe ser anterior a la fecha de vencimiento."
+
+#: ../data/functions.xml.in.h:1099
+msgid "Issue date"
+msgstr "Fecha de emisión"
+
+#: ../data/functions.xml.in.h:1100
+msgid "Annual rate of security"
+msgstr "Tasa anual de seguridad"
+
+#: ../data/functions.xml.in.h:1101
+msgid "Par value"
+msgstr "Valor nominal"
+
+#: ../data/functions.xml.in.h:1102
+msgid "Accrued interest of security with periodic interest payments"
+msgstr "Interés acumulado por una seguridad con pagos de interés periódicos"
+
+#: ../data/functions.xml.in.h:1103
+msgid "r:accrint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1104
+msgid ""
+"Returns accrued interest for a security which pays periodic interest.&#10;"
+"&#10;Allowed frequencies are 1 - annual, 2 - semi-annual or 4 - quarterly. "
+"Basis is the type of day counting you want to use: 0: US 30/360 (default), "
+"1: real days, 2: real days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Devuelve el interés acumulado por una seguridad con pagos de interés "
+"periódicos&#10;&#10;"
+"Las frecuencias permitidas son: 1: anual, 2: semi-anual, 4: trimestral. "
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense (predeterminado), 1: días reales, "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo. "
+"La fecha de liquidación debe ser anterior a la fecha de vencimiento."
+
+#: ../data/functions.xml.in.h:1105
+msgid "First interest"
+msgstr "Primer interés"
+
+#: ../data/functions.xml.in.h:1106
+msgid "Frequency"
+msgstr "Frecuencia"
+
+#: ../data/functions.xml.in.h:1107
+msgid "Number of coupons to be paid"
+msgstr "Número de cupones a pagar"
+
+#: ../data/functions.xml.in.h:1108
+msgid "r:coupnum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1109
+msgid ""
+"Returns the number of coupons to be paid between the settlement and the "
+"maturity.&#10;&#10;Basis is the type of day counting you want to use: 0: US "
+"30/360 (default), 1: real days, 2: real days/360, 3: real days/365 or 4: "
+"European 30/360."
+msgstr ""
+"Devuelve el número de cupones a pagar entre la fecha del acuerdo y el "
+"vencimiento.&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense (predeterminado), 1: días reales, "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo. "
+"La fecha de liquidación debe ser anterior a la fecha de vencimiento."
+
+#: ../data/functions.xml.in.h:1110
+msgid "Price per $100 face value of a discounted security"
+msgstr "Precio por $100 de valor nominal de seguridad descontada"
+
+#: ../data/functions.xml.in.h:1111
+msgid "r:pricedisc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1112
+msgid ""
+"Calculates and returns the price per $100 face value of a discounted "
+"security. The security does not pay interest at maturity.&#10;&#10;Basis is "
+"the type of day counting you want to use: 0: US 30/360 (default), 1: real "
+"days, 2: real days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Calcula y devuelve el precio por cada $100 de valor nominal de una "
+"seguridad descontada. La seguridad no paga interés en el "
+"vencimiento.&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense (predeterminado), 1: días reales, "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo. "
+"La fecha de liquidación debe ser anterior a la fecha de vencimiento."
+
+#: ../data/functions.xml.in.h:1113
+msgid "Discount"
+msgstr "Descuento"
+
+#: ../data/functions.xml.in.h:1114
+msgid "Price per $100 face value of a security"
+msgstr "Precio por $100 de valor nominal de una seguridad"
+
+#: ../data/functions.xml.in.h:1115
+msgid "r:pricemat"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1116
+msgid ""
+"Calculates and returns the price per $100 face value of a security. The "
+"security pays interest at maturity.&#10;&#10;Basis is the type of day "
+"counting you want to use: 0: US 30/360 (default), 1: real days, 2: real "
+"days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Calcula y devuelve el precio por cada $100 de valor nominal de una "
+"seguridad. La seguridad paga interés en el vencimiento.&#10;&#10;"
+"La base es el tipo de contado de días que quieres usar: "
+"0: 30/360 estadounidense (predeterminado), 1: días reales, "
+"2: días reales/360, 3: días reales/365, 4: 30/360 europeo. "
+"La fecha de liquidación debe ser anterior a la fecha de vencimiento."
+
+#: ../data/functions.xml.in.h:1117
+msgid "Annual yield"
+msgstr "Rendimiento anual"
+
+#: ../data/functions.xml.in.h:1118
+msgid "Level-Coupon Bond"
+msgstr "Bono de cupón de nivel"
+
+#: ../data/functions.xml.in.h:1119
+msgid "r:level_coupon"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1120
+msgid "Calculates the value of a level-coupon bond."
+msgstr "Calcula el valor de un bono de cupón de nivel"
+
+#: ../data/functions.xml.in.h:1121
+msgid "Coupon rate"
+msgstr "Tasa de cupón"
+
+#: ../data/functions.xml.in.h:1122
+msgid "Coupons per year"
+msgstr "Cupones por año"
+
+#: ../data/functions.xml.in.h:1123
+msgid "Market interest rate"
+msgstr "Tasa de interés de mercado"
+
+#: ../data/planets.xml.in.h:1
+msgid "Earth"
+msgstr "Tierra"
+
+#: ../data/planets.xml.in.h:2
+msgid "Mars"
+msgstr "Marte"
+
+#. Planet
+#: ../data/planets.xml.in.h:4
+msgid "!planets!Mercury"
+msgstr "Mercurio"
+
+#: ../data/planets.xml.in.h:5
+msgid "Venus"
+msgstr "Venus"
+
+#: ../data/planets.xml.in.h:6
+msgid "Jupiter"
+msgstr "Júpiter"
+
+#: ../data/planets.xml.in.h:7
+msgid "Saturn"
+msgstr "Saturno"
+
+#: ../data/planets.xml.in.h:8
+msgid "Neptune"
+msgstr "Neptuno"
+
+#: ../data/planets.xml.in.h:9
+msgid "Pluto"
+msgstr "Plutón"
+
+#: ../data/planets.xml.in.h:10
+msgid "Uranus"
+msgstr "Urano"
+
+#: ../data/prefixes.xml.in.h:1
+msgid "yocto"
+msgstr "yocto"
+
+#: ../data/prefixes.xml.in.h:2
+msgid "zepto"
+msgstr "zepto"
+
+#: ../data/prefixes.xml.in.h:3
+msgid "atto"
+msgstr "atto"
+
+#: ../data/prefixes.xml.in.h:4
+msgid "femto"
+msgstr "femto"
+
+#: ../data/prefixes.xml.in.h:5
+msgid "pico"
+msgstr "pico"
+
+#: ../data/prefixes.xml.in.h:6
+msgid "nano"
+msgstr "nano"
+
+#: ../data/prefixes.xml.in.h:7
+msgid "micro"
+msgstr "micro"
+
+#: ../data/prefixes.xml.in.h:8
+msgid "milli"
+msgstr "mili"
+
+#: ../data/prefixes.xml.in.h:9
+msgid "centi"
+msgstr "centi"
+
+#: ../data/prefixes.xml.in.h:10
+msgid "deci"
+msgstr "deci"
+
+#: ../data/prefixes.xml.in.h:11
+msgid "deca"
+msgstr "deca"
+
+#: ../data/prefixes.xml.in.h:12
+msgid "hecto"
+msgstr "hecto"
+
+#: ../data/prefixes.xml.in.h:13
+msgid "kilo"
+msgstr "kilo"
+
+#: ../data/prefixes.xml.in.h:14
+msgid "mega"
+msgstr "mega"
+
+#: ../data/prefixes.xml.in.h:15
+msgid "giga"
+msgstr "giga"
+
+#: ../data/prefixes.xml.in.h:16
+msgid "tera"
+msgstr "tera"
+
+#: ../data/prefixes.xml.in.h:17
+msgid "peta"
+msgstr "peta"
+
+#: ../data/prefixes.xml.in.h:18
+msgid "exa"
+msgstr "exa"
+
+#: ../data/prefixes.xml.in.h:19
+msgid "zetta"
+msgstr "zetta"
+
+#: ../data/prefixes.xml.in.h:20
+msgid "yotta"
+msgstr "yotta"
+
+#: ../data/prefixes.xml.in.h:21
+msgid "kibi"
+msgstr "kibi"
+
+#: ../data/prefixes.xml.in.h:22
+msgid "mebi"
+msgstr "mebi"
+
+#: ../data/prefixes.xml.in.h:23
+msgid "gibi"
+msgstr "gibi"
+
+#: ../data/prefixes.xml.in.h:24
+msgid "tebi"
+msgstr "tebi"
+
+#: ../data/prefixes.xml.in.h:25
+msgid "pebi"
+msgstr "pebi"
+
+#: ../data/prefixes.xml.in.h:26
+msgid "exbi"
+msgstr "exbi"
+
+#. Unit category
+#: ../data/units.xml.in.h:2
+msgid "!units!Length"
+msgstr "Longitud"
+
+#: ../data/units.xml.in.h:3
+msgid "Meter"
+msgstr "Metro"
+
+#: ../data/units.xml.in.h:4
+msgid "ar:m,meter,p:meters,metre,p:metres"
+msgstr ""
+
+#: ../data/units.xml.in.h:5
+msgid "Kilometer"
+msgstr "Kilómetro"
+
+#: ../data/units.xml.in.h:6
+msgid "Decimeter"
+msgstr "Decímetro"
+
+#: ../data/units.xml.in.h:7
+msgid "Centimeter"
+msgstr "Centímetro"
+
+#: ../data/units.xml.in.h:8
+msgid "Millimeter"
+msgstr "Milímetro"
+
+#: ../data/units.xml.in.h:9
+msgid "Nautical Mile"
+msgstr "Milla náutica"
+
+#: ../data/units.xml.in.h:10
+msgid "r:nautical_mile,p:nautical_miles"
+msgstr ""
+
+#: ../data/units.xml.in.h:11
+msgid "&#xC5;ngstr&#xF6;m"
+msgstr ""
+
+#: ../data/units.xml.in.h:12
+msgid "aru:&#xC5;,u:&#xE5;ngstr&#xF6;m,angstrom"
+msgstr ""
+
+#: ../data/units.xml.in.h:13
+msgid "U.S. Survey Inch"
+msgstr "Pulgada de US Survey"
+
+#: ../data/units.xml.in.h:14
+msgid "ar:US_in,US_inch,p:US_inches"
+msgstr ""
+
+#: ../data/units.xml.in.h:15
+msgid "Inch"
+msgstr "Pulgada"
+
+#: ../data/units.xml.in.h:16
+msgid "ar:in,inch,p:inches"
+msgstr ""
+
+#: ../data/units.xml.in.h:17
+msgid "Hand"
+msgstr "Mano"
+
+#: ../data/units.xml.in.h:18
+msgid "r:hand,p:hands"
+msgstr ""
+
+#: ../data/units.xml.in.h:19
+msgid "Foot"
+msgstr "Pie"
+
+#: ../data/units.xml.in.h:20
+msgid "ar:ft,foot,p:feet"
+msgstr ""
+
+#: ../data/units.xml.in.h:21
+msgid "U.S. Survey Foot"
+msgstr "Pie de US Survey"
+
+#: ../data/units.xml.in.h:22
+msgid "ar:US_ft,US_foot,p:US_feet"
+msgstr ""
+
+#: ../data/units.xml.in.h:23
+msgid "Link"
+msgstr "Link"
+
+#: ../data/units.xml.in.h:24
+msgid "ar:li,link,p:links"
+msgstr ""
+
+#: ../data/units.xml.in.h:25
+msgid "Yard"
+msgstr "Yarda"
+
+#: ../data/units.xml.in.h:26
+msgid "ar:yd,yard,p:yards"
+msgstr ""
+
+#: ../data/units.xml.in.h:27
+msgid "Rod (pole/perch)"
+msgstr "Rod (vara/pértiga)"
+
+#: ../data/units.xml.in.h:28
+msgid "ar:rd,rod,p:rods"
+msgstr ""
+
+#: ../data/units.xml.in.h:29
+msgid "Fathom"
+msgstr "Braza"
+
+#: ../data/units.xml.in.h:30
+msgid "r:fathom,p:fathoms"
+msgstr ""
+
+#: ../data/units.xml.in.h:31
+msgid "Chain"
+msgstr "Cadena"
+
+#: ../data/units.xml.in.h:32
+msgid "ar:ch,chain,p:chains"
+msgstr ""
+
+#: ../data/units.xml.in.h:33
+msgid "Furlong"
+msgstr "Furlong"
+
+#: ../data/units.xml.in.h:34
+msgid "ar:fur,furlong,p:furlongs"
+msgstr ""
+
+#: ../data/units.xml.in.h:35
+msgid "Mile"
+msgstr "Milla"
+
+#: ../data/units.xml.in.h:36
+msgid "ar:mi,mile,p:miles"
+msgstr ""
+
+#: ../data/units.xml.in.h:37
+msgid "U.S. Survey Mile"
+msgstr "Milla de US Survey"
+
+#: ../data/units.xml.in.h:38
+msgid "ar:US_mi,US_mile,p:US_miles"
+msgstr ""
+
+#: ../data/units.xml.in.h:39
+msgid "Mil (1/1000 in)"
+msgstr "Mil (1/1000 in)"
+
+#: ../data/units.xml.in.h:40
+msgid "r:mil,p:mils"
+msgstr ""
+
+#: ../data/units.xml.in.h:41
+msgid "Astronomical Unit"
+msgstr "Unidad astronómica"
+
+#: ../data/units.xml.in.h:42
+msgid "ar:AU,astronomical_unit,p:astronomical_units"
+msgstr ""
+
+#: ../data/units.xml.in.h:43
+msgid "Light Year"
+msgstr "Año luz"
+
+#: ../data/units.xml.in.h:44
+msgid "ar:ly,lightyear,p:lightyears"
+msgstr ""
+
+#: ../data/units.xml.in.h:45
+msgid "Parsec"
+msgstr "Pársec"
+
+#: ../data/units.xml.in.h:46
+msgid "ar:pc,parsec,p:parsecs"
+msgstr ""
+
+#: ../data/units.xml.in.h:47
+msgid "Pied du roi (French Royal Foot)"
+msgstr "Pie francés"
+
+#: ../data/units.xml.in.h:48
+msgid "r:pied_du_roi"
+msgstr ""
+
+#: ../data/units.xml.in.h:49
+msgid "Pouce (French Royal Inch)"
+msgstr "Pulgada francesa"
+
+#: ../data/units.xml.in.h:50
+msgid "r:pouce"
+msgstr ""
+
+#: ../data/units.xml.in.h:51
+msgid "Ligne"
+msgstr "Línea francesa"
+
+#: ../data/units.xml.in.h:52
+msgid "r:ligne"
+msgstr ""
+
+#: ../data/units.xml.in.h:53
+msgid "Toise"
+msgstr "Altura francesa"
+
+#: ../data/units.xml.in.h:54
+msgid "r:toise"
+msgstr ""
+
+#: ../data/units.xml.in.h:55
+msgid "Planck Length"
+msgstr "Longitud de Planck"
+
+#: ../data/units.xml.in.h:56
+msgid "Bohr (Atomic Unit of Length)"
+msgstr "Radio de Bohr (unidad atómica de longitud)"
+
+#: ../data/units.xml.in.h:57
+msgid "Electronvolt Distance"
+msgstr "Distancia de electronvoltio"
+
+#: ../data/units.xml.in.h:58
+msgid "Natural Unit of Length"
+msgstr "Unidad natural de longitud"
+
+#. Unit category
+#: ../data/units.xml.in.h:60
+msgid "!units!Angle"
+msgstr "Ángulo"
+
+#: ../data/units.xml.in.h:61
+msgid "Plane Angle"
+msgstr "Ángulo plano"
+
+#: ../data/units.xml.in.h:62
+msgid "Meter per Meter"
+msgstr "Metro por metro"
+
+#: ../data/units.xml.in.h:63
+msgid "Radian"
+msgstr "Radián"
+
+#: ../data/units.xml.in.h:64
+msgid "ar:rad,radian,p:radians"
+msgstr ""
+
+#: ../data/units.xml.in.h:66
+msgid "ar:deg,au:&#xB0;,degree,p:degrees"
+msgstr ""
+
+#: ../data/units.xml.in.h:67
+msgid "Gradian (Gon)"
+msgstr "Gradián (Gon)"
+
+#: ../data/units.xml.in.h:68
+msgid "ar:gra,gradian,p:gradians,gon,p:gons"
+msgstr ""
+
+#: ../data/units.xml.in.h:69
+msgid "Arcminute"
+msgstr "Arcominuto"
+
+#: ../data/units.xml.in.h:70
+msgid "ar:arcmin,arcminute,p:arcminutes"
+msgstr ""
+
+#: ../data/units.xml.in.h:71
+msgid "Arcsecond"
+msgstr "Arcosegundo"
+
+#: ../data/units.xml.in.h:72
+msgid "ar:arcsec,arcsecond,p:arcseconds"
+msgstr ""
+
+#: ../data/units.xml.in.h:73
+msgid "Turn"
+msgstr "Vuelta"
+
+#: ../data/units.xml.in.h:74
+msgid "r:turn,p:turns"
+msgstr ""
+
+#: ../data/units.xml.in.h:75
+msgid "Solid Angle"
+msgstr "Ángulo sólido"
+
+#: ../data/units.xml.in.h:76
+msgid "Square Meter per Square Meter"
+msgstr "Metro cuadrado por metro cuadrado"
+
+#: ../data/units.xml.in.h:77
+msgid "Square Degree"
+msgstr "Grado cuadrado"
+
+#: ../data/units.xml.in.h:78
+msgid "Steradian"
+msgstr "Estereorradián"
+
+#: ../data/units.xml.in.h:79
+msgid "ar:sr,steradian,p:steradians"
+msgstr ""
+
+#: ../data/units.xml.in.h:80
+msgid "Angular Acceleration"
+msgstr "Aceleración angular"
+
+#: ../data/units.xml.in.h:81
+msgid "Radians per Second Squared"
+msgstr "Radianes por segundo al cuadrado"
+
+#: ../data/units.xml.in.h:82
+msgid "Angular Velocity"
+msgstr "Velocidad angular"
+
+#: ../data/units.xml.in.h:83
+msgid "Radians per Second"
+msgstr "Radianes por segundo"
+
+#. Unit category
+#: ../data/units.xml.in.h:85
+msgid "!units!Mass"
+msgstr "Masa"
+
+#: ../data/units.xml.in.h:86
+msgid "Gram"
+msgstr "Gramo"
+
+#: ../data/units.xml.in.h:87
+msgid "ar:g,gram,p:grams"
+msgstr ""
+
+#: ../data/units.xml.in.h:88
+msgid "Kilogram"
+msgstr "Kilogramo"
+
+#: ../data/units.xml.in.h:89
+msgid "Hectogram"
+msgstr "Hectogramo"
+
+#: ../data/units.xml.in.h:90
+msgid "Metric Ton (Tonne)"
+msgstr "Tonelada métrica"
+
+#: ../data/units.xml.in.h:91
+msgid "ar:t,tonne,p:tonnes,ton,p:tons"
+msgstr ""
+
+#: ../data/units.xml.in.h:92
+msgid "Grain"
+msgstr "Grano"
+
+#: ../data/units.xml.in.h:93
+msgid "ar:gr,grain,p:grains"
+msgstr ""
+
+#: ../data/units.xml.in.h:94
+msgid "Pennyweight"
+msgstr "Pennyweight"
+
+#: ../data/units.xml.in.h:95
+msgid "ar:pwt,pennyweight,p:pennyweights"
+msgstr ""
+
+#: ../data/units.xml.in.h:96
+msgid "Ounce (troy)"
+msgstr "Onza troy"
+
+#: ../data/units.xml.in.h:97
+msgid "ar:oz_t,troy_ounce,p:troy_ounces"
+msgstr ""
+
+#: ../data/units.xml.in.h:98
+msgid "Pound (troy)"
+msgstr "Libra troy"
+
+#: ../data/units.xml.in.h:99
+msgid "ar:lb_t,troy_pound,p:troy_pounds"
+msgstr ""
+
+#: ../data/units.xml.in.h:100
+msgid "Dram"
+msgstr "Dracma"
+
+#: ../data/units.xml.in.h:101
+msgid "ar:dr,dram,p:drams"
+msgstr ""
+
+#: ../data/units.xml.in.h:102
+msgid "Ounce"
+msgstr "Onza"
+
+#: ../data/units.xml.in.h:103
+msgid "ar:oz,ounce,p:ounces"
+msgstr ""
+
+#: ../data/units.xml.in.h:104
+msgid "Pound"
+msgstr "Libra"
+
+#: ../data/units.xml.in.h:105
+msgid "ar:lb,pound,p:pounds"
+msgstr ""
+
+#: ../data/units.xml.in.h:106
+msgid "Short Hundredweight (Cental)"
+msgstr "Centena corta"
+
+#: ../data/units.xml.in.h:107
+msgid "ar:cwt,hundredweight,cental,p:hundredweights,centals"
+msgstr ""
+
+#: ../data/units.xml.in.h:108
+msgid "Long Hundredweight"
+msgstr "Centena larga"
+
+#: ../data/units.xml.in.h:109
+msgid "ar:l_cwt,long_hundredweight,p:long_hundredweights"
+msgstr ""
+
+#: ../data/units.xml.in.h:110
+msgid "Short Ton"
+msgstr "Tonelada corta"
+
+#: ../data/units.xml.in.h:111
+msgid "ar:s_ton,short_ton,p:short_tons"
+msgstr ""
+
+#: ../data/units.xml.in.h:112
+msgid "Long Ton"
+msgstr "Tonelada larga"
+
+#: ../data/units.xml.in.h:113
+msgid "ar:l_ton,long_ton,p:long_tons"
+msgstr ""
+
+#: ../data/units.xml.in.h:114
+msgid "Stone"
+msgstr "Stone"
+
+#: ../data/units.xml.in.h:115
+msgid "r:stone,p:stones"
+msgstr ""
+
+#: ../data/units.xml.in.h:116
+msgid "Carat"
+msgstr "Quilate"
+
+#: ../data/units.xml.in.h:117
+msgid "r:carat,p:carats"
+msgstr ""
+
+#: ../data/units.xml.in.h:118
+msgid "Pfund"
+msgstr "Pfund"
+
+#: ../data/units.xml.in.h:119
+msgid "r:pfund"
+msgstr ""
+
+#: ../data/units.xml.in.h:120
+msgid "Zentner"
+msgstr "Zentner"
+
+#: ../data/units.xml.in.h:121
+msgid "r:zentner"
+msgstr ""
+
+#: ../data/units.xml.in.h:122
+msgid "Planck Mass"
+msgstr "Masa de Planck"
+
+#: ../data/units.xml.in.h:123
+msgid "Atomic/Natural Unit of Mass"
+msgstr "Unidad de masa natural"
+
+#: ../data/units.xml.in.h:124
+msgid "Electronvolt Mass"
+msgstr "Masa de electronvoltio"
+
+#: ../data/units.xml.in.h:125
+msgid "Atomic Mass Unit"
+msgstr "Unidad de masa atómica"
+
+#: ../data/units.xml.in.h:126
+msgid "ar:u,a:AMU,atomic_mass_unit,p:atomic_mass_units"
+msgstr ""
+
+#: ../data/units.xml.in.h:127
+msgid "Dalton"
+msgstr "Dalton"
+
+#: ../data/units.xml.in.h:128
+msgid "ar:Da,dalton,p:daltons"
+msgstr ""
+
+#: ../data/units.xml.in.h:129
+msgid "Kilodalton"
+msgstr "Kilodalton"
+
+#: ../data/units.xml.in.h:131
+msgid "Kilogram per Cubic Meter"
+msgstr "Kilogramo por metro cúbico"
+
+#: ../data/units.xml.in.h:132
+msgid "Gram per Cubic Decimeter"
+msgstr "Gramo por decímetro cúbico"
+
+#: ../data/units.xml.in.h:133
+msgid "Gram per Cubic Centimeter"
+msgstr "Gramo por centímetro cúbico"
+
+#: ../data/units.xml.in.h:134
+msgid "Atomic Mass"
+msgstr "Masa atómica"
+
+#: ../data/units.xml.in.h:135
+msgid "Gram per Mole"
+msgstr "Gramo por mol"
+
+#: ../data/units.xml.in.h:136
+msgid "Mass Fraction"
+msgstr "Fracción de masa"
+
+#: ../data/units.xml.in.h:137
+msgid "Kilogram per Kilogram"
+msgstr "Kilogramo por kilogramo"
+
+#: ../data/units.xml.in.h:140
+msgid "ar:s,second,p:seconds"
+msgstr ""
+
+#: ../data/units.xml.in.h:142
+msgid "ar:min,minute,p:minutes"
+msgstr ""
+
+#: ../data/units.xml.in.h:144
+msgid "ar:h,hour,p:hours"
+msgstr ""
+
+#: ../data/units.xml.in.h:146
+msgid "ar:d,day,p:days"
+msgstr ""
+
+#: ../data/units.xml.in.h:147
+msgid "Week"
+msgstr "Semana"
+
+#: ../data/units.xml.in.h:148
+msgid "r:week,p:weeks"
+msgstr ""
+
+#: ../data/units.xml.in.h:149
+msgid "Fortnight"
+msgstr "Quincena"
+
+#: ../data/units.xml.in.h:150
+msgid "r:fortnight,p:fortnights"
+msgstr ""
+
+#: ../data/units.xml.in.h:151
+msgid "Julian Year"
+msgstr "Año juliano"
+
+#: ../data/units.xml.in.h:152
+msgid "r:year,p:years"
+msgstr ""
+
+#: ../data/units.xml.in.h:154
+msgid "r:month,p:months"
+msgstr ""
+
+#: ../data/units.xml.in.h:155
+msgid "Planck Time"
+msgstr "Tiempo de Planck"
+
+#: ../data/units.xml.in.h:156
+msgid "Atomic Unit of Time"
+msgstr "Unidad atómica de tiempo"
+
+#: ../data/units.xml.in.h:157
+msgid "Natural Unit of Time"
+msgstr "Unidad natural de tiempo"
+
+#: ../data/units.xml.in.h:158
+msgid "Electronvolt Time"
+msgstr "Tiempo de electronvoltio"
+
+#. Unit category
+#: ../data/units.xml.in.h:160
+msgid "!units!Frequency"
+msgstr "Frecuencia"
+
+#: ../data/units.xml.in.h:161
+msgid "Hertz"
+msgstr "Hercio"
+
+#: ../data/units.xml.in.h:162
+msgid "ar:Hz,hertz"
+msgstr ""
+
+#: ../data/units.xml.in.h:163
+msgid "Electricity"
+msgstr "Electricidad"
+
+#: ../data/units.xml.in.h:164
+msgid "Electric Current"
+msgstr "Corriente eléctrica"
+
+#: ../data/units.xml.in.h:165
+msgid "Ampere"
+msgstr "Amperio"
+
+#: ../data/units.xml.in.h:166
+msgid "ar:A,ampere,p:amperes"
+msgstr ""
+
+#: ../data/units.xml.in.h:167
+msgid "Abampere"
+msgstr "Abamperio"
+
+#: ../data/units.xml.in.h:168
+msgid "r:abampere,a:abA,a:aA,p:abamperes"
+msgstr ""
+
+#: ../data/units.xml.in.h:169
+msgid "Current Density"
+msgstr "Densidad de corriente"
+
+#: ../data/units.xml.in.h:170
+msgid "Ampere per Meter Squared"
+msgstr "Amperio por metro cuadrado"
+
+#: ../data/units.xml.in.h:171
+msgid "Electric Charge"
+msgstr "Carga eléctrica"
+
+#: ../data/units.xml.in.h:172
+msgid "Ampere Second"
+msgstr "Amperio segundo"
+
+#: ../data/units.xml.in.h:173
+msgid "Coulomb"
+msgstr "Culombio"
+
+#: ../data/units.xml.in.h:174
+msgid "ar:C,coulomb,p:coulombs"
+msgstr ""
+
+#: ../data/units.xml.in.h:175
+msgid "Abcoulomb"
+msgstr "Abculombio"
+
+#: ../data/units.xml.in.h:176
+msgid "r:abcoulomb,p:abcoulombs,a:abC,a:aC"
+msgstr ""
+
+#: ../data/units.xml.in.h:177
+msgid "Statcoulomb (Franklin)"
+msgstr "Franklin"
+
+#: ../data/units.xml.in.h:178
+msgid "r:statcoulomb,p:statcoulombs,a:statC,franklin,a:Fr,p:franklins"
+msgstr ""
+
+#: ../data/units.xml.in.h:179
+msgid "Planck Charge"
+msgstr "Carga de Planck"
+
+#: ../data/units.xml.in.h:180
+msgid "Atomic Unit of Charge"
+msgstr "Unidad atómica de carga"
+
+#: ../data/units.xml.in.h:181
+msgid "Electric Charge Density"
+msgstr "Densidad de carga eléctrica"
+
+#: ../data/units.xml.in.h:182
+msgid "Coulomb per Cubic Meter"
+msgstr "Culombio por metro cúbico"
+
+#: ../data/units.xml.in.h:183
+msgid "Electric Flux Density"
+msgstr "Densidad de flujo eléctrico"
+
+#: ../data/units.xml.in.h:184
+msgid "Coulomb per Meter Squared"
+msgstr "Culombio por metro cuadrado"
+
+#: ../data/units.xml.in.h:185
+msgid "Electric Potential"
+msgstr "Potencial eléctrico"
+
+#: ../data/units.xml.in.h:186
+msgid "Watt per Ampere"
+msgstr "Vatio por amperio"
+
+#: ../data/units.xml.in.h:187
+msgid "Volt"
+msgstr "Voltio"
+
+#: ../data/units.xml.in.h:188
+msgid "ar:V,volt,p:volts"
+msgstr ""
+
+#: ../data/units.xml.in.h:189
+msgid "Statvolt"
+msgstr "Estatvoltio"
+
+#: ../data/units.xml.in.h:190
+msgid "r:statvolt,p:statvolts,a:statV"
+msgstr ""
+
+#: ../data/units.xml.in.h:191
+msgid "Abvolt"
+msgstr "Abvoltio"
+
+#: ../data/units.xml.in.h:192
+msgid "r:abvolt,p:abvolts,a:abV"
+msgstr ""
+
+#: ../data/units.xml.in.h:193
+msgid "Atomic Unit of Electric Potential"
+msgstr "Unidad atómica de potencial eléctrico"
+
+#: ../data/units.xml.in.h:194
+msgid "Capacitance"
+msgstr "Capacidad"
+
+#: ../data/units.xml.in.h:195
+msgid "Coulomb per Volt"
+msgstr "Culombio por voltio"
+
+#: ../data/units.xml.in.h:196
+msgid "Farad"
+msgstr "Faradio"
+
+#: ../data/units.xml.in.h:197
+msgid "ar:F,farad,p:farads"
+msgstr ""
+
+#: ../data/units.xml.in.h:198
+msgid "Electric Resistance"
+msgstr "Resistencia eléctrica"
+
+#: ../data/units.xml.in.h:199
+msgid "Volt per Ampere"
+msgstr "Voltio por amperio"
+
+#: ../data/units.xml.in.h:200
+msgid "Ohm"
+msgstr "Ohmio"
+
+#: ../data/units.xml.in.h:201
+msgid "au:&#x3A9;,r:ohm,p:ohms"
+msgstr ""
+
+#: ../data/units.xml.in.h:202
+msgid "Abohm"
+msgstr "Abohmio"
+
+#: ../data/units.xml.in.h:203
+msgid "r:abohm,p:abohms,au:ab&#x3A9;"
+msgstr ""
+
+#: ../data/units.xml.in.h:204
+msgid "Statohm"
+msgstr "Estatohmio"
+
+#: ../data/units.xml.in.h:205
+msgid "r:statohm,p:statohms,au:stat&#x3A9;"
+msgstr ""
+
+#: ../data/units.xml.in.h:206
+msgid "Electric Conductance"
+msgstr "Conductancia eléctrica"
+
+#: ../data/units.xml.in.h:207
+msgid "Ampere per Volt"
+msgstr "Amperio por voltio"
+
+#: ../data/units.xml.in.h:208
+msgid "Siemens"
+msgstr "Siemens"
+
+#: ../data/units.xml.in.h:209
+msgid "ar:S,siemens"
+msgstr ""
+
+#: ../data/units.xml.in.h:210
+msgid "Electric Field Strength"
+msgstr "Intensidad de campo eléctrico"
+
+#: ../data/units.xml.in.h:211
+msgid "Volt per Meter"
+msgstr "Voltio por metro"
+
+#: ../data/units.xml.in.h:212
+msgid "Atomic Unit of Electric Field"
+msgstr "Unidad atómica de campo eléctrico"
+
+#: ../data/units.xml.in.h:213
+msgid "Permittivity"
+msgstr "Permisividad"
+
+#: ../data/units.xml.in.h:214
+msgid "Farad per Meter"
+msgstr "Faradio por metro"
+
+#: ../data/units.xml.in.h:215
+msgid "Inductance"
+msgstr "Inductancia"
+
+#: ../data/units.xml.in.h:216
+msgid "Weber per Ampere"
+msgstr "Weber por amperio"
+
+#: ../data/units.xml.in.h:217
+msgid "Henry"
+msgstr "Henrio"
+
+#: ../data/units.xml.in.h:218
+msgid "ar:H,henry,p:henrys"
+msgstr ""
+
+#: ../data/units.xml.in.h:219
+msgid "Permeability"
+msgstr "Permeabilidad"
+
+#: ../data/units.xml.in.h:220
+msgid "Henry per Meter"
+msgstr "Henrio por metro"
+
+#: ../data/units.xml.in.h:221
+msgid "Temperature"
+msgstr "Temperatura"
+
+#: ../data/units.xml.in.h:222
+msgid "Kelvin"
+msgstr "Kelvin"
+
+#: ../data/units.xml.in.h:223
+msgid "ar:K,kelvin,p:kelvins"
+msgstr ""
+
+#: ../data/units.xml.in.h:224
+msgid "Degree Celsius"
+msgstr "Grado Celsius"
+
+#: ../data/units.xml.in.h:225
+msgid ""
+"ar:oC,au:&#xB0;C,au:&#x2103;,r:celsius,p:celsius,centigrade,p:centigrades"
+msgstr ""
+
+#: ../data/units.xml.in.h:226
+msgid "Degree Rankine"
+msgstr "Grado Rankine"
+
+#: ../data/units.xml.in.h:227
+msgid "ar:oR,au:&#xB0;R,r:rankine"
+msgstr ""
+
+#: ../data/units.xml.in.h:228
+msgid "Degree Fahrenheit"
+msgstr "Grado Fahrenheit"
+
+#: ../data/units.xml.in.h:229
+msgid "ar:oF,au:&#xB0;F,au:&#x2109;,r:fahrenheit"
+msgstr ""
+
+#: ../data/units.xml.in.h:230
+msgid "Planck Temperature"
+msgstr "Temperatura de Planck"
+
+#: ../data/units.xml.in.h:231
+msgid "Electronvolt Temperature"
+msgstr "Temperatura de electronvoltio"
+
+#: ../data/units.xml.in.h:232
+msgid "Substance"
+msgstr "Sustancia"
+
+#: ../data/units.xml.in.h:233
+msgid "Mole"
+msgstr "Mol"
+
+#: ../data/units.xml.in.h:234
+msgid "ar:mol,mole,p:moles"
+msgstr ""
+
+#: ../data/units.xml.in.h:235
+msgid "Einstein"
+msgstr "Einstein"
+
+#: ../data/units.xml.in.h:236
+msgid "r:einstein,p:einsteins"
+msgstr ""
+
+#: ../data/units.xml.in.h:237
+msgid "Substance Concentration"
+msgstr "Concentración de sustancia"
+
+#: ../data/units.xml.in.h:238
+msgid "Mole per Cubic Meter"
+msgstr "Mol por metro cúbico"
+
+#: ../data/units.xml.in.h:239
+msgid "Catalytic Activity"
+msgstr "Actividad catalítica"
+
+#: ../data/units.xml.in.h:240
+msgid "Reciprocal Seconds Mole"
+msgstr "Mol por segundo"
+
+#: ../data/units.xml.in.h:241
+msgid "Katal"
+msgstr "Katal"
+
+#: ../data/units.xml.in.h:242
+msgid "ar:kat,katal,p:katals"
+msgstr ""
+
+#: ../data/units.xml.in.h:243
+msgid "Catalytic Concentration"
+msgstr "Concentración catalítica"
+
+#: ../data/units.xml.in.h:244
+msgid "Katal per Cubic Meter"
+msgstr "Katal por metro cúbico"
+
+#: ../data/units.xml.in.h:245
+msgid "Light"
+msgstr "Luz"
+
+#: ../data/units.xml.in.h:246
+msgid "Luminous Intensity"
+msgstr "Intensidad luminosa"
+
+#: ../data/units.xml.in.h:247
+msgid "Candela"
+msgstr "Candela"
+
+#: ../data/units.xml.in.h:248
+msgid "ar:cd,candela,p:candelas"
+msgstr ""
+
+#: ../data/units.xml.in.h:249
+msgid "Luminance"
+msgstr "Luminancia"
+
+#: ../data/units.xml.in.h:250
+msgid "Candela per Meter Squared"
+msgstr "Candela por metro cuadrado"
+
+#: ../data/units.xml.in.h:251
+msgid "Stilb"
+msgstr "Stilb"
+
+#: ../data/units.xml.in.h:252
+msgid "ar:sb,stilb,p:stilbs"
+msgstr ""
+
+#: ../data/units.xml.in.h:253
+msgid "Luminous Flux"
+msgstr "Flujo luminoso"
+
+#: ../data/units.xml.in.h:254
+msgid "Candela Steradian"
+msgstr "Candela estereorradián"
+
+#: ../data/units.xml.in.h:255
+msgid "Lumen"
+msgstr "Lumen"
+
+#: ../data/units.xml.in.h:256
+msgid "ar:lm,lumen,p:lumens"
+msgstr ""
+
+#: ../data/units.xml.in.h:257
+msgid "Illuminance"
+msgstr "Iluminancia"
+
+#: ../data/units.xml.in.h:258
+msgid "Lumen per Meter Squared"
+msgstr "Lumen por metro cuadrado"
+
+#: ../data/units.xml.in.h:259
+msgid "Lumen per Foot Squared"
+msgstr "Lumen por pie cuadrado"
+
+#: ../data/units.xml.in.h:260
+msgid "Lux"
+msgstr "Lux"
+
+#: ../data/units.xml.in.h:261
+msgid "ar:lx,lux"
+msgstr ""
+
+#: ../data/units.xml.in.h:262
+msgid "Foot-Candle"
+msgstr "Vela"
+
+#: ../data/units.xml.in.h:263
+msgid "ar:fc,footcandle,p:footcandles"
+msgstr ""
+
+#: ../data/units.xml.in.h:264
+msgid "Phot"
+msgstr "Phot"
+
+#: ../data/units.xml.in.h:265
+msgid "ar:ph,phot,p:phots"
+msgstr ""
+
+#: ../data/units.xml.in.h:266
+msgid "Radiant Intensity"
+msgstr "Intensidad radiante"
+
+#: ../data/units.xml.in.h:267
+msgid "Watt per Steradian"
+msgstr "Vatio por estereorradián"
+
+#: ../data/units.xml.in.h:268
+msgid "Irradiance"
+msgstr "Irradiancia"
+
+#: ../data/units.xml.in.h:269
+msgid "Watt per Meter Squared"
+msgstr "Vatio por metro cuadrado"
+
+#: ../data/units.xml.in.h:270
+msgid "Einstein per Meter Squared per Second"
+msgstr "Einstein por metro cuadrado por segundo"
+
+#: ../data/units.xml.in.h:271
+msgid "Microeinstein per Meter Squared per Second"
+msgstr "Microeinstein por metro cuadrado por segundo"
+
+#: ../data/units.xml.in.h:272
+msgid "Radiance"
+msgstr "Radiancia"
+
+#: ../data/units.xml.in.h:273
+msgid "Watt per Square Meter Steradian"
+msgstr "Vatio por metro cuadrado estereorradián"
+
+#: ../data/units.xml.in.h:274
+msgid "Area"
+msgstr "Área"
+
+#: ../data/units.xml.in.h:275
+msgid "Square Meter"
+msgstr "Metro cuadrado"
+
+#: ../data/units.xml.in.h:276
+msgid "Square Kilometer"
+msgstr "Kilómetro cuadrado"
+
+#: ../data/units.xml.in.h:277
+msgid "Are"
+msgstr "Área"
+
+#: ../data/units.xml.in.h:278
+msgid "ar:a,are,p:ares"
+msgstr ""
+
+#: ../data/units.xml.in.h:279
+msgid "Circular Mil"
+msgstr "Mil circular"
+
+#: ../data/units.xml.in.h:280
+msgid "r:cmil,p:cmils"
+msgstr ""
+
+#: ../data/units.xml.in.h:281
+msgid "Thousand of Circular Mil"
+msgstr "Mil Mils circulares"
+
+#: ../data/units.xml.in.h:282
+msgid "Hectare"
+msgstr "Hectárea"
+
+#: ../data/units.xml.in.h:283
+msgid "ar:ha,hectare,p:hectares"
+msgstr ""
+
+#: ../data/units.xml.in.h:284
+msgid "Decare"
+msgstr "Dectárea"
+
+#: ../data/units.xml.in.h:285
+msgid "a:da,r:decare,p:decares"
+msgstr ""
+
+#: ../data/units.xml.in.h:286
+msgid "Barn"
+msgstr "Barn"
+
+#: ../data/units.xml.in.h:287
+msgid "ar:b,barn,p:barns"
+msgstr ""
+
+#: ../data/units.xml.in.h:288
+msgid "Rood"
+msgstr "Rood"
+
+#: ../data/units.xml.in.h:289
+msgid "r:rood,p:roods"
+msgstr ""
+
+#: ../data/units.xml.in.h:290
+msgid "Acre"
+msgstr "Acre"
+
+#: ../data/units.xml.in.h:291
+msgid "r:acre,p:acres"
+msgstr ""
+
+#: ../data/units.xml.in.h:292
+msgid "Section"
+msgstr "Sección"
+
+#: ../data/units.xml.in.h:293
+msgid "r:section,p:sections"
+msgstr ""
+
+#: ../data/units.xml.in.h:294
+msgid "Township"
+msgstr "Municipio de US Survey"
+
+#: ../data/units.xml.in.h:295
+msgid "r:township,p:townships"
+msgstr ""
+
+#: ../data/units.xml.in.h:296
+msgid "Square Foot"
+msgstr "Pie cuadrado"
+
+#: ../data/units.xml.in.h:297
+msgid "Square Inch"
+msgstr "Pulgada cuadrada"
+
+#: ../data/units.xml.in.h:298
+msgid "Square Mile"
+msgstr "Milla cuadrada"
+
+#: ../data/units.xml.in.h:299
+msgid "Volume"
+msgstr "Volumen"
+
+#: ../data/units.xml.in.h:300
+msgid "Cubic Meter"
+msgstr "Metro cúbico"
+
+#: ../data/units.xml.in.h:301
+msgid "Liter"
+msgstr "Litro"
+
+#: ../data/units.xml.in.h:302
+msgid "ar:L,a:l,liter,p:liters,litre,p:litres"
+msgstr ""
+
+#: ../data/units.xml.in.h:303
+msgid "Milliliter"
+msgstr "Mililitro"
+
+#: ../data/units.xml.in.h:304
+msgid "Centiliter"
+msgstr "Centilitro"
+
+#: ../data/units.xml.in.h:305
+msgid "Deciliter"
+msgstr "Decilitro"
+
+#: ../data/units.xml.in.h:306
+msgid "Cubic Inch"
+msgstr "Pulgada cúbica"
+
+#: ../data/units.xml.in.h:307
+msgid "Fuel Economy"
+msgstr "Economía de combustible"
+
+#: ../data/units.xml.in.h:308
+msgid "Liter per Kilometer"
+msgstr "Litro por kilómetro"
+
+#: ../data/units.xml.in.h:309
+msgid "Kilometer per Liter"
+msgstr "Kilómetro por litro"
+
+#: ../data/units.xml.in.h:310
+msgid "Miles per Gallon"
+msgstr "Millas por galón"
+
+#: ../data/units.xml.in.h:311
+msgid "a-cr:mpg"
+msgstr ""
+
+#: ../data/units.xml.in.h:312
+msgid "Cooking"
+msgstr "Cocina"
+
+#: ../data/units.xml.in.h:313
+msgid "Teaspoon"
+msgstr "Cuchara de té"
+
+#: ../data/units.xml.in.h:314
+msgid "r:teaspoon,p:teaspoons"
+msgstr ""
+
+#: ../data/units.xml.in.h:315
+msgid "Dessertspoon"
+msgstr "Cuchara de postres"
+
+#: ../data/units.xml.in.h:316
+msgid "r:dessertspoon,p:dessertspoons"
+msgstr ""
+
+#: ../data/units.xml.in.h:317
+msgid "Tablespoon"
+msgstr "Cuchara de mesa"
+
+#: ../data/units.xml.in.h:318
+msgid "r:tablespoon,p:tablespoons"
+msgstr ""
+
+#: ../data/units.xml.in.h:319
+msgid "Cup (U.S.)"
+msgstr "Taza estadounidense"
+
+#: ../data/units.xml.in.h:320
+msgid "r:cup,p:cups"
+msgstr ""
+
+#: ../data/units.xml.in.h:321
+msgid "Imperial Capacity"
+msgstr "Capacidad imperial"
+
+#: ../data/units.xml.in.h:322
+msgid "Imperial Fluid Ounce"
+msgstr "Onza fluida imperial"
+
+#: ../data/units.xml.in.h:323
+msgid "ar:UK_fl_oz,imperial_fluid_ounce,p:imperial_fluid_ounces"
+msgstr ""
+
+#: ../data/units.xml.in.h:324
+msgid "Imperial Gill"
+msgstr "Gill imperial"
+
+#: ../data/units.xml.in.h:325
+msgid "ar:UK_gi,imperial_gill,p:imperial_gills"
+msgstr ""
+
+#: ../data/units.xml.in.h:326
+msgid "Imperial Pint"
+msgstr "Pinta imperial"
+
+#: ../data/units.xml.in.h:327
+msgid "ar:UK_pt,imperial_pint,p:imperial_pints"
+msgstr ""
+
+#: ../data/units.xml.in.h:328
+msgid "Imperial Quart"
+msgstr "Cuartos imperiales"
+
+#: ../data/units.xml.in.h:329
+msgid "ar:UK_qt,imperial_quart,p:imperial_quarts"
+msgstr ""
+
+#: ../data/units.xml.in.h:330
+msgid "Imperial Gallon"
+msgstr "Galón imperial"
+
+#: ../data/units.xml.in.h:331
+msgid "ar:UK_gal,imperial_gallon,p:imperial_gallons"
+msgstr ""
+
+#: ../data/units.xml.in.h:332
+msgid "Imperial Minim"
+msgstr "Minim imperial"
+
+#: ../data/units.xml.in.h:333
+msgid "r:imperial_minim,p:imperial_minims"
+msgstr ""
+
+#: ../data/units.xml.in.h:334
+msgid "Imperial Fluid Scuple"
+msgstr "Escrúpulo líquido imperial"
+
+#: ../data/units.xml.in.h:335
+msgid "r:imperial_fluid_scuple,p:imperial_fluid_scuples"
+msgstr ""
+
+#: ../data/units.xml.in.h:336
+msgid "Imperial Fluid Drachm"
+msgstr "Dracma líquido imperial"
+
+#: ../data/units.xml.in.h:337
+msgid "ar:UK_fl_dr,imperial_fluid_drachm,p:imperial_fluid_drachms"
+msgstr ""
+
+#: ../data/units.xml.in.h:338
+msgid "Imperial Bushel"
+msgstr "Bushel imperial"
+
+#: ../data/units.xml.in.h:339
+msgid "ar:UK_bu,imperial_bushel,p:imperial_bushels"
+msgstr ""
+
+#: ../data/units.xml.in.h:340
+msgid "U.S. Capacity"
+msgstr "Capacidad estadounidense"
+
+#: ../data/units.xml.in.h:341
+msgid "U.S. Fluid Ounce"
+msgstr "Onza fluida estadounidense"
+
+#: ../data/units.xml.in.h:342
+msgid "ar:fl_oz,fluid_ounce,p:fluid_ounces"
+msgstr ""
+
+#: ../data/units.xml.in.h:343
+msgid "U.S. Gill"
+msgstr "Gill estadounidense"
+
+#: ../data/units.xml.in.h:344
+msgid "ar:gi,gill,p:gills"
+msgstr ""
+
+#: ../data/units.xml.in.h:345
+msgid "U.S. Liquid Pints"
+msgstr "Pinta líquida estadounidense"
+
+#: ../data/units.xml.in.h:346
+msgid "ar:liq_pt,liquid_pint,p:liquid_pints"
+msgstr ""
+
+#: ../data/units.xml.in.h:347
+msgid "U.S. Liquid Quarts"
+msgstr "Cuarto líquido estadounidense"
+
+#: ../data/units.xml.in.h:348
+msgid "ar:liq_qt,liquid_quart,p:liquid_quarts"
+msgstr ""
+
+#: ../data/units.xml.in.h:349
+msgid "U.S. Minim"
+msgstr "Minim estadounidense"
+
+#: ../data/units.xml.in.h:350
+msgid "r:minim,p:minims"
+msgstr ""
+
+#: ../data/units.xml.in.h:351
+msgid "U.S. Fluid Drachm"
+msgstr "Dracma líquido estadounidense"
+
+#: ../data/units.xml.in.h:352
+msgid "ar:fl_dr,fluid_drachm,p:fluid_drachms"
+msgstr ""
+
+#: ../data/units.xml.in.h:353
+msgid "U.S. Dry Pint"
+msgstr "Pinta seca estadounidense"
+
+#: ../data/units.xml.in.h:354
+msgid "ar:dry_pt,dry_pint,p:dry_pints"
+msgstr ""
+
+#: ../data/units.xml.in.h:355
+msgid "U.S. Dry Quart"
+msgstr "Cuarta seca estadounidense"
+
+#: ../data/units.xml.in.h:356
+msgid "ar:dry_qt,dry_quart,p:dry_quarts"
+msgstr ""
+
+#: ../data/units.xml.in.h:357
+msgid "U.S. Peck"
+msgstr "Peck estadounidense"
+
+#: ../data/units.xml.in.h:358
+msgid "ar:pk,peck,p:pecks"
+msgstr ""
+
+#: ../data/units.xml.in.h:359
+msgid "U.S. Bushel"
+msgstr "Bushel estadounidense"
+
+#: ../data/units.xml.in.h:360
+msgid "ar:bu,bushel,p:bushels"
+msgstr ""
+
+#: ../data/units.xml.in.h:361
+msgid "U.S. Gallon"
+msgstr "Galón estadounidense"
+
+#: ../data/units.xml.in.h:362
+msgid "ar:gal,gallon,p:gallons"
+msgstr ""
+
+#: ../data/units.xml.in.h:363
+msgid "U.S. Barrel (oil)"
+msgstr "Barril (petróleo) estadounidense"
+
+#: ../data/units.xml.in.h:364
+msgid "ar:bbl,barrel,p:barrels"
+msgstr ""
+
+#: ../data/units.xml.in.h:365
+msgid "Specific Volume"
+msgstr "Volumen específico"
+
+#: ../data/units.xml.in.h:366
+msgid "Cubic Meter per Kilogram"
+msgstr "Metro cúbico por kilogramo"
+
+#: ../data/units.xml.in.h:367
+msgid "Speed"
+msgstr "Velocidad"
+
+#: ../data/units.xml.in.h:368
+msgid "Meter per Second"
+msgstr "Metro por segundo"
+
+#: ../data/units.xml.in.h:369
+msgid "Kilometer per Hour"
+msgstr "Kilómetro por hora"
+
+#: ../data/units.xml.in.h:370
+msgid "Nautical Mile per Hour"
+msgstr "Milla náutica por hora"
+
+#: ../data/units.xml.in.h:371
+msgid "Knot"
+msgstr "Nudo"
+
+#: ../data/units.xml.in.h:372
+msgid "r:knot,p:knots"
+msgstr ""
+
+#: ../data/units.xml.in.h:373
+msgid "Miles per Hour"
+msgstr "Milla por hora"
+
+#: ../data/units.xml.in.h:374
+msgid "a-cr:mph"
+msgstr ""
+
+#: ../data/units.xml.in.h:375
+msgid "Speed of Light (Natural Unit of Velocity)"
+msgstr "Velocidad de la luz (unidad natural de velocidad)"
+
+#: ../data/units.xml.in.h:376
+msgid "Atomic Unit of Velocity"
+msgstr "Unidad atómica de velocidad"
+
+#: ../data/units.xml.in.h:377
+msgid "Acceleration"
+msgstr "Aceleración"
+
+#: ../data/units.xml.in.h:378
+msgid "Meter per Second Squared"
+msgstr "Metro por segundo al cuadrado"
+
+#: ../data/units.xml.in.h:379
+msgid "Galileo"
+msgstr "Gal"
+
+#: ../data/units.xml.in.h:380
+msgid "ar:Gal,galileo,p:galileos"
+msgstr ""
+
+#: ../data/units.xml.in.h:381
+msgid "Gee"
+msgstr "Ge"
+
+#: ../data/units.xml.in.h:382
+msgid "r:gee,p:gees"
+msgstr ""
+
+#: ../data/units.xml.in.h:383
+msgid "Magnetism"
+msgstr "Magnetismo"
+
+#: ../data/units.xml.in.h:384
+msgid "Wave Number"
+msgstr "Número de onda"
+
+#: ../data/units.xml.in.h:385
+msgid "Reciprocal Meter"
+msgstr "Longitud recíproca"
+
+#: ../data/units.xml.in.h:386
+msgid "Magnetic Field Strength"
+msgstr "Intensidad de campo magnético"
+
+#: ../data/units.xml.in.h:387
+msgid "Ampere per Meter"
+msgstr "Amperio por metro"
+
+#: ../data/units.xml.in.h:388
+msgid "Oersted"
+msgstr "Oersted"
+
+#: ../data/units.xml.in.h:389
+msgid "ar:Oe,oersted,p:oersteds"
+msgstr ""
+
+#: ../data/units.xml.in.h:390
+msgid "Magnetic Flux"
+msgstr "Flujo magnético"
+
+#: ../data/units.xml.in.h:391
+msgid "Volt Seconds"
+msgstr "Voltio segundo"
+
+#: ../data/units.xml.in.h:392
+msgid "Weber"
+msgstr "Weber"
+
+#: ../data/units.xml.in.h:393
+msgid "ar:Wb,weber,p:webers"
+msgstr ""
+
+#: ../data/units.xml.in.h:394
+msgid "Maxwell"
+msgstr "Maxwell"
+
+#: ../data/units.xml.in.h:395
+msgid "ar:Mx,maxwell,p:maxwells"
+msgstr ""
+
+#: ../data/units.xml.in.h:396
+msgid "Magnetic Flux Density"
+msgstr "Densidad de flujo magnético"
+
+#: ../data/units.xml.in.h:397
+msgid "Weber per Meter Squared"
+msgstr "Weber por metro cuadrado"
+
+#: ../data/units.xml.in.h:398
+msgid "Tesla"
+msgstr "Tesla"
+
+#: ../data/units.xml.in.h:399
+msgid "ar:T,tesla,p:teslas"
+msgstr ""
+
+#: ../data/units.xml.in.h:400
+msgid "Gauss"
+msgstr "Gauss"
+
+#: ../data/units.xml.in.h:401
+msgid "r:gauss"
+msgstr ""
+
+#: ../data/units.xml.in.h:402
+msgid "Atomic Unit of Magnetic Flux Density"
+msgstr "Unidad atómica de densidad de flujo magnético"
+
+#: ../data/units.xml.in.h:403
+msgid "Magnetic Dipole Moment"
+msgstr "Momento dipolo magnético"
+
+#: ../data/units.xml.in.h:404
+msgid "Joule per Tesla"
+msgstr "Julio por tesla"
+
+#: ../data/units.xml.in.h:405
+msgid "Atomic Unit of Magnetic Dipole Moment"
+msgstr "Unidad atómica de momento dipolo magnético"
+
+#: ../data/units.xml.in.h:406
+msgid "Force"
+msgstr "Fuerza"
+
+#: ../data/units.xml.in.h:407
+msgid "Meter Kilogram per Second Squared"
+msgstr "Metro kilogramo por segundo al cuadrado"
+
+#: ../data/units.xml.in.h:408
+msgid "Newton"
+msgstr "Newton"
+
+#: ../data/units.xml.in.h:409
+msgid "ar:N,newton,p:newtons"
+msgstr ""
+
+#: ../data/units.xml.in.h:410
+msgid "Dyne"
+msgstr "Dina"
+
+#: ../data/units.xml.in.h:411
+msgid "ar:dyn,dyne,p:dynes"
+msgstr ""
+
+#: ../data/units.xml.in.h:412
+msgid "Pound-force"
+msgstr "Libra-fuerza"
+
+#: ../data/units.xml.in.h:413
+msgid "ar:lbf,pound_force"
+msgstr ""
+
+#: ../data/units.xml.in.h:414
+msgid "Pound Foot per Second Squared"
+msgstr "Libra pie por segundo al cuadrado"
+
+#: ../data/units.xml.in.h:415
+msgid "Poundal"
+msgstr "Poundal"
+
+#: ../data/units.xml.in.h:416
+msgid "r:poundal,p:poundals,a:pdl"
+msgstr ""
+
+#: ../data/units.xml.in.h:417
+msgid "Pond (Gram-Force)"
+msgstr "Pondio (gramo-fuerza)"
+
+#: ../data/units.xml.in.h:418
+msgid "r:pond,p:ponds,a:gf"
+msgstr ""
+
+#: ../data/units.xml.in.h:419
+msgid "Kilopond (Kilogram-Force)"
+msgstr "Kilopondio (kilogramo-fuerza)"
+
+#: ../data/units.xml.in.h:420
+msgid "Atomic Unit of Force"
+msgstr "Unidad atómica de fuerza"
+
+#: ../data/units.xml.in.h:421
+msgid "Moment of Force"
+msgstr "Momento de fuerza"
+
+#: ../data/units.xml.in.h:422
+msgid "Newton Meter"
+msgstr "Newton metro"
+
+#: ../data/units.xml.in.h:423
+msgid "Momentum"
+msgstr "Momento"
+
+#: ../data/units.xml.in.h:424
+msgid "Kilogram Meter per Second"
+msgstr "Kilogramo metro por segundo"
+
+#: ../data/units.xml.in.h:425
+msgid "Electronvolt Momentum"
+msgstr "Momento de electronvoltio"
+
+#: ../data/units.xml.in.h:426
+msgid "Natural Unit of Momentum"
+msgstr "Unidad natural de momento"
+
+#: ../data/units.xml.in.h:427
+msgid "Atomic Unit of Momentum"
+msgstr "Unidad atómica de momento"
+
+#: ../data/units.xml.in.h:428
+msgid "Pressure"
+msgstr "Presión"
+
+#: ../data/units.xml.in.h:429
+msgid "Newton per Meter Squared"
+msgstr "Newton por metro cuadrado"
+
+#: ../data/units.xml.in.h:430
+msgid "Pound-force per Square Inch"
+msgstr "Libra-fuerza por pulgada cuadrada"
+
+#: ../data/units.xml.in.h:431
+msgid "Pascal"
+msgstr "Pascal"
+
+#: ../data/units.xml.in.h:432
+msgid "ar:Pa,pascal,p:pascals"
+msgstr ""
+
+#: ../data/units.xml.in.h:433
+msgid "Kilogram-force per Square Centimetre"
+msgstr "Kilogramo-fuerza por centímetro cuadrado"
+
+#: ../data/units.xml.in.h:434
+msgid "Pound-force per Square Inch (psi)"
+msgstr "Libra-fuerza por pulgada cuadrada (psi)"
+
+#: ../data/units.xml.in.h:435
+msgid "a-cr:psi"
+msgstr ""
+
+#: ../data/units.xml.in.h:436
+msgid "Bar"
+msgstr "Bar"
+
+#: ../data/units.xml.in.h:437
+msgid "r:bar,p:bars"
+msgstr ""
+
+#: ../data/units.xml.in.h:438
+msgid "Atmosphere"
+msgstr "Atmósfera"
+
+#: ../data/units.xml.in.h:439
+msgid "ar:atm,atmosphere,p:atmospheres"
+msgstr ""
+
+#: ../data/units.xml.in.h:440
+msgid "Torr"
+msgstr "Torr"
+
+#: ../data/units.xml.in.h:441
+msgid "r:torr,p:torrs"
+msgstr ""
+
+#: ../data/units.xml.in.h:442
+msgid "Millimeter of Mercury"
+msgstr "Milímetro de mercurio"
+
+#: ../data/units.xml.in.h:443
+msgid "ar:mmHg"
+msgstr ""
+
+#: ../data/units.xml.in.h:444
+msgid "Inch of Mercury"
+msgstr "Pulgada de mercurio"
+
+#: ../data/units.xml.in.h:445
+msgid "ar:inHg"
+msgstr ""
+
+#: ../data/units.xml.in.h:446
+msgid "Dynamic Viscosity"
+msgstr "Viscosidad dinámica"
+
+#: ../data/units.xml.in.h:447
+msgid "Pascal Second"
+msgstr "Pascal segundo"
+
+#: ../data/units.xml.in.h:448
+msgid "Poise"
+msgstr "Poise"
+
+#: ../data/units.xml.in.h:449
+msgid "ar:P,poise,p:poises"
+msgstr ""
+
+#: ../data/units.xml.in.h:450
+msgid "Kinematic Viscosity"
+msgstr "Viscosidad cinemática"
+
+#: ../data/units.xml.in.h:451
+msgid "Square Meter per Second"
+msgstr "Metro cuadrado por segundo"
+
+#: ../data/units.xml.in.h:452
+msgid "Stokes"
+msgstr "Stokes"
+
+#: ../data/units.xml.in.h:453
+msgid "ar:St,stokes"
+msgstr ""
+
+#: ../data/units.xml.in.h:454
+msgid "Surface Tension"
+msgstr "Tensión superficial"
+
+#: ../data/units.xml.in.h:455
+msgid "Newton per Meter"
+msgstr "Newton por metro"
+
+#: ../data/units.xml.in.h:456
+msgid "Energy"
+msgstr "Energía"
+
+#: ../data/units.xml.in.h:457
+msgid "Joule"
+msgstr "Julio"
+
+#: ../data/units.xml.in.h:458
+msgid "ar:J,joule,p:joules"
+msgstr ""
+
+#: ../data/units.xml.in.h:459
+msgid "Watt Hour"
+msgstr "Vatio hora"
+
+#: ../data/units.xml.in.h:460
+msgid "Kilowatt Hour"
+msgstr "Kilovatio hora"
+
+#: ../data/units.xml.in.h:461
+msgid "Calorie (international table)"
+msgstr "Caloría (tabla internacional)"
+
+#: ../data/units.xml.in.h:462
+msgid "ais:cal_IT,ar:cal,c:calorie,cp:calories"
+msgstr ""
+
+#: ../data/units.xml.in.h:463
+msgid "Calorie (capital C)"
+msgstr "Caloría (C mayúscula)"
+
+#: ../data/units.xml.in.h:464
+msgid "cr:Calorie,cp:Calories"
+msgstr ""
+
+#: ../data/units.xml.in.h:465
+msgid "Calorie (thermochemical)"
+msgstr "Caloría (termoquímica)"
+
+#: ../data/units.xml.in.h:466
+msgid "ars:cal_th"
+msgstr ""
+
+#: ../data/units.xml.in.h:467
+msgid "Gram of TNT"
+msgstr "Gramo de TNT"
+
+#: ../data/units.xml.in.h:468
+msgid "a-cr:gTNT,gramTNT"
+msgstr ""
+
+#: ../data/units.xml.in.h:469
+msgid "Ton of TNT"
+msgstr "Tonelada de TNT"
+
+#: ../data/units.xml.in.h:470
+msgid "a-cr:tTNT,tonTNT"
+msgstr ""
+
+#: ../data/units.xml.in.h:471
+msgid "Calorie (15 degrees Celsius)"
+msgstr "Caloría (15 grados Celsius)"
+
+#: ../data/units.xml.in.h:472
+msgid "ars:cal_fifteen"
+msgstr ""
+
+#: ../data/units.xml.in.h:473
+msgid "Calorie (mean)"
+msgstr "Caloría (media)"
+
+#: ../data/units.xml.in.h:474
+msgid "ars:cal_mean"
+msgstr ""
+
+#: ../data/units.xml.in.h:475
+msgid "British Thermal Unit (IT)"
+msgstr "Unidad térmica británica (BTU)"
+
+#: ../data/units.xml.in.h:476
+msgid "ar:Btu"
+msgstr ""
+
+#: ../data/units.xml.in.h:477
+msgid "Electronvolt"
+msgstr "Electronvoltio"
+
+#: ../data/units.xml.in.h:478
+msgid "ar:eV,electronvolt,p:electronvolts"
+msgstr ""
+
+#: ../data/units.xml.in.h:479
+msgid "Erg"
+msgstr "Ergio"
+
+#: ../data/units.xml.in.h:480
+msgid "r:erg,p:ergs"
+msgstr ""
+
+#: ../data/units.xml.in.h:481
+msgid "Foe"
+msgstr "Foe"
+
+#: ../data/units.xml.in.h:482
+msgid "r:foe,p:foes"
+msgstr ""
+
+#: ../data/units.xml.in.h:483
+msgid "Foot-Pound Force"
+msgstr "Pie-libra fuerza"
+
+#: ../data/units.xml.in.h:484
+msgid "Hartree (Atomic Unit of Energy)"
+msgstr "Hartree (unidad atómica de energía)"
+
+#: ../data/units.xml.in.h:485
+msgid "Rydberg (unit)"
+msgstr "Rydberg (unidad)"
+
+#: ../data/units.xml.in.h:486
+msgid "Natural Unit of Energy"
+msgstr "Unidad natural de energía"
+
+#: ../data/units.xml.in.h:487
+msgid "Specific Energy"
+msgstr "Energía específica"
+
+#: ../data/units.xml.in.h:488
+msgid "Joule per Kilogram"
+msgstr "Julio por kilogramo"
+
+#: ../data/units.xml.in.h:489
+msgid "Power"
+msgstr "Potencia"
+
+#: ../data/units.xml.in.h:490
+msgid "Joule per Second"
+msgstr "Julio por segundo"
+
+#: ../data/units.xml.in.h:491
+msgid "Watt"
+msgstr "Vatio"
+
+#: ../data/units.xml.in.h:492
+msgid "ar:W,watt,p:watts"
+msgstr ""
+
+#: ../data/units.xml.in.h:493
+msgid "Horse Power"
+msgstr "Caballo de fuerza"
+
+#: ../data/units.xml.in.h:494
+msgid "ar:hp,horsepower,p:horsepowers"
+msgstr ""
+
+#: ../data/units.xml.in.h:495
+msgid "Pferdest&#xE4;rke"
+msgstr ""
+
+#: ../data/units.xml.in.h:496
+msgid "ar:PS,u:pferdest&#xE4;rke"
+msgstr ""
+
+#: ../data/units.xml.in.h:497
+msgid "Decibel Milliwatt"
+msgstr "Decibel milivatio"
+
+#: ../data/units.xml.in.h:498
+msgid "ar:dBm"
+msgstr ""
+
+#: ../data/units.xml.in.h:499
+msgid "Decibel Watt"
+msgstr "Decibel vatio"
+
+#: ../data/units.xml.in.h:500
+msgid "ar:dBW"
+msgstr ""
+
+#: ../data/units.xml.in.h:501
+msgid "Entropy"
+msgstr "Entropía"
+
+#: ../data/units.xml.in.h:502
+msgid "Joule per Kelvin"
+msgstr "Julio por kelvin"
+
+#: ../data/units.xml.in.h:503
+msgid "Boltzmann (unit)"
+msgstr "Boltzmann (unidad)"
+
+#: ../data/units.xml.in.h:504
+msgid "Specific Entropy"
+msgstr "Entropía específica"
+
+#: ../data/units.xml.in.h:505
+msgid "Joule per Kilogram Kelvin"
+msgstr "Julio por kilogramo kelvin"
+
+#: ../data/units.xml.in.h:506
+msgid "Thermal Conductivity"
+msgstr "Conductividad térmica"
+
+#: ../data/units.xml.in.h:507
+msgid "Watt per Meter Kelvin"
+msgstr "Vatio por metro kelvin"
+
+#: ../data/units.xml.in.h:508
+msgid "Energy Density"
+msgstr "Densidad de energía"
+
+#: ../data/units.xml.in.h:509
+msgid "Joule per Cubic Meter"
+msgstr "Julio por metro cúbico"
+
+#: ../data/units.xml.in.h:510
+msgid "Molar Energy"
+msgstr "Energía molar"
+
+#: ../data/units.xml.in.h:511
+msgid "Joule per Mole"
+msgstr "Julio por mol"
+
+#: ../data/units.xml.in.h:512
+msgid "Molar Entropy"
+msgstr "Entropía molar"
+
+#: ../data/units.xml.in.h:513
+msgid "Joule per Mole Kelvin"
+msgstr "Julio por mol kelvin"
+
+#: ../data/units.xml.in.h:514
+msgid "Action"
+msgstr "Acción"
+
+#: ../data/units.xml.in.h:515
+msgid "Joule Second"
+msgstr "Julio segundo"
+
+#: ../data/units.xml.in.h:516
+msgid "Reduced Planck (Atomic/Natural Unit of Action)"
+msgstr "Planck reducido (unidad atómica/natural de acción)"
+
+#: ../data/units.xml.in.h:517
+msgid "Radioactivity"
+msgstr "Radioactividad"
+
+#: ../data/units.xml.in.h:518
+msgid "Becquerel"
+msgstr "Becquerel"
+
+#: ../data/units.xml.in.h:519
+msgid "ar:Bq,becquerel,p:becquerels"
+msgstr ""
+
+#: ../data/units.xml.in.h:520
+msgid "Curie"
+msgstr "Curio"
+
+#: ../data/units.xml.in.h:521
+msgid "ar:Ci,curie,p:curies"
+msgstr ""
+
+#: ../data/units.xml.in.h:522
+msgid "Absorbed Dose"
+msgstr "Dosis absorbida"
+
+#: ../data/units.xml.in.h:523
+msgid "Gray"
+msgstr "Gray"
+
+#: ../data/units.xml.in.h:524
+msgid "ar:Gy,gray,p:grays"
+msgstr ""
+
+#: ../data/units.xml.in.h:525
+msgid "Rad"
+msgstr "Rad"
+
+#: ../data/units.xml.in.h:526
+msgid "r:rad_radioactivity"
+msgstr ""
+
+#: ../data/units.xml.in.h:527
+msgid "Dose Equivalent"
+msgstr "Dosis equivalente"
+
+#: ../data/units.xml.in.h:528
+msgid "Sievert"
+msgstr "Sievert"
+
+#: ../data/units.xml.in.h:529
+msgid "ar:Sv,sievert,p:sieverts"
+msgstr ""
+
+#: ../data/units.xml.in.h:530
+msgid "Rem"
+msgstr "Rem"
+
+#: ../data/units.xml.in.h:531
+msgid "r:rem_radioactivity"
+msgstr ""
+
+#: ../data/units.xml.in.h:532
+msgid "Exposure"
+msgstr "Exposición"
+
+#: ../data/units.xml.in.h:533
+msgid "Coulomb per Kilogram"
+msgstr "Culombio por kilogramo"
+
+#: ../data/units.xml.in.h:534
+msgid "Roentgen"
+msgstr "Roentgen"
+
+#: ../data/units.xml.in.h:535
+msgid "ar:R,roentgen,p:roentgens"
+msgstr ""
+
+#: ../data/units.xml.in.h:536
+msgid "Absorbed Dose Rate"
+msgstr "Tasa de dosis absorbida"
+
+#: ../data/units.xml.in.h:537
+msgid "Gray per Second"
+msgstr "Grays por segundo"
+
+#: ../data/units.xml.in.h:538
+msgid "Ratio"
+msgstr "Proporción"
+
+#: ../data/units.xml.in.h:539
+msgid "Neper"
+msgstr "Neperio"
+
+#: ../data/units.xml.in.h:540
+msgid "ar:Np,neper,p:nepers"
+msgstr ""
+
+#: ../data/units.xml.in.h:541
+msgid "Bel"
+msgstr "Bel"
+
+#: ../data/units.xml.in.h:542
+msgid "ar:B,bel,p:bels"
+msgstr ""
+
+#: ../data/units.xml.in.h:543
+msgid "Decibel"
+msgstr "Decibelio"
+
+#: ../data/units.xml.in.h:544
+msgid "Information"
+msgstr "Información"
+
+#: ../data/units.xml.in.h:545
+msgid "Bit"
+msgstr "Bit"
+
+#: ../data/units.xml.in.h:546
+msgid "r:bit,p:bits"
+msgstr ""
+
+#: ../data/units.xml.in.h:547
+msgid "Byte (8-bit)"
+msgstr "Byte (8 bits)"
+
+#: ../data/units.xml.in.h:548
+msgid "r:byte,p:bytes,octet,p:octets"
+msgstr ""
+
+#: ../data/units.xml.in.h:549
+msgid "Nibble"
+msgstr "Nibble"
+
+#: ../data/units.xml.in.h:550
+msgid "r:nibble,p:nibbles,nybble,p:nybbles,semioctet,p:semioctets"
+msgstr ""
+
+#: ../data/units.xml.in.h:551
+msgid "Tribble"
+msgstr "Tribble"
+
+#: ../data/units.xml.in.h:552
+msgid "r:tribble,p:tribbles"
+msgstr ""
+
+#: ../data/units.xml.in.h:553
+msgid "Word (16-bit)"
+msgstr "Palabra (16 bits)"
+
+#: ../data/units.xml.in.h:554
+msgid "r:word,p:words"
+msgstr ""
+
+#: ../data/units.xml.in.h:555
+msgid "Kilobyte"
+msgstr "Kilobyte"
+
+#: ../data/units.xml.in.h:556
+msgid "Kibibyte"
+msgstr "Kibibyte"
+
+#: ../data/units.xml.in.h:557
+msgid "Mebibyte"
+msgstr "Mebibyte"
+
+#: ../data/units.xml.in.h:558
+msgid "Gibibyte"
+msgstr "Gibibyte"
+
+#: ../data/units.xml.in.h:559
+msgid "Megabyte"
+msgstr "Megabyte"
+
+#: ../data/units.xml.in.h:560
+msgid "Gigabyte"
+msgstr "Gigabyte"
+
+#: ../data/units.xml.in.h:561
+msgid "Terabyte"
+msgstr "Terabyte"
+
+#: ../data/units.xml.in.h:562
+msgid "Kilobit"
+msgstr "Kilobit"
+
+#: ../data/units.xml.in.h:563
+msgid "Kibibit"
+msgstr "Kibibit"
+
+#: ../data/units.xml.in.h:564
+msgid "Mebibit"
+msgstr "mebibit"
+
+#: ../data/units.xml.in.h:565
+msgid "Gibibit"
+msgstr "Gibibit"
+
+#: ../data/units.xml.in.h:566
+msgid "Megabit"
+msgstr "Megabit"
+
+#: ../data/units.xml.in.h:567
+msgid "Gigabit"
+msgstr "Gigabit"
+
+#: ../data/units.xml.in.h:568
+msgid "Terabit"
+msgstr "Terabit"
+
+#: ../data/units.xml.in.h:569
+msgid "Typography"
+msgstr "Tipografía"
+
+#: ../data/units.xml.in.h:570
+msgid "PostScript Point"
+msgstr "Punto de PostScript"
+
+#: ../data/units.xml.in.h:571
+msgid "ar:pt,a:pts,point,p:points"
+msgstr ""
+
+#: ../data/units.xml.in.h:572
+msgid "PostScript Pica"
+msgstr "Pica de PostScript"
+
+#: ../data/units.xml.in.h:573
+msgid "r:pica,p:picas"
+msgstr ""
+
+#: ../data/units.xml.in.h:574
+msgid "ATA Pica"
+msgstr "Pica de ATA"
+
+#: ../data/units.xml.in.h:575
+msgid "r:ata_pica,p:ata_picas"
+msgstr ""
+
+#: ../data/units.xml.in.h:576
+msgid "ATA Point"
+msgstr "Punto de ATA"
+
+#: ../data/units.xml.in.h:577
+msgid "r:ata_point,a:ata_pt,p:ata_points"
+msgstr ""
+
+#: ../data/units.xml.in.h:578
+msgid "New Didot Point"
+msgstr "Punto de nuevo Didot"
+
+#: ../data/units.xml.in.h:579
+msgid "r:new_didot"
+msgstr ""
+
+#: ../data/units.xml.in.h:580
+msgid "Didot Point"
+msgstr "Punto de Didot"
+
+#: ../data/units.xml.in.h:581
+msgid "r:didot,a:dd"
+msgstr ""
+
+#: ../data/units.xml.in.h:582
+msgid "Cicero"
+msgstr "Cícero"
+
+#: ../data/units.xml.in.h:583
+msgid "r:cicero"
+msgstr ""
+
+#: ../data/variables.xml.in.h:1
+msgid "Small Numbers"
+msgstr "Números pequeños"
+
+#: ../data/variables.xml.in.h:2
+msgid "Per Mille"
+msgstr "Por mil"
+
+#: ../data/variables.xml.in.h:3
+msgid "r:permille,au:&#x2030;"
+msgstr ""
+
+#: ../data/variables.xml.in.h:4
+msgid "Per Myriad"
+msgstr "Por diez mil"
+
+#: ../data/variables.xml.in.h:5
+msgid "r:permyriad,au:&#x2031;"
+msgstr ""
+
+#: ../data/variables.xml.in.h:6
+msgid "Percent"
+msgstr "Por ciento"
+
+#: ../data/variables.xml.in.h:8
+#, no-c-format
+msgid "a:%,r:percent"
+msgstr ""
+
+#: ../data/variables.xml.in.h:9
+msgid "Large Numbers"
+msgstr "Números grandes"
+
+#: ../data/variables.xml.in.h:10
+msgid "Googolplex"
+msgstr "Gúgolplex"
+
+#: ../data/variables.xml.in.h:11
+msgid "r:googolplex"
+msgstr ""
+
+#: ../data/variables.xml.in.h:12
+msgid "Googol"
+msgstr "Gúgol"
+
+#: ../data/variables.xml.in.h:13
+msgid "r:googol"
+msgstr ""
+
+#: ../data/variables.xml.in.h:14
+msgid "Centillion"
+msgstr "1E303"
+
+#: ../data/variables.xml.in.h:15
+msgid "-r:centillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:16
+msgid "Vigintillion"
+msgstr "Mil decillones"
+
+#: ../data/variables.xml.in.h:17
+msgid "-r:vigintillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:18
+msgid "Novemdecillion"
+msgstr "Decillón"
+
+#: ../data/variables.xml.in.h:19
+msgid "-r:novemdecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:20
+msgid "Octodecillion"
+msgstr "Mil nonillones"
+
+#: ../data/variables.xml.in.h:21
+msgid "-r:octodecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:22
+msgid "Septendecillion"
+msgstr "Nonillón"
+
+#: ../data/variables.xml.in.h:23
+msgid "-r:septendecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:24
+msgid "Sexdecillion"
+msgstr "Mil octillones"
+
+#: ../data/variables.xml.in.h:25
+msgid "-r:sexdecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:26
+msgid "Quindecillion"
+msgstr "Octillón"
+
+#: ../data/variables.xml.in.h:27
+msgid "-r:quindecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:28
+msgid "Quattuordecillion"
+msgstr "Mil septillones"
+
+#: ../data/variables.xml.in.h:29
+msgid "-r:quattuordecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:30
+msgid "Tredecillion"
+msgstr "Septillón"
+
+#: ../data/variables.xml.in.h:31
+msgid "-r:tredecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:32
+msgid "Duodecillion"
+msgstr "Mil sextillones"
+
+#: ../data/variables.xml.in.h:33
+msgid "-r:duodecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:34
+msgid "Undecillion"
+msgstr "Sextillón"
+
+#: ../data/variables.xml.in.h:35
+msgid "-r:undecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:36
+msgid "Decillion"
+msgstr "Mil quintillones"
+
+#: ../data/variables.xml.in.h:37
+msgid "-r:decillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:38
+msgid "Nonillion"
+msgstr "Quintillón"
+
+#: ../data/variables.xml.in.h:39
+msgid "-r:nonillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:40
+msgid "Octillion"
+msgstr "Mil cuatrillones"
+
+#: ../data/variables.xml.in.h:41
+msgid "-r:octillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:42
+msgid "Septillion"
+msgstr "Cuatrillón"
+
+#: ../data/variables.xml.in.h:43
+msgid "-r:septillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:44
+msgid "Sextillion"
+msgstr "Mil trillones"
+
+#: ../data/variables.xml.in.h:45
+msgid "-r:sextillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:46
+msgid "Quintillion"
+msgstr "Trillón"
+
+#: ../data/variables.xml.in.h:47
+msgid "-r:quintillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:48
+msgid "Quadrillion"
+msgstr "Mil billones"
+
+#: ../data/variables.xml.in.h:49
+msgid "-r:quadrillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:50
+msgid "Trillion"
+msgstr "Billón"
+
+#: ../data/variables.xml.in.h:51
+msgid "-r:trillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:52
+msgid "Billion"
+msgstr "Mil millones"
+
+#: ../data/variables.xml.in.h:53
+msgid "-r:billion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:54
+msgid "Million"
+msgstr "Millón"
+
+#: ../data/variables.xml.in.h:55
+msgid "-r:million"
+msgstr ""
+
+#: ../data/variables.xml.in.h:56
+msgid "Thousand"
+msgstr "Mil"
+
+#: ../data/variables.xml.in.h:57
+msgid "-r:thousand"
+msgstr ""
+
+#: ../data/variables.xml.in.h:58
+msgid "Hundred"
+msgstr "Cien"
+
+#: ../data/variables.xml.in.h:59
+msgid "-r:hundred"
+msgstr ""
+
+#: ../data/variables.xml.in.h:60
+msgid "Physical Constants"
+msgstr "Constantes físicas"
+
+#: ../data/variables.xml.in.h:61
+msgid "Universal Constants"
+msgstr "Constantes universales"
+
+#: ../data/variables.xml.in.h:62
+msgid "Characteristic Impedance of Vacuum"
+msgstr "Impedancia característica del vacío"
+
+#: ../data/variables.xml.in.h:63
+msgid "Electric Constant (Permittivity of Free Space)"
+msgstr "Constante eléctrica (Permitividad de espacio libre)"
+
+#: ../data/variables.xml.in.h:64
+msgid "Magnetic Constant (Permeability of Free Space)"
+msgstr "Constante magnética (Permeabilidad de espacio libre)"
+
+#: ../data/variables.xml.in.h:65
+msgid "Planck Constant"
+msgstr "Constante de Planck"
+
+#: ../data/variables.xml.in.h:66
+msgid "Reduced Planck Constant (Dirac constant)"
+msgstr "Constante de Planck reducida (constante de Dirac)"
+
+#: ../data/variables.xml.in.h:67
+msgid "Newtonian Constant of Gravitation"
+msgstr "Constante de gravitación universal"
+
+#: ../data/variables.xml.in.h:68
+msgid "Speed of Light in Vacuum"
+msgstr "Velocidad de la luz en el vacío"
+
+#: ../data/variables.xml.in.h:69
+msgid "Standard Acceleration due to Gravity"
+msgstr "Aceleración estándar debida a la gravedad"
+
+#: ../data/variables.xml.in.h:70
+msgid "Electromagnetic Constants"
+msgstr "Constantes electromagnéticas"
+
+#: ../data/variables.xml.in.h:71
+msgid "Bohr Magneton"
+msgstr "Magnetón de Bohr"
+
+#: ../data/variables.xml.in.h:72
+msgid "Conductance Quantum"
+msgstr "Cuanto de conductancia"
+
+#: ../data/variables.xml.in.h:73
+msgid "Coulomb's Constant (Electric Force Constant)"
+msgstr "Constante de Coulomb (constante de fuerza eléctrica)"
+
+#: ../data/variables.xml.in.h:74
+msgid "Elementary Charge"
+msgstr "Carga elemental"
+
+#: ../data/variables.xml.in.h:75
+msgid "Inverse of Conductance Quantum"
+msgstr "Inverso del cuanto de conductancia"
+
+#: ../data/variables.xml.in.h:76
+msgid "Josephson Constant"
+msgstr "Constante de Josephson"
+
+#: ../data/variables.xml.in.h:77
+msgid "Josephson Constant (conventional value)"
+msgstr "Constante de Josephson (valor convencional)"
+
+#: ../data/variables.xml.in.h:78
+msgid "Magnetic Flux Quantum"
+msgstr "Cuanto de flujo magnético"
+
+#: ../data/variables.xml.in.h:79
+msgid "Nuclear Magneton"
+msgstr "Magnetón nuclear"
+
+#: ../data/variables.xml.in.h:80
+msgid "von Klitzing Constant"
+msgstr "Constante de von Klitzing"
+
+#: ../data/variables.xml.in.h:81
+msgid "von Klitzing Constant (conventional value)"
+msgstr "Constante de von Klitzing (valor convencional)"
+
+#: ../data/variables.xml.in.h:82
+msgid "Particle Mass in u"
+msgstr "Masa de partícula en unidades de masa atómica"
+
+#: ../data/variables.xml.in.h:83
+msgid "Deuteron Mass (in u)"
+msgstr "Masa de deuterón (en u)"
+
+#: ../data/variables.xml.in.h:84
+msgid "Electron Mass (in u)"
+msgstr "Masa de electrón (en u)"
+
+#: ../data/variables.xml.in.h:85
+msgid "Helion Mass (in u)"
+msgstr "Masa de helión (en u)"
+
+#: ../data/variables.xml.in.h:86
+msgid "Neutron Mass (in u)"
+msgstr "Masa de neutrón (en u)"
+
+#: ../data/variables.xml.in.h:87
+msgid "Proton Mass (in u)"
+msgstr "Masa de protón (en u)"
+
+#: ../data/variables.xml.in.h:88
+msgid "Tau Mass (in u)"
+msgstr "Masa de tau (en u)"
+
+#: ../data/variables.xml.in.h:89
+msgid "Muon Mass (in u)"
+msgstr "Masa de muon (en u)"
+
+#: ../data/variables.xml.in.h:90
+msgid "Triton Mass (in u)"
+msgstr "Masa de tritón (en u)"
+
+#: ../data/variables.xml.in.h:91
+msgid "Alpha Particle Mass (in u)"
+msgstr "Masa de partícula alfa (en u)"
+
+#: ../data/variables.xml.in.h:92
+msgid "Particle Mass in MeV*c^(-2)"
+msgstr "Masa de partícula en MeV*c^(-2)"
+
+#: ../data/variables.xml.in.h:93
+msgid "Electron Mass (in MeV/c^2)"
+msgstr "Masa de electrón (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:94
+msgid "Neutron Mass (in MeV/c^2)"
+msgstr "Masa de neutrón (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:95
+msgid "Proton Mass (in MeV/c^2)"
+msgstr "Masa de protón (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:96
+msgid "Tau Mass (in MeV/c^2)"
+msgstr "Masa de tau (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:97
+msgid "Muon Mass (in MeV/c^2)"
+msgstr "Masa de muon (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:98
+msgid "Alpha Particle Mass (in MeV/c^2)"
+msgstr "Masa de partícula alfa (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:99
+msgid "Up Quark Mass (in MeV/c^2)"
+msgstr "Masa de cuark arriba (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:100
+msgid "Down Quark Mass (in MeV/c^2)"
+msgstr "Masa de cuark abajo (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:101
+msgid "Charm Quark Mass (in MeV/c^2)"
+msgstr "Masa de cuark encanto (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:102
+msgid "Strange Quark Mass (in MeV/c^2)"
+msgstr "Masa de cuark extraño (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:103
+msgid "Top Quark Mass (in MeV/c^2)"
+msgstr "Masa de cuark cima (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:104
+msgid "Bottom Quark Mass (in MeV/c^2)"
+msgstr "Masa de cuark fondo (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:105
+msgid "Higgs Boson Mass (in MeV/c^2)"
+msgstr "Masa de bosón de Higgs (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:106
+msgid "W Boson Mass (in MeV/c^2)"
+msgstr "Masa de bosón W (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:107
+msgid "Z Boson Mass (in MeV/c^2)"
+msgstr "Masa de bosón Z (en MeV*c^(-2))"
+
+#: ../data/variables.xml.in.h:108
+msgid "Particle Mass in kg"
+msgstr "Masa de partícula en kg"
+
+#: ../data/variables.xml.in.h:109
+msgid "Deuteron Mass"
+msgstr "Masa de deuterón"
+
+#: ../data/variables.xml.in.h:110
+msgid "Electron Mass"
+msgstr "Masa de electrón"
+
+#: ../data/variables.xml.in.h:111
+msgid "Helion Mass"
+msgstr "Masa de helión"
+
+#: ../data/variables.xml.in.h:112
+msgid "Neutron Mass"
+msgstr "Masa de neutrón"
+
+#: ../data/variables.xml.in.h:113
+msgid "Proton Mass"
+msgstr "Masa de protón"
+
+#: ../data/variables.xml.in.h:114
+msgid "Tau Mass"
+msgstr "Masa de tau"
+
+#: ../data/variables.xml.in.h:115
+msgid "Muon Mass"
+msgstr "Masa de muon"
+
+#: ../data/variables.xml.in.h:116
+msgid "Triton Mass"
+msgstr "Masa de tritón"
+
+#: ../data/variables.xml.in.h:117
+msgid "Alpha Particle Mass"
+msgstr "Masa de partícula alfa"
+
+#: ../data/variables.xml.in.h:118
+msgid "Atomic and Nuclear Constants"
+msgstr "Constantes atómicas y nucleares"
+
+#: ../data/variables.xml.in.h:119
+msgid "Bohr Radius"
+msgstr "Radio de Bohr"
+
+#: ../data/variables.xml.in.h:120
+msgid "Classical Electron Radius"
+msgstr "Radio clásico del electrón"
+
+#: ../data/variables.xml.in.h:121
+msgid "Fermi Coupling Constant"
+msgstr "Constante de acoplamiento de Fermi"
+
+#: ../data/variables.xml.in.h:122
+msgid "Fine-Structure Constant"
+msgstr "Constante de estructura fina"
+
+#: ../data/variables.xml.in.h:123
+msgid "Hartree Energy (constant)"
+msgstr "Energía de Hartree (constante)"
+
+#: ../data/variables.xml.in.h:124
+msgid "Quantum of Circulation"
+msgstr "Cuanto de circulación"
+
+#: ../data/variables.xml.in.h:125
+msgid "Quantum of Circulation times 2"
+msgstr "Cuanto de circulación por 2"
+
+#: ../data/variables.xml.in.h:126
+msgid "Rydberg Constant"
+msgstr "Constante de Rydberg"
+
+#: ../data/variables.xml.in.h:127
+msgid "Thomson cross section"
+msgstr "Sección eficaz de Thomson"
+
+#: ../data/variables.xml.in.h:128
+msgid "Weak Mixing Angle (Weinberg Angle)"
+msgstr "Ángulo de mezcla débil (ángulo de Weinberg)"
+
+#: ../data/variables.xml.in.h:129
+msgid "W to Z Mass Ratio"
+msgstr "Relación de masa de W a Z"
+
+#: ../data/variables.xml.in.h:130
+msgid "Physico-Chemical Constants"
+msgstr "Constantes físico-químicas"
+
+#: ../data/variables.xml.in.h:131
+msgid "Lattice Spacing of Ideal Silicon (220)"
+msgstr "Espaciado de red de silicio ideal (220)"
+
+#: ../data/variables.xml.in.h:132
+msgid "Atomic Mass Constant"
+msgstr "Constante de masa atómica"
+
+#: ../data/variables.xml.in.h:133
+msgid "Avogadro Constant"
+msgstr "Constante de Avogadro"
+
+#: ../data/variables.xml.in.h:134
+msgid "Boltzmann Constant"
+msgstr "Constante de Boltzmann"
+
+#: ../data/variables.xml.in.h:135
+msgid "Molar Mass Constant"
+msgstr "Constante de masa molar"
+
+#: ../data/variables.xml.in.h:136
+msgid "Compton Wavelength"
+msgstr "Longitud de onda de Compton"
+
+#: ../data/variables.xml.in.h:137
+msgid "Reduced Compton Wavelength"
+msgstr "Longitud de onda de Compton reducida"
+
+#: ../data/variables.xml.in.h:138
+msgid "Electronvolt (constant)"
+msgstr "Electronvoltio (constante)"
+
+#: ../data/variables.xml.in.h:139
+msgid "Faraday Constant"
+msgstr "Constante de Faraday"
+
+#: ../data/variables.xml.in.h:140
+msgid "First Radiation Constant"
+msgstr "Primera constante de radiación"
+
+#: ../data/variables.xml.in.h:141
+msgid "First Radiation Constant for Spectral Radiance"
+msgstr "Primera constante de radiación para radiancia espectral"
+
+#: ../data/variables.xml.in.h:142
+msgid "Gas Constant"
+msgstr "Constante de los gases ideales"
+
+#: ../data/variables.xml.in.h:143
+msgid "Lattice Parameter of Silicon"
+msgstr "Parámetro de red del silicio"
+
+#: ../data/variables.xml.in.h:144
+msgid "Loschmidt Constant (273.15 K, 100 kPa)"
+msgstr "Constante de Loschmidt (273.15 K, 100 kPa)"
+
+#: ../data/variables.xml.in.h:145
+msgid "Loschmidt Constant (273.15 K, 101.325 kPa)"
+msgstr "Constante de Loschmidt (273.15 K, 101.325 kPa)"
+
+#: ../data/variables.xml.in.h:146
+msgid "Molar Planck Constant"
+msgstr "Constante de Planck molar"
+
+#: ../data/variables.xml.in.h:147
+msgid "Molar Volume of Ideal Gas (273.15 K, 100 kPa)"
+msgstr "Volumen molar del gas ideal (273.15 K, 100 kPa)"
+
+#: ../data/variables.xml.in.h:148
+msgid "Molar Volume of Ideal Gas (273.15 K, 101.325 kPa)"
+msgstr "Volumen molar del gas ideal (273.15 K, 101.325 kPa)"
+
+#: ../data/variables.xml.in.h:149
+msgid "Sackur-Tetrode constant (1 K, 100 kPa)"
+msgstr "Constante de Sackur-Tetrode (1 K, 100 kPa)"
+
+#: ../data/variables.xml.in.h:150
+msgid "Sackur-Tetrode constant (1 K, 101.325 kPa)"
+msgstr "Constante de Sackur-Tetrode (1 K, 101.325 kPa)"
+
+#: ../data/variables.xml.in.h:151
+msgid "Second Radiation Constant"
+msgstr "Segunda constante de radiación"
+
+#: ../data/variables.xml.in.h:152
+msgid "Stefan-Boltzmann Constant"
+msgstr "Constante de Stefan-Boltzmann"
+
+#: ../data/variables.xml.in.h:153
+msgid "Wien frequency displacement law constant"
+msgstr "Constante de ley de desplazamiento de frecuencia de Wien"
+
+#: ../data/variables.xml.in.h:154
+msgid "Wien wavelength displacement law constant"
+msgstr "Constante de ley de desplazamiento de longitud de onda de Wien"
+
+#: ../data/variables.xml.in.h:155
+msgid "Conversion factors for energy equivalents"
+msgstr "Factores de conversión para equivalentes de energía"
+
+#: ../data/variables.xml.in.h:156
+msgid "Hertz - Inverse Meter Relationship"
+msgstr "Relación hercio - inverso de metro"
+
+#: ../data/variables.xml.in.h:157
+msgid "Hertz - Joule Relationship"
+msgstr "Relación hercio - julio"
+
+#: ../data/variables.xml.in.h:158
+msgid "Hertz - Kelvin Relationship"
+msgstr "Relación hercio - kelvin"
+
+#: ../data/variables.xml.in.h:159
+msgid "Hertz - Kilogram Relationship"
+msgstr "Relación hercio - kilogramo"
+
+#: ../data/variables.xml.in.h:160
+msgid "Inverse Meter - Hertz Relationship"
+msgstr "Relación inverso de metro - hercio"
+
+#: ../data/variables.xml.in.h:161
+msgid "Inverse Meter - Joule Relationship"
+msgstr "Relación inverso de metro - julio"
+
+#: ../data/variables.xml.in.h:162
+msgid "Inverse Meter - Kelvin Relationship"
+msgstr "Relación inverso de metro - kelvin"
+
+#: ../data/variables.xml.in.h:163
+msgid "Inverse Meter - Kilogram Relationship"
+msgstr "Relación inverso de metro - kilogramo"
+
+#: ../data/variables.xml.in.h:164
+msgid "Joule - Hertz Relationship"
+msgstr "Relación julio - hercio"
+
+#: ../data/variables.xml.in.h:165
+msgid "Joule - Inverse Meter Relationship"
+msgstr "Relación julio - inverso de metro"
+
+#: ../data/variables.xml.in.h:166
+msgid "Joule - Kelvin Relationship"
+msgstr "Relación julio - kelvin"
+
+#: ../data/variables.xml.in.h:167
+msgid "Joule - Kilogram Relationship"
+msgstr "Relación julio - kilogramo"
+
+#: ../data/variables.xml.in.h:168
+msgid "Kelvin - Hertz Relationship"
+msgstr "Relación kelvin - hercio"
+
+#: ../data/variables.xml.in.h:169
+msgid "Kelvin - Inverse Meter Relationship"
+msgstr "Relación kelvin - inverso de metro"
+
+#: ../data/variables.xml.in.h:170
+msgid "Kelvin - Joule Relationship"
+msgstr "Relación kelvin - julio"
+
+#: ../data/variables.xml.in.h:171
+msgid "Kelvin - Kilogram Relationship"
+msgstr "Relación kelvin - kilogramo"
+
+#: ../data/variables.xml.in.h:172
+msgid "Kilogram - Hertz Relationship"
+msgstr "Relación kilogramo - "
+
+#: ../data/variables.xml.in.h:173
+msgid "Kilogram - Inverse Meter Relationship"
+msgstr "Relación kilogramo - inverso de metro"
+
+#: ../data/variables.xml.in.h:174
+msgid "Kilogram - Joule Relationship"
+msgstr "Relación kilogramo - julio"
+
+#: ../data/variables.xml.in.h:175
+msgid "Kilogram - Kelvin Relationship"
+msgstr "Relación kilogramo - kelvin"
+
+#: ../data/variables.xml.in.h:176
+msgid "Basic Constants"
+msgstr "Constantes básicas"
+
+#: ../data/variables.xml.in.h:177
+msgid "Golden Ratio"
+msgstr "Número áureo"
+
+#: ../data/variables.xml.in.h:178
+msgid "Omega Constant"
+msgstr "Constante omega"
+
+#: ../data/variables.xml.in.h:179
+msgid "Pythagoras' Constant (sqrt 2)"
+msgstr "Constante de Pitágoras (sqrt 2)"
+
+#: ../data/variables.xml.in.h:180
+msgid "Apery's Constant"
+msgstr "Constante de Apéry"
+
+#: ../data/variables.xml.in.h:181
+msgid "Tau (2pi)"
+msgstr "Tau (2pi)"
+
+#: ../data/variables.xml.in.h:182
+msgid "Base of Natural Logarithms (e)"
+msgstr "Base de logaritmo natural (e)"
+
+#: ../data/variables.xml.in.h:183
+msgid "Archimedes' Constant (pi)"
+msgstr "Constante de Arquímedes (pi)"
+
+#: ../data/variables.xml.in.h:184
+msgid "Euler's Constant"
+msgstr "Constante de Euler-Mascheroni"
+
+#: ../data/variables.xml.in.h:185
+msgid "Catalan's Constant"
+msgstr "Constante de Catalan"
+
+#: ../data/variables.xml.in.h:186
+msgid "Special Numbers"
+msgstr "Números especiales"
+
+#: ../data/variables.xml.in.h:187
+msgid "Imaginary i (sqrt -1)"
+msgstr "i imaginaria (sqrt -1)"
+
+#: ../data/variables.xml.in.h:188
+msgid "Positive Infinity"
+msgstr "Infinito positivo"
+
+#: ../data/variables.xml.in.h:189
+msgid "a:&#x221E;,r:plus_infinity,r:infinity"
+msgstr ""
+
+#: ../data/variables.xml.in.h:190
+msgid "Negative Infinity"
+msgstr "Infinito negativo"
+
+#: ../data/variables.xml.in.h:191
+msgid "r:minus_infinity"
+msgstr ""
+
+#: ../data/variables.xml.in.h:192
+msgid "Undefined"
+msgstr "Indefinido"
+
+#: ../data/variables.xml.in.h:193
+msgid "r:undefined"
+msgstr ""
+
+#: ../data/variables.xml.in.h:194
+msgid "False"
+msgstr "Falso"
+
+#: ../data/variables.xml.in.h:195
+msgid "r:false,r:no"
+msgstr ""
+
+#: ../data/variables.xml.in.h:196
+msgid "True"
+msgstr "Verdadero"
+
+#: ../data/variables.xml.in.h:197
+msgid "r:true,r:yes"
+msgstr ""
+
+#: ../data/variables.xml.in.h:199
+msgid "Precision"
+msgstr "Precisión"
+
+#: ../data/variables.xml.in.h:200
+msgid "r:precision"
+msgstr ""
+
+#: ../data/variables.xml.in.h:201
+msgid "System Uptime"
+msgstr "Tiempo de actividad del sistema"
+
+#: ../data/variables.xml.in.h:202
+msgid "r:uptime"
+msgstr ""
+
+#: ../data/variables.xml.in.h:203
+msgid "Unknowns"
+msgstr "Incógnitas"
+
+#: ../data/variables.xml.in.h:204
+msgid "n (integer)"
+msgstr "n (entero)"
+
+#: ../data/variables.xml.in.h:206
+msgid "Today"
+msgstr "Hoy"
+
+#: ../data/variables.xml.in.h:207
+msgid "r:today"
+msgstr ""
+
+#: ../data/variables.xml.in.h:208
+msgid "Tomorrow"
+msgstr "Mañana"
+
+#: ../data/variables.xml.in.h:209
+msgid "r:tomorrow"
+msgstr ""
+
+#: ../data/variables.xml.in.h:210
+msgid "Yesterday"
+msgstr "Ayer"
+
+#: ../data/variables.xml.in.h:211
+msgid "r:yesterday"
+msgstr ""
+
+#: ../data/variables.xml.in.h:212
+msgid "Now (date and time)"
+msgstr "Ahora (fecha y tiempo)"
+
+#: ../data/variables.xml.in.h:213
+msgid "r:now"
+msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -1,0 +1,3654 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-07-12 06:04+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../src/defs2doc.cc:301 ../src/qalc.cc:3422 ../libqalculate/Function.cc:222
+#: ../libqalculate/Function.cc:1375
+msgid "argument"
+msgstr ""
+
+#: ../src/defs2doc.cc:324 ../src/qalc.cc:3445
+#, c-format
+msgid ""
+"Retrieves data from the %s data set for a given object and property. If "
+"\"info\" is typed as property, all properties of the object will be listed."
+msgstr ""
+
+#: ../src/defs2doc.cc:331 ../src/qalc.cc:3454
+msgid "Example:"
+msgstr ""
+
+#: ../src/defs2doc.cc:339 ../src/qalc.cc:3463
+msgid "Arguments"
+msgstr ""
+
+#. optional argument, in description
+#: ../src/defs2doc.cc:356 ../src/qalc.cc:3480
+msgid "optional"
+msgstr ""
+
+#. argument default, in description
+#: ../src/defs2doc.cc:359 ../src/qalc.cc:3484
+msgid "default: "
+msgstr ""
+
+#: ../src/defs2doc.cc:372 ../src/qalc.cc:3495
+msgid "Requirement"
+msgstr ""
+
+#: ../src/defs2doc.cc:381 ../src/qalc.cc:3503
+msgid "Properties"
+msgstr ""
+
+#: ../src/defs2doc.cc:397 ../src/qalc.cc:3518
+msgid "key"
+msgstr ""
+
+#: ../src/defs2doc.cc:431 ../src/qalc.cc:3633
+msgid "a previous result"
+msgstr ""
+
+#: ../src/defs2doc.cc:434
+msgid "current precision"
+msgstr ""
+
+#: ../src/defs2doc.cc:438 ../src/defs2doc.cc:539 ../src/qalc.cc:1478
+msgid "relative uncertainty"
+msgstr ""
+
+#: ../src/defs2doc.cc:453 ../src/qalc.cc:1500 ../src/qalc.cc:3639
+#: ../libqalculate/Function.cc:2144
+msgid "matrix"
+msgstr ""
+
+#: ../src/defs2doc.cc:455 ../src/qalc.cc:1502 ../src/qalc.cc:3641
+#: ../libqalculate/Function.cc:2083
+msgid "vector"
+msgstr ""
+
+#: ../src/defs2doc.cc:463 ../src/qalc.cc:266 ../src/qalc.cc:710
+#: ../src/qalc.cc:1519 ../src/qalc.cc:3014 ../src/qalc.cc:3651
+#: ../src/qalc.cc:3770 ../src/qalc.cc:4001
+msgid "positive"
+msgstr ""
+
+#: ../src/defs2doc.cc:464 ../src/qalc.cc:272 ../src/qalc.cc:711
+#: ../src/qalc.cc:1520 ../src/qalc.cc:3015 ../src/qalc.cc:3652
+#: ../src/qalc.cc:3774 ../src/qalc.cc:4005
+msgid "non-positive"
+msgstr ""
+
+#: ../src/defs2doc.cc:465 ../src/qalc.cc:270 ../src/qalc.cc:712
+#: ../src/qalc.cc:1521 ../src/qalc.cc:3016 ../src/qalc.cc:3653
+#: ../src/qalc.cc:3772 ../src/qalc.cc:4003
+msgid "negative"
+msgstr ""
+
+#: ../src/defs2doc.cc:466 ../src/qalc.cc:268 ../src/qalc.cc:713
+#: ../src/qalc.cc:1522 ../src/qalc.cc:3017 ../src/qalc.cc:3654
+#: ../src/qalc.cc:3776 ../src/qalc.cc:4007
+msgid "non-negative"
+msgstr ""
+
+#: ../src/defs2doc.cc:467 ../src/qalc.cc:264 ../src/qalc.cc:714
+#: ../src/qalc.cc:1523 ../src/qalc.cc:3018 ../src/qalc.cc:3655
+#: ../src/qalc.cc:3768 ../src/qalc.cc:3999
+msgid "non-zero"
+msgstr ""
+
+#: ../src/defs2doc.cc:472 ../src/qalc.cc:262 ../src/qalc.cc:719
+#: ../src/qalc.cc:1528 ../src/qalc.cc:3023 ../src/qalc.cc:3660
+#: ../src/qalc.cc:3784 ../src/qalc.cc:4015 ../libqalculate/Function.cc:1939
+msgid "integer"
+msgstr ""
+
+#: ../src/defs2doc.cc:473 ../src/qalc.cc:260 ../src/qalc.cc:720
+#: ../src/qalc.cc:1529 ../src/qalc.cc:3024 ../src/qalc.cc:3661
+#: ../src/qalc.cc:3782 ../src/qalc.cc:4013
+msgid "rational"
+msgstr ""
+
+#: ../src/defs2doc.cc:474 ../src/qalc.cc:256 ../src/qalc.cc:721
+#: ../src/qalc.cc:1530 ../src/qalc.cc:3025 ../src/qalc.cc:3662
+#: ../src/qalc.cc:3780 ../src/qalc.cc:4011
+msgid "real"
+msgstr ""
+
+#: ../src/defs2doc.cc:475 ../src/qalc.cc:722 ../src/qalc.cc:1531
+#: ../src/qalc.cc:3026 ../src/qalc.cc:3663
+msgid "complex"
+msgstr ""
+
+#: ../src/defs2doc.cc:476 ../src/qalc.cc:258 ../src/qalc.cc:723
+#: ../src/qalc.cc:1532 ../src/qalc.cc:3027 ../src/qalc.cc:3664
+#: ../src/qalc.cc:3778 ../src/qalc.cc:4009 ../libqalculate/Function.cc:1778
+msgid "number"
+msgstr ""
+
+#: ../src/defs2doc.cc:477 ../src/qalc.cc:724 ../src/qalc.cc:1533
+#: ../src/qalc.cc:3028 ../src/qalc.cc:3665
+msgid "non-matrix"
+msgstr ""
+
+#: ../src/defs2doc.cc:480 ../src/qalc.cc:250 ../src/qalc.cc:727
+#: ../src/qalc.cc:1536 ../src/qalc.cc:3031 ../src/qalc.cc:3668
+#: ../src/qalc.cc:3766 ../src/qalc.cc:3997
+msgid "unknown"
+msgstr ""
+
+#: ../src/defs2doc.cc:482 ../src/qalc.cc:1538 ../src/qalc.cc:3670
+msgid "default assumptions"
+msgstr ""
+
+#: ../src/defs2doc.cc:488
+msgid "variable precision"
+msgstr ""
+
+#. qalc command
+#: ../src/defs2doc.cc:492 ../src/defs2doc.cc:546 ../src/qalc.cc:932
+#: ../src/qalc.cc:1494 ../src/qalc.cc:1511 ../src/qalc.cc:2623
+#: ../src/qalc.cc:3048 ../src/qalc.cc:3304 ../src/qalc.cc:3582
+#: ../src/qalc.cc:3592 ../src/qalc.cc:3696 ../src/qalc.cc:3792
+#: ../src/qalc.cc:4127
+msgid "approximate"
+msgstr ""
+
+#: ../src/defs2doc.cc:583 ../src/qalc.cc:1950
+msgid "ans"
+msgstr ""
+
+#: ../src/defs2doc.cc:584 ../src/defs2doc.cc:587 ../src/defs2doc.cc:588
+#: ../src/defs2doc.cc:589 ../src/defs2doc.cc:590 ../src/qalc.cc:1951
+#: ../src/qalc.cc:1954 ../src/qalc.cc:1955 ../src/qalc.cc:1956
+#: ../src/qalc.cc:1957 ../src/qalc.cc:2217
+#: ../libqalculate/Calculator-definitions.cc:2255
+#: ../libqalculate/Calculator-definitions.cc:2271
+msgid "Temporary"
+msgstr ""
+
+#: ../src/defs2doc.cc:584 ../src/qalc.cc:1951
+msgid "Last Answer"
+msgstr ""
+
+#: ../src/defs2doc.cc:585 ../src/qalc.cc:1952
+msgid "answer"
+msgstr ""
+
+#: ../src/defs2doc.cc:587 ../src/qalc.cc:1954
+msgid "Answer 2"
+msgstr ""
+
+#: ../src/defs2doc.cc:588 ../src/qalc.cc:1955
+msgid "Answer 3"
+msgstr ""
+
+#: ../src/defs2doc.cc:589 ../src/qalc.cc:1956
+msgid "Answer 4"
+msgstr ""
+
+#: ../src/defs2doc.cc:590 ../src/qalc.cc:1957
+msgid "Answer 5"
+msgstr ""
+
+#: ../src/defs2doc.cc:594
+#, c-format
+msgid "Failed to load global definitions!\n"
+msgstr ""
+
+#: ../src/defs2doc.cc:643 ../src/defs2doc.cc:710 ../src/defs2doc.cc:711
+#: ../src/defs2doc.cc:712 ../src/defs2doc.cc:794 ../src/defs2doc.cc:795
+#: ../src/defs2doc.cc:796
+msgid "Uncategorized"
+msgstr ""
+
+#: ../src/qalc.cc:169 ../src/qalc.cc:236 ../src/qalc.cc:3745
+#: ../libqalculate/util.cc:175
+msgid "yes"
+msgstr ""
+
+#: ../src/qalc.cc:170 ../src/qalc.cc:238 ../src/qalc.cc:3745
+#: ../libqalculate/util.cc:176
+msgid "no"
+msgstr ""
+
+#: ../src/qalc.cc:171 ../libqalculate/util.cc:183
+msgid "true"
+msgstr ""
+
+#: ../src/qalc.cc:172 ../libqalculate/util.cc:184
+msgid "false"
+msgstr ""
+
+#: ../src/qalc.cc:173 ../src/qalc.cc:808 ../src/qalc.cc:828 ../src/qalc.cc:1144
+#: ../src/qalc.cc:1181 ../src/qalc.cc:3147 ../src/qalc.cc:3160
+#: ../src/qalc.cc:3218 ../src/qalc.cc:3744 ../src/qalc.cc:3859
+#: ../src/qalc.cc:3866 ../src/qalc.cc:3917 ../libqalculate/util.cc:191
+msgid "on"
+msgstr ""
+
+#: ../src/qalc.cc:174 ../src/qalc.cc:806 ../src/qalc.cc:827 ../src/qalc.cc:1053
+#: ../src/qalc.cc:1117 ../src/qalc.cc:1129 ../src/qalc.cc:1142
+#: ../src/qalc.cc:1179 ../src/qalc.cc:3079 ../src/qalc.cc:3146
+#: ../src/qalc.cc:3151 ../src/qalc.cc:3158 ../src/qalc.cc:3187
+#: ../src/qalc.cc:3194 ../src/qalc.cc:3201 ../src/qalc.cc:3217
+#: ../src/qalc.cc:3251 ../src/qalc.cc:3744 ../src/qalc.cc:3814
+#: ../src/qalc.cc:3857 ../src/qalc.cc:3863 ../src/qalc.cc:3866
+#: ../src/qalc.cc:3874 ../src/qalc.cc:3881 ../src/qalc.cc:3891
+#: ../src/qalc.cc:3915 ../src/qalc.cc:3950 ../libqalculate/util.cc:192
+msgid "off"
+msgstr ""
+
+#: ../src/qalc.cc:243
+msgid "Please answer yes or no"
+msgstr ""
+
+#: ../src/qalc.cc:275
+msgid "Unrecognized assumption."
+msgstr ""
+
+#: ../src/qalc.cc:440 ../src/qalc.cc:474 ../libqalculate/Calculator.cc:246
+#: ../libqalculate/Calculator.cc:474 ../libqalculate/DataSet.cc:1104
+#: ../libqalculate/DataSet.cc:1166 ../libqalculate/MathStructure-print.cc:3438
+#: ../libqalculate/Function.cc:2304 ../libqalculate/Function.cc:2320
+msgid "or"
+msgstr ""
+
+#: ../src/qalc.cc:561 ../libqalculate/Calculator-definitions.cc:3828
+#, c-format
+msgid "It has been %s day(s) since the exchange rates last were updated."
+msgstr ""
+
+#: ../src/qalc.cc:566
+msgid "Do you wish to update the exchange rates now?"
+msgstr ""
+
+#: ../src/qalc.cc:580 ../src/qalc.cc:581
+msgid ""
+"\n"
+"Press Enter to continue."
+msgstr ""
+
+#: ../src/qalc.cc:596 ../src/qalc.cc:597 ../src/qalc.cc:598 ../src/qalc.cc:599
+#: ../src/qalc.cc:600 ../src/qalc.cc:601 ../src/qalc.cc:750 ../src/qalc.cc:845
+#: ../src/qalc.cc:848 ../src/qalc.cc:1004 ../src/qalc.cc:1023
+#: ../src/qalc.cc:1035 ../src/qalc.cc:1044 ../src/qalc.cc:2426
+#: ../src/qalc.cc:2563
+msgid "Illegal value"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:629 ../src/qalc.cc:966 ../src/qalc.cc:2404
+#: ../src/qalc.cc:2910 ../src/qalc.cc:2916 ../src/qalc.cc:3108
+#: ../src/qalc.cc:3269 ../src/qalc.cc:3306 ../src/qalc.cc:3826
+#: ../src/qalc.cc:3963 ../src/qalc.cc:4119 ../src/qalc.cc:4965
+#: ../src/qalc.cc:4969 ../libqalculate/Calculator-calculate.cc:840
+#: ../libqalculate/Calculator-calculate.cc:844
+msgid "base"
+msgstr ""
+
+#: ../src/qalc.cc:629 ../src/qalc.cc:631 ../src/qalc.cc:3227
+#: ../src/qalc.cc:3928
+msgid "input base"
+msgstr ""
+
+#: ../src/qalc.cc:629 ../src/qalc.cc:632
+msgid "output base"
+msgstr ""
+
+#: ../src/qalc.cc:633 ../src/qalc.cc:2676 ../src/qalc.cc:3110
+#: ../src/qalc.cc:3229 ../src/qalc.cc:3838 ../src/qalc.cc:3936
+#: ../src/qalc.cc:4881 ../libqalculate/Calculator-calculate.cc:760
+msgid "roman"
+msgstr ""
+
+#: ../src/qalc.cc:634 ../src/qalc.cc:2681 ../src/qalc.cc:3111
+#: ../src/qalc.cc:3230 ../src/qalc.cc:4883
+#: ../libqalculate/Calculator-calculate.cc:762
+msgid "bijective"
+msgstr ""
+
+#: ../src/qalc.cc:640 ../src/qalc.cc:2716 ../src/qalc.cc:3118
+#: ../src/qalc.cc:3836 ../src/qalc.cc:4897
+#: ../libqalculate/Calculator-calculate.cc:776
+msgid "time"
+msgstr ""
+
+#: ../src/qalc.cc:641 ../src/qalc.cc:2651 ../src/qalc.cc:4871
+#: ../libqalculate/Calculator-calculate.cc:750
+msgid "hexadecimal"
+msgstr ""
+
+#: ../src/qalc.cc:648 ../src/qalc.cc:2671 ../src/qalc.cc:4879
+#: ../libqalculate/Calculator-calculate.cc:758
+msgid "duodecimal"
+msgstr ""
+
+#: ../src/qalc.cc:649 ../src/qalc.cc:2656 ../src/qalc.cc:4873
+#: ../libqalculate/Calculator-calculate.cc:752
+msgid "binary"
+msgstr ""
+
+#: ../src/qalc.cc:650 ../src/qalc.cc:2666 ../src/qalc.cc:4877
+#: ../libqalculate/Calculator-calculate.cc:756
+msgid "octal"
+msgstr ""
+
+#: ../src/qalc.cc:651 ../src/qalc.cc:2661 ../src/qalc.cc:4875
+#: ../libqalculate/Calculator-calculate.cc:754
+msgid "decimal"
+msgstr ""
+
+#: ../src/qalc.cc:652 ../src/qalc.cc:2686 ../src/qalc.cc:3112
+#: ../src/qalc.cc:4885 ../libqalculate/Calculator-calculate.cc:764
+msgid "sexagesimal"
+msgstr ""
+
+#: ../src/qalc.cc:662 ../src/qalc.cc:788 ../src/qalc.cc:3129
+#: ../src/qalc.cc:3850
+msgid "base display"
+msgstr ""
+
+#: ../src/qalc.cc:692
+msgid "Illegal base."
+msgstr ""
+
+#: ../src/qalc.cc:700 ../src/qalc.cc:728 ../src/qalc.cc:3032
+#: ../src/qalc.cc:3763
+msgid "assumptions"
+msgstr ""
+
+#: ../src/qalc.cc:731 ../src/qalc.cc:3260 ../src/qalc.cc:3955
+msgid "all prefixes"
+msgstr ""
+
+#: ../src/qalc.cc:732 ../src/qalc.cc:3077 ../src/qalc.cc:3814
+msgid "color"
+msgstr ""
+
+#. light color
+#: ../src/qalc.cc:735 ../src/qalc.cc:3080 ../src/qalc.cc:3814
+msgid "light"
+msgstr ""
+
+#: ../src/qalc.cc:736 ../src/qalc.cc:3081 ../src/qalc.cc:3814
+msgid "default"
+msgstr ""
+
+#: ../src/qalc.cc:739 ../src/qalc.cc:797 ../src/qalc.cc:814 ../src/qalc.cc:834
+#: ../src/qalc.cc:866 ../src/qalc.cc:883 ../src/qalc.cc:909 ../src/qalc.cc:923
+#: ../src/qalc.cc:937 ../src/qalc.cc:954 ../src/qalc.cc:979 ../src/qalc.cc:995
+#: ../src/qalc.cc:1064 ../src/qalc.cc:1070 ../src/qalc.cc:1094
+#: ../src/qalc.cc:1151 ../src/qalc.cc:1170 ../src/qalc.cc:1186
+msgid "Illegal value."
+msgstr ""
+
+#: ../src/qalc.cc:744 ../src/qalc.cc:3066 ../src/qalc.cc:3803
+msgid "complex numbers"
+msgstr ""
+
+#: ../src/qalc.cc:745 ../src/qalc.cc:3091 ../src/qalc.cc:3816
+msgid "excessive parentheses"
+msgstr ""
+
+#: ../src/qalc.cc:746 ../src/qalc.cc:3067 ../src/qalc.cc:3364
+#: ../src/qalc.cc:3369 ../src/qalc.cc:3804
+msgid "functions"
+msgstr ""
+
+#: ../src/qalc.cc:747 ../src/qalc.cc:3068 ../src/qalc.cc:3805
+msgid "infinite numbers"
+msgstr ""
+
+#: ../src/qalc.cc:748 ../src/qalc.cc:3278 ../src/qalc.cc:3976
+msgid "show negative exponents"
+msgstr ""
+
+#: ../src/qalc.cc:749 ../src/qalc.cc:3092 ../src/qalc.cc:3817
+msgid "minus last"
+msgstr ""
+
+#: ../src/qalc.cc:751 ../src/qalc.cc:3010 ../src/qalc.cc:3760
+msgid "assume nonzero denominators"
+msgstr ""
+
+#: ../src/qalc.cc:752 ../src/qalc.cc:3011 ../src/qalc.cc:3761
+msgid "warn nonzero denominators"
+msgstr ""
+
+#: ../src/qalc.cc:753 ../src/qalc.cc:3277 ../src/qalc.cc:3975
+msgid "prefixes"
+msgstr ""
+
+#: ../src/qalc.cc:754 ../src/qalc.cc:3273 ../src/qalc.cc:3971
+msgid "binary prefixes"
+msgstr ""
+
+#: ../src/qalc.cc:761 ../src/qalc.cc:3275 ../src/qalc.cc:3973
+msgid "denominator prefixes"
+msgstr ""
+
+#: ../src/qalc.cc:762 ../src/qalc.cc:3276 ../src/qalc.cc:3974
+msgid "place units separately"
+msgstr ""
+
+#: ../src/qalc.cc:763 ../src/qalc.cc:3065 ../src/qalc.cc:3802
+msgid "calculate variables"
+msgstr ""
+
+#: ../src/qalc.cc:764 ../src/qalc.cc:3064 ../src/qalc.cc:3801
+msgid "calculate functions"
+msgstr ""
+
+#: ../src/qalc.cc:765 ../src/qalc.cc:3279 ../src/qalc.cc:3977
+msgid "sync units"
+msgstr ""
+
+#: ../src/qalc.cc:766 ../src/qalc.cc:3198 ../src/qalc.cc:3887
+msgid "round to even"
+msgstr ""
+
+#: ../src/qalc.cc:767 ../src/qalc.cc:3256 ../src/qalc.cc:3951
+msgid "rpn syntax"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:768 ../src/qalc.cc:2407 ../src/qalc.cc:3291
+#: ../src/qalc.cc:3328 ../src/qalc.cc:3989 ../src/qalc.cc:4069
+msgid "rpn"
+msgstr ""
+
+#: ../src/qalc.cc:769 ../src/qalc.cc:3101 ../src/qalc.cc:3819
+msgid "short multiplication"
+msgstr ""
+
+#: ../src/qalc.cc:770 ../src/qalc.cc:3181 ../src/qalc.cc:3870
+msgid "lowercase e"
+msgstr ""
+
+#: ../src/qalc.cc:771 ../src/qalc.cc:3182 ../src/qalc.cc:3871
+msgid "lowercase numbers"
+msgstr ""
+
+#: ../src/qalc.cc:772 ../src/qalc.cc:3165 ../src/qalc.cc:3226
+#: ../src/qalc.cc:3868 ../src/qalc.cc:3927
+msgid "imaginary j"
+msgstr ""
+
+#: ../src/qalc.cc:790 ../src/qalc.cc:807 ../src/qalc.cc:861 ../src/qalc.cc:962
+#: ../src/qalc.cc:988 ../src/qalc.cc:3005 ../src/qalc.cc:3041
+#: ../src/qalc.cc:3054 ../src/qalc.cc:3131 ../src/qalc.cc:3265
+#: ../src/qalc.cc:3791 ../src/qalc.cc:3850 ../src/qalc.cc:3959
+msgid "none"
+msgstr ""
+
+#: ../src/qalc.cc:791 ../src/qalc.cc:3132 ../src/qalc.cc:3850
+msgid "normal"
+msgstr ""
+
+#: ../src/qalc.cc:792 ../src/qalc.cc:3133 ../src/qalc.cc:3850
+msgid "alternative"
+msgstr ""
+
+#: ../src/qalc.cc:802 ../src/qalc.cc:3210 ../src/qalc.cc:3905
+msgid "two's complement"
+msgstr ""
+
+#: ../src/qalc.cc:803 ../src/qalc.cc:3164 ../src/qalc.cc:3867
+msgid "hexadecimal two's"
+msgstr ""
+
+#: ../src/qalc.cc:804 ../src/qalc.cc:3149 ../src/qalc.cc:3863
+msgid "digit grouping"
+msgstr ""
+
+#: ../src/qalc.cc:808 ../src/qalc.cc:3152 ../src/qalc.cc:3863
+msgid "standard"
+msgstr ""
+
+#: ../src/qalc.cc:809 ../src/qalc.cc:829 ../src/qalc.cc:3145
+#: ../src/qalc.cc:3153 ../src/qalc.cc:3216 ../src/qalc.cc:3855
+#: ../src/qalc.cc:3863 ../src/qalc.cc:3913
+msgid "locale"
+msgstr ""
+
+#: ../src/qalc.cc:819 ../src/qalc.cc:3103 ../src/qalc.cc:3821
+msgid "spell out logical"
+msgstr ""
+
+#: ../src/qalc.cc:820 ../src/qalc.cc:3224 ../src/qalc.cc:3925
+msgid "ignore dot"
+msgstr ""
+
+#: ../src/qalc.cc:821 ../src/qalc.cc:3221 ../src/qalc.cc:3922
+msgid "ignore comma"
+msgstr ""
+
+#: ../src/qalc.cc:825 ../src/qalc.cc:3144 ../src/qalc.cc:3215
+#: ../src/qalc.cc:3852 ../src/qalc.cc:3910
+msgid "decimal comma"
+msgstr ""
+
+#: ../src/qalc.cc:844 ../src/qalc.cc:3241 ../src/qalc.cc:3948
+msgid "limit implicit multiplication"
+msgstr ""
+
+#: ../src/qalc.cc:846 ../src/qalc.cc:3102 ../src/qalc.cc:3820
+msgid "spacious"
+msgstr ""
+
+#: ../src/qalc.cc:847 ../src/qalc.cc:3104 ../src/qalc.cc:3822
+msgid "unicode"
+msgstr ""
+
+#: ../src/qalc.cc:850 ../src/qalc.cc:3069 ../src/qalc.cc:3366
+#: ../src/qalc.cc:3371 ../src/qalc.cc:3806
+msgid "units"
+msgstr ""
+
+#: ../src/qalc.cc:851 ../src/qalc.cc:3070 ../src/qalc.cc:3807
+msgid "unknowns"
+msgstr ""
+
+#: ../src/qalc.cc:852 ../src/qalc.cc:3071 ../src/qalc.cc:3365
+#: ../src/qalc.cc:3370 ../src/qalc.cc:3808
+msgid "variables"
+msgstr ""
+
+#: ../src/qalc.cc:853 ../src/qalc.cc:3076 ../src/qalc.cc:3813
+msgid "abbreviations"
+msgstr ""
+
+#: ../src/qalc.cc:854 ../src/qalc.cc:3209 ../src/qalc.cc:3904
+msgid "show ending zeroes"
+msgstr ""
+
+#: ../src/qalc.cc:855 ../src/qalc.cc:3197 ../src/qalc.cc:3886
+msgid "repeating decimals"
+msgstr ""
+
+#: ../src/qalc.cc:856 ../src/qalc.cc:3036 ../src/qalc.cc:3791
+msgid "angle unit"
+msgstr ""
+
+#: ../src/qalc.cc:858 ../src/qalc.cc:3038 ../src/qalc.cc:3039
+msgid "rad"
+msgstr ""
+
+#: ../src/qalc.cc:858 ../src/qalc.cc:3791
+msgid "radians"
+msgstr ""
+
+#: ../src/qalc.cc:859
+msgid "deg"
+msgstr ""
+
+#: ../src/qalc.cc:859 ../src/qalc.cc:3791
+msgid "degrees"
+msgstr ""
+
+#: ../src/qalc.cc:860 ../src/qalc.cc:3040
+msgid "gra"
+msgstr ""
+
+#: ../src/qalc.cc:860 ../src/qalc.cc:3791
+msgid "gradians"
+msgstr ""
+
+#: ../src/qalc.cc:873 ../src/qalc.cc:3214 ../src/qalc.cc:3909
+msgid "caret as xor"
+msgstr ""
+
+#: ../src/qalc.cc:874 ../src/qalc.cc:3242 ../src/qalc.cc:3949
+#: ../src/qalc.cc:4185
+msgid "parsing mode"
+msgstr ""
+
+#: ../src/qalc.cc:876 ../src/qalc.cc:1077 ../src/qalc.cc:3168
+#: ../src/qalc.cc:3244 ../src/qalc.cc:3869 ../src/qalc.cc:3949
+#: ../src/qalc.cc:4193
+msgid "adaptive"
+msgstr ""
+
+#: ../src/qalc.cc:877 ../src/qalc.cc:3245 ../src/qalc.cc:3949
+#: ../src/qalc.cc:4190
+msgid "implicit first"
+msgstr ""
+
+#: ../src/qalc.cc:878 ../src/qalc.cc:3246 ../src/qalc.cc:3949
+#: ../src/qalc.cc:4187
+msgid "conventional"
+msgstr ""
+
+#: ../src/qalc.cc:888 ../src/qalc.cc:1724 ../src/qalc.cc:3280
+#: ../src/qalc.cc:3978
+msgid "update exchange rates"
+msgstr ""
+
+#: ../src/qalc.cc:889 ../src/qalc.cc:3283 ../src/qalc.cc:3980
+msgid "never"
+msgstr ""
+
+#: ../src/qalc.cc:891 ../src/qalc.cc:3282 ../src/qalc.cc:3979
+msgid "ask"
+msgstr ""
+
+#: ../src/qalc.cc:899 ../src/qalc.cc:3093 ../src/qalc.cc:3818
+msgid "multiplication sign"
+msgstr ""
+
+#: ../src/qalc.cc:914 ../src/qalc.cc:3084 ../src/qalc.cc:3815
+msgid "division sign"
+msgstr ""
+
+#: ../src/qalc.cc:928 ../src/qalc.cc:3044 ../src/qalc.cc:3792
+msgid "approximation"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:930 ../src/qalc.cc:1001 ../src/qalc.cc:1143
+#: ../src/qalc.cc:2613 ../src/qalc.cc:3046 ../src/qalc.cc:3159
+#: ../src/qalc.cc:3308 ../src/qalc.cc:3792 ../src/qalc.cc:3866
+#: ../src/qalc.cc:4123
+msgid "exact"
+msgstr ""
+
+#: ../src/qalc.cc:931 ../src/qalc.cc:3047 ../src/qalc.cc:3792
+msgid "try exact"
+msgstr ""
+
+#: ../src/qalc.cc:946 ../src/qalc.cc:3052 ../src/qalc.cc:3794
+msgid "interval calculation"
+msgstr ""
+
+#: ../src/qalc.cc:946
+msgid "uncertainty propagation"
+msgstr ""
+
+#: ../src/qalc.cc:948 ../src/qalc.cc:3055 ../src/qalc.cc:3794
+msgid "variance formula"
+msgstr ""
+
+#: ../src/qalc.cc:948
+msgid "variance"
+msgstr ""
+
+#: ../src/qalc.cc:949 ../src/qalc.cc:1101 ../src/qalc.cc:3051
+#: ../src/qalc.cc:3056 ../src/qalc.cc:3793 ../src/qalc.cc:3794
+msgid "interval arithmetic"
+msgstr ""
+
+#: ../src/qalc.cc:959 ../src/qalc.cc:3261 ../src/qalc.cc:3956
+msgid "autoconversion"
+msgstr ""
+
+#: ../src/qalc.cc:963 ../src/qalc.cc:2904
+msgid "best"
+msgstr ""
+
+#: ../src/qalc.cc:964 ../src/qalc.cc:3270 ../src/qalc.cc:3965
+msgid "optimalsi"
+msgstr ""
+
+#: ../src/qalc.cc:965 ../src/qalc.cc:2904 ../src/qalc.cc:3268
+#: ../src/qalc.cc:3961 ../src/qalc.cc:4961
+#: ../libqalculate/Calculator-calculate.cc:836
+msgid "optimal"
+msgstr ""
+
+#: ../src/qalc.cc:967 ../src/qalc.cc:1145 ../src/qalc.cc:3161
+#: ../src/qalc.cc:3264 ../src/qalc.cc:3866 ../src/qalc.cc:3967
+#: ../src/qalc.cc:4998 ../libqalculate/Calculator-calculate.cc:865
+msgid "mixed"
+msgstr ""
+
+#: ../src/qalc.cc:985 ../src/qalc.cc:3274 ../src/qalc.cc:3972
+msgid "currency conversion"
+msgstr ""
+
+#: ../src/qalc.cc:986 ../src/qalc.cc:3003 ../src/qalc.cc:3759
+msgid "algebra mode"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:989 ../src/qalc.cc:2991 ../src/qalc.cc:3736
+msgid "simplify"
+msgstr ""
+
+#: ../src/qalc.cc:989 ../src/qalc.cc:2991 ../src/qalc.cc:3007
+#: ../src/qalc.cc:3309 ../src/qalc.cc:3736 ../src/qalc.cc:3759
+#: ../src/qalc.cc:5030 ../libqalculate/Calculator-calculate.cc:904
+msgid "expand"
+msgstr ""
+
+#: ../src/qalc.cc:990 ../src/qalc.cc:3006 ../src/qalc.cc:3759
+#: ../src/qalc.cc:5027 ../libqalculate/Calculator-calculate.cc:900
+msgid "factorize"
+msgstr ""
+
+#: ../src/qalc.cc:1020 ../src/qalc.cc:3290 ../src/qalc.cc:3988
+msgid "ignore locale"
+msgstr ""
+
+#: ../src/qalc.cc:1032 ../src/qalc.cc:3293 ../src/qalc.cc:3322
+#: ../src/qalc.cc:3991
+msgid "save mode"
+msgstr ""
+
+#: ../src/qalc.cc:1041 ../src/qalc.cc:3292 ../src/qalc.cc:3321
+#: ../src/qalc.cc:3990
+msgid "save definitions"
+msgstr ""
+
+#: ../src/qalc.cc:1050 ../src/qalc.cc:3199 ../src/qalc.cc:3888
+msgid "scientific notation"
+msgstr ""
+
+#: ../src/qalc.cc:1054 ../src/qalc.cc:3202 ../src/qalc.cc:3893
+msgid "auto"
+msgstr ""
+
+#: ../src/qalc.cc:1055 ../src/qalc.cc:3203 ../src/qalc.cc:3897
+msgid "pure"
+msgstr ""
+
+#: ../src/qalc.cc:1056 ../src/qalc.cc:3204 ../src/qalc.cc:3899
+msgid "scientific"
+msgstr ""
+
+#: ../src/qalc.cc:1057 ../src/qalc.cc:3205 ../src/qalc.cc:3895
+msgid "engineering"
+msgstr ""
+
+#: ../src/qalc.cc:1066 ../src/qalc.cc:3060 ../src/qalc.cc:3795
+msgid "precision"
+msgstr ""
+
+#: ../src/qalc.cc:1075 ../src/qalc.cc:3166 ../src/qalc.cc:3869
+msgid "interval display"
+msgstr ""
+
+#: ../src/qalc.cc:1078 ../src/qalc.cc:3171 ../src/qalc.cc:3869
+msgid "significant"
+msgstr ""
+
+#: ../src/qalc.cc:1079 ../src/qalc.cc:3172 ../src/qalc.cc:3869
+msgid "interval"
+msgstr ""
+
+#: ../src/qalc.cc:1080 ../src/qalc.cc:3173 ../src/qalc.cc:3869
+msgid "plusminus"
+msgstr ""
+
+#: ../src/qalc.cc:1081 ../src/qalc.cc:3174 ../src/qalc.cc:3869
+msgid "midpoint"
+msgstr ""
+
+#: ../src/qalc.cc:1082 ../src/qalc.cc:3176 ../src/qalc.cc:3869
+msgid "upper"
+msgstr ""
+
+#: ../src/qalc.cc:1083 ../src/qalc.cc:3175 ../src/qalc.cc:3869
+msgid "lower"
+msgstr ""
+
+#: ../src/qalc.cc:1108 ../src/qalc.cc:3072 ../src/qalc.cc:3809
+msgid "variable units"
+msgstr ""
+
+#: ../src/qalc.cc:1115 ../src/qalc.cc:3183 ../src/qalc.cc:3872
+msgid "max decimals"
+msgstr ""
+
+#: ../src/qalc.cc:1127 ../src/qalc.cc:3190 ../src/qalc.cc:3879
+msgid "min decimals"
+msgstr ""
+
+#: ../src/qalc.cc:1140 ../src/qalc.cc:3156 ../src/qalc.cc:3866
+msgid "fractions"
+msgstr ""
+
+#: ../src/qalc.cc:1145
+msgid "combined"
+msgstr ""
+
+#: ../src/qalc.cc:1146 ../src/qalc.cc:3160 ../src/qalc.cc:3866
+msgid "long"
+msgstr ""
+
+#: ../src/qalc.cc:1159 ../src/qalc.cc:3136 ../src/qalc.cc:3851
+msgid "complex form"
+msgstr ""
+
+#: ../src/qalc.cc:1161 ../src/qalc.cc:2776 ../src/qalc.cc:3138
+#: ../src/qalc.cc:3851 ../src/qalc.cc:4946
+#: ../libqalculate/Calculator-calculate.cc:814
+msgid "rectangular"
+msgstr ""
+
+#: ../src/qalc.cc:1161 ../src/qalc.cc:2776 ../src/qalc.cc:4946
+#: ../libqalculate/Calculator-calculate.cc:814
+msgid "cartesian"
+msgstr ""
+
+#: ../src/qalc.cc:1162 ../src/qalc.cc:2788 ../src/qalc.cc:3139
+#: ../src/qalc.cc:3851 ../src/qalc.cc:4949
+#: ../libqalculate/Calculator-calculate.cc:816
+msgid "exponential"
+msgstr ""
+
+#: ../src/qalc.cc:1163 ../src/qalc.cc:2800 ../src/qalc.cc:3140
+#: ../src/qalc.cc:3851 ../src/qalc.cc:4952
+#: ../libqalculate/Calculator-calculate.cc:818
+msgid "polar"
+msgstr ""
+
+#: ../src/qalc.cc:1164 ../src/qalc.cc:2812 ../src/qalc.cc:3141
+#: ../src/qalc.cc:3851 ../src/qalc.cc:4955
+#: ../libqalculate/Calculator-calculate.cc:820 ../libqalculate/Function.cc:2245
+msgid "angle"
+msgstr ""
+
+#: ../src/qalc.cc:1164 ../src/qalc.cc:2812 ../src/qalc.cc:4955
+#: ../libqalculate/Calculator-calculate.cc:820
+msgid "phasor"
+msgstr ""
+
+#: ../src/qalc.cc:1177 ../src/qalc.cc:3249 ../src/qalc.cc:3950
+msgid "read precision"
+msgstr ""
+
+#: ../src/qalc.cc:1180 ../src/qalc.cc:3252 ../src/qalc.cc:3950
+msgid "always"
+msgstr ""
+
+#: ../src/qalc.cc:1181 ../src/qalc.cc:3253 ../src/qalc.cc:3950
+msgid "when decimals"
+msgstr ""
+
+#: ../src/qalc.cc:1212
+msgid "Unrecognized option."
+msgstr ""
+
+#: ../src/qalc.cc:1336
+msgid "Calendar"
+msgstr ""
+
+#: ../src/qalc.cc:1336
+msgid "Day"
+msgstr ""
+
+#: ../src/qalc.cc:1336
+msgid "Month"
+msgstr ""
+
+#: ../src/qalc.cc:1336
+msgid "Year"
+msgstr ""
+
+#: ../src/qalc.cc:1337 ../libqalculate/Calculator-calculate.cc:956
+msgid "failed"
+msgstr ""
+
+#: ../src/qalc.cc:1338 ../libqalculate/Calculator-calculate.cc:957
+msgid "Gregorian:"
+msgstr ""
+
+#: ../src/qalc.cc:1339 ../libqalculate/Calculator-calculate.cc:958
+msgid "Hebrew:"
+msgstr ""
+
+#: ../src/qalc.cc:1340 ../libqalculate/Calculator-calculate.cc:959
+msgid "Islamic:"
+msgstr ""
+
+#: ../src/qalc.cc:1341 ../libqalculate/Calculator-calculate.cc:960
+msgid "Persian:"
+msgstr ""
+
+#: ../src/qalc.cc:1342 ../libqalculate/Calculator-calculate.cc:961
+msgid "Indian national:"
+msgstr ""
+
+#: ../src/qalc.cc:1343 ../libqalculate/Calculator-calculate.cc:962
+msgid "Chinese:"
+msgstr ""
+
+#: ../src/qalc.cc:1348 ../libqalculate/Calculator-calculate.cc:966
+msgid "Julian:"
+msgstr ""
+
+#: ../src/qalc.cc:1349 ../libqalculate/Calculator-calculate.cc:967
+msgid "Revised julian:"
+msgstr ""
+
+#: ../src/qalc.cc:1350 ../libqalculate/Calculator-calculate.cc:968
+msgid "Coptic:"
+msgstr ""
+
+#: ../src/qalc.cc:1351 ../libqalculate/Calculator-calculate.cc:969
+msgid "Ethiopian:"
+msgstr ""
+
+#: ../src/qalc.cc:1418 ../libqalculate/BuiltinFunctions-matrixvector.cc:567
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:597
+msgid "No matching item found."
+msgstr ""
+
+#: ../src/qalc.cc:1449 ../src/qalc.cc:1450 ../src/qalc.cc:1580
+#: ../src/qalc.cc:1581 ../src/qalc.cc:1648 ../src/qalc.cc:1649
+msgid ""
+"For more information about a specific function, variable or unit, please use "
+"the info command (in interactive mode)."
+msgstr ""
+
+#: ../src/qalc.cc:1463
+msgid "Variables:"
+msgstr ""
+
+#: ../src/qalc.cc:1465
+msgid "Name"
+msgstr ""
+
+#: ../src/qalc.cc:1466 ../src/qalc.cc:3676 ../src/qalc.cc:3683
+msgid "Value"
+msgstr ""
+
+#: ../src/qalc.cc:1554
+msgid "Functions:"
+msgstr ""
+
+#: ../src/qalc.cc:1568
+msgid "Units:"
+msgstr ""
+
+#: ../src/qalc.cc:1575
+msgid "No local variables, functions or units have been defined."
+msgstr ""
+
+#: ../src/qalc.cc:1715
+msgid "usage: qalc [options] [expression]"
+msgstr ""
+
+#: ../src/qalc.cc:1717
+msgid "where options are:"
+msgstr ""
+
+#: ../src/qalc.cc:1718 ../src/qalc.cc:1752 ../src/qalc.cc:3306
+msgid "BASE"
+msgstr ""
+
+#: ../src/qalc.cc:1719
+msgid "set the number base for results and, optionally, expressions"
+msgstr ""
+
+#: ../src/qalc.cc:1721
+msgid "use colors to hightlight different elements of expressions and results"
+msgstr ""
+
+#: ../src/qalc.cc:1726
+msgid "FILE"
+msgstr ""
+
+#: ../src/qalc.cc:1727
+msgid "execute commands from a file first"
+msgstr ""
+
+#: ../src/qalc.cc:1729
+msgid "start in interactive mode"
+msgstr ""
+
+#: ../src/qalc.cc:1730 ../src/qalc.cc:1732 ../src/qalc.cc:1734
+#: ../src/qalc.cc:1736
+msgid "SEARCH TERM"
+msgstr ""
+
+#: ../src/qalc.cc:1731
+msgid ""
+"displays a list of all user-defined or matching variables, functions and "
+"units"
+msgstr ""
+
+#: ../src/qalc.cc:1733
+msgid "displays a list of all or matching functions"
+msgstr ""
+
+#: ../src/qalc.cc:1735
+msgid "displays a list of all or matching units"
+msgstr ""
+
+#: ../src/qalc.cc:1737
+msgid "displays a list of all or matching variables"
+msgstr ""
+
+#: ../src/qalc.cc:1738
+msgid "MILLISECONDS"
+msgstr ""
+
+#: ../src/qalc.cc:1739
+msgid ""
+"terminate calculation and display of result after specified amount of time"
+msgstr ""
+
+#: ../src/qalc.cc:1741
+msgid "do not load any functions, units, or variables from file"
+msgstr ""
+
+#: ../src/qalc.cc:1743
+msgid "do not load any global currencies from file"
+msgstr ""
+
+#: ../src/qalc.cc:1745
+msgid "do not load any global data sets from file"
+msgstr ""
+
+#: ../src/qalc.cc:1747
+msgid "do not load any global functions from file"
+msgstr ""
+
+#: ../src/qalc.cc:1749
+msgid "do not load any global units from file"
+msgstr ""
+
+#: ../src/qalc.cc:1751
+msgid "do not load any global variables from file"
+msgstr ""
+
+#: ../src/qalc.cc:1753
+msgid ""
+"start in programming mode (same as -b \"BASE BASE\" -s \"xor^\", with base "
+"conversion)"
+msgstr ""
+
+#: ../src/qalc.cc:1754 ../src/qalc.cc:3323
+msgid "OPTION"
+msgstr ""
+
+#: ../src/qalc.cc:1754 ../src/qalc.cc:3323
+msgid "VALUE"
+msgstr ""
+
+#: ../src/qalc.cc:1755
+msgid "as set command in interactive program session (e.g. -set \"base 16\")"
+msgstr ""
+
+#: ../src/qalc.cc:1757
+msgid "reduce output to just the result of the input expression"
+msgstr ""
+
+#: ../src/qalc.cc:1759
+msgid "switch unicode support on/off"
+msgstr ""
+
+#: ../src/qalc.cc:1761
+msgid "show application version and exit"
+msgstr ""
+
+#: ../src/qalc.cc:1763
+msgid ""
+"The program will start in interactive mode if no expression and no file is "
+"specified (or interactive mode is explicitly selected)."
+msgstr ""
+
+#: ../src/qalc.cc:1763
+msgid "Type help in interactive mode for information about available commands."
+msgstr ""
+
+#: ../src/qalc.cc:1766 ../src/qalc.cc:3342
+msgid ""
+"For more information about mathematical expression and different options, "
+"and a complete list of functions, variables and units, see the relevant "
+"sections in the manual of the graphical user interface (available at https://"
+"qalculate.github.io/manual/index.html)."
+msgstr ""
+
+#: ../src/qalc.cc:1768 ../src/qalc.cc:3344
+msgid ""
+"For more information about mathematical expression and different options, "
+"please consult the man page, or the relevant sections in the manual of the "
+"graphical user interface (available at https://qalculate.github.io/manual/"
+"index.html), which also includes a complete list of functions, variables and "
+"units."
+msgstr ""
+
+#: ../src/qalc.cc:1890
+msgid "No option and value specified for set command."
+msgstr ""
+
+#: ../src/qalc.cc:1901
+msgid "No file specified."
+msgstr ""
+
+#: ../src/qalc.cc:1968
+msgid "Failed to load global definitions!"
+msgstr ""
+
+#: ../src/qalc.cc:2014
+#, c-format
+msgid "Could not open \"%s\".\n"
+msgstr ""
+
+#: ../src/qalc.cc:2060 ../src/qalc.cc:2112 ../src/qalc.cc:4215
+#, c-format
+msgid "Illegal character, '%c', in expression."
+msgstr ""
+
+#. The qalc command "set" as in "set precision 10". The original text string for commands is kept in addition to the translation.
+#: ../src/qalc.cc:2179 ../src/qalc.cc:3323 ../src/qalc.cc:3740
+msgid "set"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2183 ../src/qalc.cc:3320 ../src/qalc.cc:4020
+msgid "save"
+msgstr ""
+
+#: ../src/qalc.cc:2183 ../src/qalc.cc:3320 ../src/qalc.cc:4020
+msgid "store"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2186 ../src/qalc.cc:2994 ../src/qalc.cc:3318
+#: ../src/qalc.cc:4046
+msgid "mode"
+msgstr ""
+
+#: ../src/qalc.cc:2188
+msgid "mode saved"
+msgstr ""
+
+#: ../src/qalc.cc:2190
+msgid "definitions"
+msgstr ""
+
+#: ../src/qalc.cc:2192
+msgid "definitions saved"
+msgstr ""
+
+#: ../src/qalc.cc:2239 ../src/qalc.cc:2241 ../src/qalc.cc:2299
+#: ../src/qalc.cc:2301 ../src/qalc.cc:2356 ../src/qalc.cc:2358
+#, c-format
+msgid "Illegal name. Save as %s instead (default: no)?"
+msgstr ""
+
+#: ../src/qalc.cc:2248 ../src/qalc.cc:2308
+msgid ""
+"An unit or variable with the same name already exists.\n"
+"Do you want to overwrite it (default: no)?"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2271 ../src/qalc.cc:3325 ../src/qalc.cc:4027
+#: ../libqalculate/Function.cc:2206
+msgid "variable"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2328 ../src/qalc.cc:3316 ../src/qalc.cc:4033
+#: ../libqalculate/Function.cc:2178
+msgid "function"
+msgstr ""
+
+#: ../src/qalc.cc:2365
+msgid ""
+"An function with the same name already exists.\n"
+"Do you want to overwrite it (default: no)?"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2385 ../src/qalc.cc:3307 ../src/qalc.cc:4040
+msgid "delete"
+msgstr ""
+
+#: ../src/qalc.cc:2396
+msgid "No user-defined variable or function with the specified name exist."
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2400 ../src/qalc.cc:3305 ../src/qalc.cc:3993
+msgid "assume"
+msgstr ""
+
+#: ../src/qalc.cc:2410
+msgid "syntax"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2417 ../src/qalc.cc:2452 ../src/qalc.cc:3329
+#: ../src/qalc.cc:4085
+msgid "stack"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2437 ../src/qalc.cc:3311 ../src/qalc.cc:4065
+msgid "exrates"
+msgstr ""
+
+#: ../src/qalc.cc:2454 ../src/qalc.cc:2472 ../src/qalc.cc:2481
+#: ../src/qalc.cc:2514 ../src/qalc.cc:2543 ../src/qalc.cc:2552
+#: ../src/qalc.cc:2569 ../src/qalc.cc:2576 ../src/qalc.cc:2594
+#: ../src/qalc.cc:2601
+msgid "The RPN stack is empty."
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2470 ../src/qalc.cc:2479 ../src/qalc.cc:3335
+#: ../src/qalc.cc:4089
+msgid "swap"
+msgstr ""
+
+#: ../src/qalc.cc:2474 ../src/qalc.cc:2483 ../src/qalc.cc:2516
+#: ../src/qalc.cc:2545 ../src/qalc.cc:2554
+msgid "The RPN stack only contains one value."
+msgstr ""
+
+#: ../src/qalc.cc:2502 ../src/qalc.cc:2535 ../src/qalc.cc:2583
+#: ../src/qalc.cc:2607
+msgid "The specified RPN stack index does not exist."
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2512 ../src/qalc.cc:3332 ../src/qalc.cc:4111
+msgid "move"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2541 ../src/qalc.cc:2550 ../src/qalc.cc:3334
+#: ../src/qalc.cc:4107
+msgid "rotate"
+msgstr ""
+
+#: ../src/qalc.cc:2558
+msgid "up"
+msgstr ""
+
+#: ../src/qalc.cc:2560
+msgid "down"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2567 ../src/qalc.cc:2574 ../src/qalc.cc:3331
+#: ../src/qalc.cc:4099
+msgid "copy"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2589 ../src/qalc.cc:3330 ../src/qalc.cc:4075
+msgid "clear stack"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2592 ../src/qalc.cc:2599 ../src/qalc.cc:3333
+#: ../src/qalc.cc:4079
+msgid "pop"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2633 ../src/qalc.cc:2634 ../src/qalc.cc:3324
+#: ../src/qalc.cc:4131
+msgid "convert"
+msgstr ""
+
+#. "to"-operator
+#: ../src/qalc.cc:2633 ../src/qalc.cc:2634 ../src/qalc.cc:3324
+#: ../src/qalc.cc:4131 ../src/qalc.cc:4177
+#: ../libqalculate/Calculator-calculate.cc:1164
+#: ../libqalculate/Calculator-calculate.cc:1166
+#: ../libqalculate/Calculator-calculate.cc:1194
+#: ../libqalculate/Calculator-calculate.cc:1196
+#: ../libqalculate/Calculator-calculate.cc:1225
+#: ../libqalculate/Calculator-calculate.cc:1229
+#: ../libqalculate/Calculator.cc:297 ../libqalculate/Calculator.cc:525
+#: ../libqalculate/Calculator.cc:1323 ../libqalculate/Calculator.cc:1324
+msgid "to"
+msgstr ""
+
+#: ../src/qalc.cc:2763 ../src/qalc.cc:4928
+#: ../libqalculate/Calculator-calculate.cc:807
+msgid "Time zone parsing failed."
+msgstr ""
+
+#: ../src/qalc.cc:2836 ../src/qalc.cc:4942
+#: ../libqalculate/Calculator-calculate.cc:832
+msgid "bases"
+msgstr ""
+
+#: ../src/qalc.cc:2882 ../src/qalc.cc:4944
+#: ../libqalculate/Calculator-calculate.cc:834
+msgid "calendars"
+msgstr ""
+
+#: ../src/qalc.cc:2892 ../src/qalc.cc:4935
+#: ../libqalculate/Calculator-calculate.cc:825
+msgid "fraction"
+msgstr ""
+
+#: ../src/qalc.cc:2900 ../src/qalc.cc:4938
+#: ../libqalculate/Calculator-calculate.cc:827
+msgid "factors"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2902 ../src/qalc.cc:2988 ../src/qalc.cc:3319
+#: ../src/qalc.cc:3732 ../src/qalc.cc:4940
+#: ../libqalculate/Calculator-calculate.cc:830
+msgid "partial fraction"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2985 ../src/qalc.cc:3314 ../src/qalc.cc:3728
+msgid "factor"
+msgstr ""
+
+#: ../src/qalc.cc:2999 ../src/qalc.cc:3757
+msgid "Algebraic Mode"
+msgstr ""
+
+#: ../src/qalc.cc:3034 ../src/qalc.cc:3789
+msgid "Calculation"
+msgstr ""
+
+#: ../src/qalc.cc:3057
+msgid "simplified"
+msgstr ""
+
+#: ../src/qalc.cc:3062 ../src/qalc.cc:3799
+msgid "Enabled Objects"
+msgstr ""
+
+#: ../src/qalc.cc:3074 ../src/qalc.cc:3811
+msgid "Generic Display Options"
+msgstr ""
+
+#: ../src/qalc.cc:3106 ../src/qalc.cc:3824
+msgid "Numerical Display"
+msgstr ""
+
+#: ../src/qalc.cc:3212 ../src/qalc.cc:3907
+msgid "Parsing"
+msgstr ""
+
+#: ../src/qalc.cc:3258 ../src/qalc.cc:3953
+msgid "Units"
+msgstr ""
+
+#: ../src/qalc.cc:3288 ../src/qalc.cc:3986
+msgid "Other"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:3296 ../src/qalc.cc:3724
+msgid "help"
+msgstr ""
+
+#: ../src/qalc.cc:3299
+msgid "Enter a mathematical expression or a command and press enter."
+msgstr ""
+
+#: ../src/qalc.cc:3300
+msgid "Complete functions, units and variables with the tabulator key."
+msgstr ""
+
+#: ../src/qalc.cc:3302
+msgid "Available commands are:"
+msgstr ""
+
+#: ../src/qalc.cc:3305
+msgid "ASSUMPTIONS"
+msgstr ""
+
+#: ../src/qalc.cc:3307 ../src/qalc.cc:3315 ../src/qalc.cc:3316
+#: ../src/qalc.cc:3320 ../src/qalc.cc:3325
+msgid "NAME"
+msgstr ""
+
+#: ../src/qalc.cc:3315 ../src/qalc.cc:3350 ../src/qalc.cc:4050
+msgid "find"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:3315 ../src/qalc.cc:3348 ../src/qalc.cc:3350
+#: ../src/qalc.cc:4050
+msgid "list"
+msgstr ""
+
+#: ../src/qalc.cc:3316 ../src/qalc.cc:3325
+msgid "EXPRESSION"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:3317 ../src/qalc.cc:3376 ../src/qalc.cc:4059
+#: ../libqalculate/Calculator-definitions.cc:2917
+#: ../libqalculate/DataSet.cc:368 ../libqalculate/DataSet.cc:395
+#: ../libqalculate/DataSet.cc:1070
+msgid "info"
+msgstr ""
+
+#: ../src/qalc.cc:3320
+msgid "CATEGORY"
+msgstr ""
+
+#: ../src/qalc.cc:3320
+msgid "TITLE"
+msgstr ""
+
+#: ../src/qalc.cc:3324
+msgid "UNIT or \"TO\" COMMAND"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:3326 ../src/qalc.cc:4181 ../src/qalc.cc:4202
+msgid "quit"
+msgstr ""
+
+#: ../src/qalc.cc:3326 ../src/qalc.cc:4181 ../src/qalc.cc:4202
+msgid "exit"
+msgstr ""
+
+#: ../src/qalc.cc:3327
+msgid "Commands for RPN mode:"
+msgstr ""
+
+#: ../src/qalc.cc:3328
+msgid "STATE"
+msgstr ""
+
+#: ../src/qalc.cc:3331 ../src/qalc.cc:3333
+msgid "INDEX"
+msgstr ""
+
+#: ../src/qalc.cc:3332 ../src/qalc.cc:3335
+msgid "INDEX 1"
+msgstr ""
+
+#: ../src/qalc.cc:3332 ../src/qalc.cc:3335
+msgid "INDEX 2"
+msgstr ""
+
+#: ../src/qalc.cc:3334
+msgid "DIRECTION"
+msgstr ""
+
+#: ../src/qalc.cc:3337
+msgid "Type help COMMAND for more information (example: help save)."
+msgstr ""
+
+#: ../src/qalc.cc:3338
+msgid ""
+"Type info NAME for information about a function, variable or unit (example: "
+"info sin)."
+msgstr ""
+
+#: ../src/qalc.cc:3339
+msgid ""
+"When a line begins with '/', the following text is always interpreted as a "
+"command."
+msgstr ""
+
+#: ../src/qalc.cc:3363 ../src/qalc.cc:3368
+msgid "currencies"
+msgstr ""
+
+#: ../src/qalc.cc:3385
+msgid "No function, variable or unit with specified name exist."
+msgstr ""
+
+#: ../src/qalc.cc:3395
+msgid "Function"
+msgstr ""
+
+#: ../src/qalc.cc:3532
+msgid "Expression:"
+msgstr ""
+
+#: ../src/qalc.cc:3541 ../src/qalc.cc:3544 ../src/qalc.cc:3711
+msgid "Unit"
+msgstr ""
+
+#: ../src/qalc.cc:3547 ../src/qalc.cc:3621
+msgid "Names"
+msgstr ""
+
+#: ../src/qalc.cc:3565
+msgid "Base Unit"
+msgstr ""
+
+#: ../src/qalc.cc:3572
+msgid "Relation"
+msgstr ""
+
+#: ../src/qalc.cc:3577 ../src/qalc.cc:3679
+msgid "Relative uncertainty"
+msgstr ""
+
+#: ../src/qalc.cc:3578 ../src/qalc.cc:3680
+msgid "Uncertainty"
+msgstr ""
+
+#: ../src/qalc.cc:3588
+msgid "Inverse Relation"
+msgstr ""
+
+#: ../src/qalc.cc:3600
+msgid "Base Units"
+msgstr ""
+
+#: ../src/qalc.cc:3615 ../src/qalc.cc:3618
+msgid "Variable"
+msgstr ""
+
+#: ../src/qalc.cc:3730
+msgid "Factorizes the current result."
+msgstr ""
+
+#: ../src/qalc.cc:3734
+msgid "Applies partial fraction decomposition to the current result."
+msgstr ""
+
+#: ../src/qalc.cc:3738
+msgid "Expands the current result."
+msgstr ""
+
+#: ../src/qalc.cc:3752
+msgid "Sets the value of an option."
+msgstr ""
+
+#: ../src/qalc.cc:3753
+msgid "Example: set base 16."
+msgstr ""
+
+#: ../src/qalc.cc:3755
+msgid ""
+"Available options and accepted values are (the current value is marked with "
+"'*'):"
+msgstr ""
+
+#: ../src/qalc.cc:3759
+msgid "Determines if the expression is factorized or not after calculation."
+msgstr ""
+
+#: ../src/qalc.cc:3760
+msgid "Determines if unknown values will be assumed non-zero (x/x=1)."
+msgstr ""
+
+#: ../src/qalc.cc:3761
+msgid "Display a message after a value has been assumed non-zero."
+msgstr ""
+
+#: ../src/qalc.cc:3764
+msgid "Default assumptions for unknown variables."
+msgstr ""
+
+#: ../src/qalc.cc:3792
+msgid ""
+"How approximate variables and calculations are handled. In exact mode "
+"approximate values will not be calculated."
+msgstr ""
+
+#: ../src/qalc.cc:3793
+msgid ""
+"If activated, interval arithmetic determines the final precision of "
+"calculations (avoids wrong results after loss of significance) with "
+"approximate functions and/or irrational numbers."
+msgstr ""
+
+#: ../src/qalc.cc:3794
+msgid ""
+"Determines the method used for interval calculation / uncertainty "
+"propagation."
+msgstr ""
+
+#: ../src/qalc.cc:3796
+msgid ""
+"Specifies the default number of significant digits displayed and determines "
+"the precision used for approximate calculations."
+msgstr ""
+
+#: ../src/qalc.cc:3807
+msgid "Interprete undefined symbols in expressions as unknown variables."
+msgstr ""
+
+#: ../src/qalc.cc:3809
+msgid ""
+"If activated physical constants include units (e.g. c = 299 792 458 m∕s)."
+msgstr ""
+
+#: ../src/qalc.cc:3813
+msgid "Use abbreviated names for units and variables."
+msgstr ""
+
+#: ../src/qalc.cc:3814
+msgid "Use colors to highlight different elements of expressions and results."
+msgstr ""
+
+#: ../src/qalc.cc:3817
+msgid "Always place negative values last."
+msgstr ""
+
+#: ../src/qalc.cc:3820
+msgid "Add extra space around operators."
+msgstr ""
+
+#: ../src/qalc.cc:3822
+msgid "Display Unicode characters."
+msgstr ""
+
+#: ../src/qalc.cc:3826 ../src/qalc.cc:3928
+msgid "bin"
+msgstr ""
+
+#: ../src/qalc.cc:3828 ../src/qalc.cc:3930
+msgid "oct"
+msgstr ""
+
+#: ../src/qalc.cc:3830 ../src/qalc.cc:3932
+msgid "dec"
+msgstr ""
+
+#: ../src/qalc.cc:3832 ../src/qalc.cc:3934
+msgid "hex"
+msgstr ""
+
+#: ../src/qalc.cc:3834
+msgid "sexa"
+msgstr ""
+
+#: ../src/qalc.cc:3853 ../src/qalc.cc:3911
+msgid "Determines the default decimal separator."
+msgstr ""
+
+#: ../src/qalc.cc:3866
+msgid ""
+"Determines how rational numbers are displayed (e.g. 5/4 = 1 + 1/4 = 1.25). "
+"'long' removes limits on the size of the numerator and denonimator."
+msgstr ""
+
+#: ../src/qalc.cc:3867
+msgid ""
+"Enables two's complement representation for display of negative hexadecimal "
+"numbers."
+msgstr ""
+
+#: ../src/qalc.cc:3868 ../src/qalc.cc:3927
+msgid "Use 'j' (instead of 'i') as default symbol for the imaginary unit."
+msgstr ""
+
+#: ../src/qalc.cc:3870
+msgid "Use lowercase e for E-notation (5e2 = 5 * 10^2)."
+msgstr ""
+
+#: ../src/qalc.cc:3871
+msgid "Use lowercase letters for number bases > 10."
+msgstr ""
+
+#: ../src/qalc.cc:3886
+msgid ""
+"If activated, 1/6 is displayed as '0.1 666...', otherwise as '0.166667'."
+msgstr ""
+
+#: ../src/qalc.cc:3887
+msgid ""
+"Determines whether halfway numbers are rounded upwards or towards the "
+"nearest even integer."
+msgstr ""
+
+#: ../src/qalc.cc:3889
+msgid "Determines how scientific notation are used (e.g. 5 543 000 = 5.543E6)."
+msgstr ""
+
+#: ../src/qalc.cc:3904
+msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgstr ""
+
+#: ../src/qalc.cc:3905
+msgid ""
+"Enables two's complement representation for display of negative binary "
+"numbers."
+msgstr ""
+
+#: ../src/qalc.cc:3909
+msgid "Use ^ as bitwise exclusive OR operator."
+msgstr ""
+
+#: ../src/qalc.cc:3922
+msgid "Allows use of ',' as thousands separator."
+msgstr ""
+
+#: ../src/qalc.cc:3925
+msgid "Allows use of '.' as thousands separator."
+msgstr ""
+
+#: ../src/qalc.cc:3949
+msgid "See 'help parsing mode'."
+msgstr ""
+
+#: ../src/qalc.cc:3950
+msgid ""
+"If activated, numbers be interpreted as approximate with precision equal to "
+"the number of significant digits (3.20 = 3.20+/-0.005)."
+msgstr ""
+
+#: ../src/qalc.cc:3955
+msgid "Enables automatic use of hecto, deca, deci, and centi."
+msgstr ""
+
+#: ../src/qalc.cc:3957
+msgid ""
+"Controls automatic unit conversion of the result. 'optimalsi' always "
+"converts non-SI units, while 'optimal' only converts to more optimal unit "
+"expressions, with less units and exponents."
+msgstr ""
+
+#: ../src/qalc.cc:3971
+msgid ""
+"If activated, binary prefixes are used by default for information units."
+msgstr ""
+
+#: ../src/qalc.cc:3972
+msgid ""
+"Enables automatic conversion to the local currency when optimal unit "
+"conversion is enabled."
+msgstr ""
+
+#: ../src/qalc.cc:3973
+msgid ""
+"Enables automatic use of prefixes in the denominator of unit expressions."
+msgstr ""
+
+#: ../src/qalc.cc:3974
+msgid ""
+"If activated, units are separated from variables at the end of the result."
+msgstr ""
+
+#: ../src/qalc.cc:3975
+msgid "Enables automatic use of prefixes in the result."
+msgstr ""
+
+#: ../src/qalc.cc:3976
+msgid ""
+"Use negative exponents instead of division for units in result (m/s = "
+"m*s^-1)."
+msgstr ""
+
+#: ../src/qalc.cc:3981
+msgid "days"
+msgstr ""
+
+#: ../src/qalc.cc:3988
+msgid "Ignore system language and use English (requires restart)."
+msgstr ""
+
+#: ../src/qalc.cc:3989
+msgid "Activates the Reverse Polish Notation stack."
+msgstr ""
+
+#: ../src/qalc.cc:3990
+msgid "Save functions, units, and variables on exit."
+msgstr ""
+
+#: ../src/qalc.cc:3991
+msgid "Save settings on exit."
+msgstr ""
+
+#: ../src/qalc.cc:3995
+msgid "Set default assumptions for unknown variables."
+msgstr ""
+
+#: ../src/qalc.cc:4022
+msgid ""
+"Saves the current result in a variable with the specified name. You may "
+"optionally also provide a category (default \"Temporary\") and a title."
+msgstr ""
+
+#: ../src/qalc.cc:4023
+msgid ""
+"If name equals \"mode\" or \"definitions\", the current mode and "
+"definitions, respectively, will be saved."
+msgstr ""
+
+#: ../src/qalc.cc:4025
+msgid "Example: store var1."
+msgstr ""
+
+#: ../src/qalc.cc:4029
+msgid "Create a variables with the specified name and expression."
+msgstr ""
+
+#: ../src/qalc.cc:4031
+msgid "Example: variable var1 pi / 2."
+msgstr ""
+
+#: ../src/qalc.cc:4035
+msgid "Creates a function with the specified name and expression."
+msgstr ""
+
+#: ../src/qalc.cc:4036
+msgid "Use '\\x', '\\y', '\\z', '\\a', etc. for arguments in the expression."
+msgstr ""
+
+#: ../src/qalc.cc:4038
+msgid "Example: function func1 5*\\x."
+msgstr ""
+
+#: ../src/qalc.cc:4042
+msgid "Removes the user-defined variable or function with the specified name."
+msgstr ""
+
+#: ../src/qalc.cc:4044
+msgid "Example: delete var1."
+msgstr ""
+
+#: ../src/qalc.cc:4048
+msgid "Displays the current mode."
+msgstr ""
+
+#: ../src/qalc.cc:4052
+msgid "Displays a list of variables, functions and units."
+msgstr ""
+
+#: ../src/qalc.cc:4053
+msgid ""
+"Enter with argument 'currencies', 'functions', 'variables' or 'units' to "
+"show a list of all currencies, functions, variables or units. Enter a search "
+"term to find matching variables, functions, and/or units. If command is "
+"called with no argument all user-definied objects are listed."
+msgstr ""
+
+#: ../src/qalc.cc:4055
+msgid "Example: list functions."
+msgstr ""
+
+#: ../src/qalc.cc:4056
+msgid "Example: find dinar."
+msgstr ""
+
+#: ../src/qalc.cc:4057
+msgid "Example: find variables planck."
+msgstr ""
+
+#: ../src/qalc.cc:4061
+msgid "Displays information about a function, variable or unit."
+msgstr ""
+
+#: ../src/qalc.cc:4063
+msgid "Example: info sin."
+msgstr ""
+
+#: ../src/qalc.cc:4067
+msgid "Downloads current exchange rates from the Internet."
+msgstr ""
+
+#: ../src/qalc.cc:4071
+msgid "(De)activates the Reverse Polish Notation stack and syntax."
+msgstr ""
+
+#: ../src/qalc.cc:4073
+msgid ""
+"\"syntax\" activates only the RPN syntax and \"stack\" enables the RPN stack."
+msgstr ""
+
+#: ../src/qalc.cc:4077
+msgid "Clears the entire RPN stack."
+msgstr ""
+
+#: ../src/qalc.cc:4081
+msgid "Removes the top of the RPN stack or the value at the specified index."
+msgstr ""
+
+#: ../src/qalc.cc:4083 ../src/qalc.cc:4095 ../src/qalc.cc:4105
+#: ../src/qalc.cc:4115
+msgid ""
+"Index 1 is the top of stack and negative index values counts from the bottom "
+"of the stack."
+msgstr ""
+
+#: ../src/qalc.cc:4087
+msgid "Displays the RPN stack."
+msgstr ""
+
+#: ../src/qalc.cc:4091
+msgid "Swaps position of values on the RPN stack."
+msgstr ""
+
+#: ../src/qalc.cc:4093
+msgid ""
+"If no index is specified, the values on the top of the stack (index 1 and "
+"index 2) will be swapped and if only one index is specified, the value at "
+"this index will be swapped with the top value."
+msgstr ""
+
+#: ../src/qalc.cc:4097
+msgid "Example: swap 2 4"
+msgstr ""
+
+#: ../src/qalc.cc:4101
+msgid "Duplicates a value on the RPN stack to the top of the stack."
+msgstr ""
+
+#: ../src/qalc.cc:4103
+msgid "If no index is specified, the top of the stack is duplicated."
+msgstr ""
+
+#: ../src/qalc.cc:4109
+msgid "Rotates the RPN stack up (default) or down."
+msgstr ""
+
+#: ../src/qalc.cc:4113
+msgid "Changes the position of a value on the RPN stack."
+msgstr ""
+
+#: ../src/qalc.cc:4117
+msgid "Example: move 2 4"
+msgstr ""
+
+#: ../src/qalc.cc:4121
+msgid "Sets the result number base (equivalent to set base)."
+msgstr ""
+
+#: ../src/qalc.cc:4125
+msgid "Equivalent to set approximation exact."
+msgstr ""
+
+#: ../src/qalc.cc:4129
+msgid "Equivalent to set approximation try exact."
+msgstr ""
+
+#: ../src/qalc.cc:4134
+msgid ""
+"Converts the current result (equivalent to using \"to\" at the end of an "
+"expression)."
+msgstr ""
+
+#: ../src/qalc.cc:4136
+msgid "Possible values:"
+msgstr ""
+
+#: ../src/qalc.cc:4138
+msgid "- a unit or unit expression (e.g. meter or km/h)"
+msgstr ""
+
+#: ../src/qalc.cc:4139
+msgid "prepend with ? to request the optimal prefix"
+msgstr ""
+
+#: ../src/qalc.cc:4140
+msgid "prepend with b? to request the optimal binary prefix"
+msgstr ""
+
+#: ../src/qalc.cc:4141
+msgid "prepend with + or - to force/disable use of mixed units"
+msgstr ""
+
+#: ../src/qalc.cc:4142
+msgid "- a variable or physical constant (e.g. c)"
+msgstr ""
+
+#: ../src/qalc.cc:4143
+msgid "- base (convert to base units)"
+msgstr ""
+
+#: ../src/qalc.cc:4144
+msgid "- optimal (convert to optimal unit)"
+msgstr ""
+
+#: ../src/qalc.cc:4145
+msgid "- mixed (convert to mixed units, e.g. hours + minutes)"
+msgstr ""
+
+#: ../src/qalc.cc:4147
+msgid "- bin / binary (show as binary number)"
+msgstr ""
+
+#: ../src/qalc.cc:4148
+msgid "- bin# (show as binary number with specified number of bits)"
+msgstr ""
+
+#: ../src/qalc.cc:4149
+msgid "- oct / octal (show as octal number)"
+msgstr ""
+
+#: ../src/qalc.cc:4150
+msgid "- duo / duodecimal (show as duodecimal number)"
+msgstr ""
+
+#: ../src/qalc.cc:4151
+msgid "- hex / hexadecimal (show as hexadecimal number)"
+msgstr ""
+
+#: ../src/qalc.cc:4152
+msgid "- hex# (show as hexadecimal number with specified number of bits)"
+msgstr ""
+
+#: ../src/qalc.cc:4153
+msgid "- sex / sexagesimal (show as sexagesimal number)"
+msgstr ""
+
+#: ../src/qalc.cc:4154
+msgid "- bijective (shown in bijective base-26)"
+msgstr ""
+
+#: ../src/qalc.cc:4155
+msgid "- fp16, fp32, fp64, fp80, fp128 (show in binary floating-point format)"
+msgstr ""
+
+#: ../src/qalc.cc:4156
+msgid "- roman (show as roman numerals)"
+msgstr ""
+
+#: ../src/qalc.cc:4157
+msgid "- time (show in time format)"
+msgstr ""
+
+#: ../src/qalc.cc:4158
+msgid "- unicode"
+msgstr ""
+
+#: ../src/qalc.cc:4159
+msgid "- base # (show in specified number base)"
+msgstr ""
+
+#: ../src/qalc.cc:4160
+msgid "- bases (show as binary, octal, decimal and hexadecimal number)"
+msgstr ""
+
+#: ../src/qalc.cc:4162
+msgid "- rectangular / cartesian (show complex numbers in rectangular form)"
+msgstr ""
+
+#: ../src/qalc.cc:4163
+msgid "- exponential (show complex numbers in exponential form)"
+msgstr ""
+
+#: ../src/qalc.cc:4164
+msgid "- polar (show complex numbers in polar form)"
+msgstr ""
+
+#: ../src/qalc.cc:4165
+msgid "- cis (show complex numbers in cis form)"
+msgstr ""
+
+#: ../src/qalc.cc:4166
+msgid "- angle / phasor (show complex numbers in angle/phasor notation)"
+msgstr ""
+
+#: ../src/qalc.cc:4168
+msgid "- fraction (show result as mixed fraction)"
+msgstr ""
+
+#: ../src/qalc.cc:4169
+msgid "- factors (factorize result)"
+msgstr ""
+
+#: ../src/qalc.cc:4171
+msgid "- UTC (show date and time in UTC time zone)"
+msgstr ""
+
+#: ../src/qalc.cc:4172
+msgid "- UTC+/-hh[:mm] (show date and time in specified time zone)"
+msgstr ""
+
+#: ../src/qalc.cc:4173
+msgid "- calendars"
+msgstr ""
+
+#: ../src/qalc.cc:4175
+msgid "Example: to ?g"
+msgstr ""
+
+#: ../src/qalc.cc:4178
+msgid ""
+"This command can also be typed directly at the end of the mathematical "
+"expression (e.g. 5 ft + 2 in to meter)."
+msgstr ""
+
+#: ../src/qalc.cc:4183
+msgid "Terminates this program."
+msgstr ""
+
+#: ../src/qalc.cc:4188
+msgid ""
+"Implicit multiplication does not differ from explicit multiplication "
+"(\"12/2(1+2) = 12/2*3 = 18\", \"5x/5y = 5*x/5*y = xy\")."
+msgstr ""
+
+#: ../src/qalc.cc:4191
+msgid ""
+"Implicit multiplication is parsed before explicit multiplication "
+"(\"12/2(1+2) = 12/(2*3) = 2\", \"5x/5y = (5*x)/(5*y) = x/y\")."
+msgstr ""
+
+#: ../src/qalc.cc:4194
+msgid ""
+"The default adaptive mode works as the \"implicit first\" mode, unless "
+"spaces are found (\"1/5x = 1/(5*x)\", but \"1/5 x = (1/5)*x\"). In the "
+"adaptive mode unit expressions are parsed separately (\"5 m/5 m/s = (5*m)/"
+"(5*(m/s)) = 1 s\")."
+msgstr ""
+
+#: ../src/qalc.cc:4196
+msgid ""
+"Function arguments without parentheses are an exception, where implicit "
+"multiplication in front of variables and units is parsed first regardless of "
+"mode (\"sqrt 2x = sqrt(2x)\")."
+msgstr ""
+
+#: ../src/qalc.cc:4210
+msgid "Unknown command."
+msgstr ""
+
+#: ../src/qalc.cc:4261
+msgid "error"
+msgstr ""
+
+#: ../src/qalc.cc:4263
+msgid "warning"
+msgstr ""
+
+#: ../src/qalc.cc:4372 ../src/qalc.cc:4410 ../src/qalc.cc:4729
+#: ../src/qalc.cc:5191 ../libqalculate/Calculator-calculate.cc:1767
+#: ../libqalculate/MathStructure.cc:448
+#, c-format
+msgid "aborted"
+msgstr ""
+
+#: ../src/qalc.cc:4422
+msgid "RPN Register Moved"
+msgstr ""
+
+#: ../src/qalc.cc:4478
+msgid "Processing (press Enter to abort)"
+msgstr ""
+
+#: ../src/qalc.cc:4573 ../src/qalc.cc:5375
+msgid "approx."
+msgstr ""
+
+#: ../src/qalc.cc:4746
+msgid "Factorizing (press Enter to abort)"
+msgstr ""
+
+#: ../src/qalc.cc:4750
+msgid "Expanding partial fractions…"
+msgstr ""
+
+#: ../src/qalc.cc:4754
+msgid "Expanding (press Enter to abort)"
+msgstr ""
+
+#: ../src/qalc.cc:4758 ../src/qalc.cc:5205
+msgid "Calculating (press Enter to abort)"
+msgstr ""
+
+#: ../src/qalc.cc:5329
+msgid "RPN Operation"
+msgstr ""
+
+#: ../src/qalc.cc:5878
+#, c-format
+msgid ""
+"Couldn't write preferences to\n"
+"%s"
+msgstr ""
+
+#: ../src/qalc.cc:5987
+msgid "Couldn't write definitions"
+msgstr ""
+
+#. thread cancellation is not safe
+#: ../src/test.cc:13 ../src/test.cc:28
+#: ../libqalculate/Calculator-calculate.cc:172
+msgid ""
+"The calculation has been forcibly terminated. Please restart the application "
+"and report this as a bug."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:359
+msgid ""
+"No equality or inequality to solve. The entered expression to solve is not "
+"correct (ex. \"x + 5 = 3\" is correct)"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:406
+#, c-format
+msgid "The comparison is true for all %s (with current assumptions)."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:410
+msgid "No possible solution was found (with current assumptions)."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:414
+#, c-format
+msgid "Was unable to completely isolate %s."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:418
+#: ../libqalculate/BuiltinFunctions-algebra.cc:581
+#: ../libqalculate/BuiltinFunctions-algebra.cc:673
+#, c-format
+msgid "The comparison is true for all %s if %s."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:422
+#, c-format
+msgid "Was unable to isolate %s."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:542
+#: ../libqalculate/BuiltinFunctions-algebra.cc:569
+#: ../libqalculate/BuiltinFunctions-algebra.cc:650
+#, c-format
+msgid ""
+"Was unable to isolate %s with the current assumptions. The assumed sign was "
+"therefore temporarily set as unknown."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:545
+#: ../libqalculate/BuiltinFunctions-algebra.cc:572
+#: ../libqalculate/BuiltinFunctions-algebra.cc:653
+#, c-format
+msgid ""
+"Was unable to isolate %s with the current assumptions. The assumed type and "
+"sign was therefore temporarily set as unknown."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:577
+#: ../libqalculate/BuiltinFunctions-algebra.cc:660
+#, c-format
+msgid "The solution requires that %s."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:667
+#, c-format
+msgid "Solution %s requires that %s."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:738
+#, c-format
+msgid ""
+"Unable to isolate %s.\n"
+"\n"
+"You might need to place the equations and variables in an appropriate order "
+"so that each equation at least contains the corresponding variable (if "
+"automatic reordering failed)."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:740
+#: ../libqalculate/BuiltinFunctions-algebra.cc:754
+#: ../libqalculate/BuiltinFunctions-algebra.cc:763
+#, c-format
+msgid "Unable to isolate %s."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:747
+#, c-format
+msgid "Inequalities is not allowed in %s()."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1089
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1094
+msgid "No differential equation found."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1098
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1127
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1133
+msgid "Unable to solve differential equation."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:34
+#: ../libqalculate/BuiltinFunctions-datetime.cc:68
+msgid "gregorian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:35
+msgid "milankovic"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:36
+msgid "julian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:37
+msgid "islamic"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:38
+msgid "hebrew"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:39
+msgid "egyptian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:40
+msgid "persian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:41
+msgid "coptic"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:42
+msgid "ethiopian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:43
+msgid "indian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:44
+msgid "chinese"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:57
+#, c-format
+msgid "Too many elements (%s) for the dimensions (%sx%s) of the matrix."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:120
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:182
+#, c-format
+msgid "Row %s does not exist in matrix."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:133
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:178
+#, c-format
+msgid "Column %s does not exist in matrix."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:193
+#, c-format
+msgid "Argument 3, %s, is ignored for vectors."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:197
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:218
+#, c-format
+msgid "Element %s does not exist in vector."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:359
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:363
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:395
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:399
+#, c-format
+msgid "%s() requires that all matrices/vectors have the same dimensions."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:539
+msgid ""
+"The number of requested elements in generate vector function must be a "
+"positive integer."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:562
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:579
+msgid "Comparison failed."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-statistics.cc:181
+#: ../libqalculate/BuiltinFunctions-statistics.cc:224
+#, c-format
+msgid "Unsolvable comparison in %s()."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-calculus.cc:314
+msgid "Unable to find limit."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-calculus.cc:409
+#: ../libqalculate/BuiltinFunctions-calculus.cc:441
+#: ../libqalculate/MathStructure-integrate.cc:7295
+#: ../libqalculate/MathStructure-integrate.cc:7315
+#: ../libqalculate/MathStructure-integrate.cc:7350
+#: ../libqalculate/MathStructure-integrate.cc:7374
+#: ../libqalculate/MathStructure-integrate.cc:7424
+#: ../libqalculate/MathStructure-integrate.cc:7463
+#: ../libqalculate/MathStructure-integrate.cc:7659
+#: ../libqalculate/MathStructure-integrate.cc:7713
+#: ../libqalculate/MathStructure-integrate.cc:7755
+msgid "Unable to integrate the expression."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-number.cc:815
+#: ../libqalculate/BuiltinFunctions-number.cc:845 ../libqalculate/Number.cc:463
+#: ../libqalculate/Number.cc:976
+#, c-format
+msgid "Character '%s' was ignored in the number \"%s\" with base %s."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-number.cc:1394
+#: ../libqalculate/Number.cc:2047 ../libqalculate/Number.cc:2172
+msgid "Floating point overflow"
+msgstr ""
+
+#. test calculated floating point value and show mpfr errors (show as errors if error_level > 1, show as warnings if error_level = 1, do not generate message if error_level is zero)
+#: ../libqalculate/BuiltinFunctions-number.cc:1395
+#: ../libqalculate/Number.cc:2046 ../libqalculate/Number.cc:2171
+msgid "Floating point underflow"
+msgstr ""
+
+#. if left value is a function without any arguments, do function replacement
+#: ../libqalculate/BuiltinFunctions-util.cc:419
+#: ../libqalculate/BuiltinFunctions-util.cc:424
+#: ../libqalculate/BuiltinFunctions-util.cc:426
+#: ../libqalculate/BuiltinFunctions-util.cc:436
+#: ../libqalculate/BuiltinFunctions-util.cc:441
+#: ../libqalculate/BuiltinFunctions-util.cc:443
+#: ../libqalculate/BuiltinFunctions-util.cc:459
+#: ../libqalculate/Calculator-calculate.cc:1371
+#: ../libqalculate/Calculator-calculate.cc:1383
+#: ../libqalculate/Calculator-calculate.cc:1385
+#: ../libqalculate/Calculator-calculate.cc:1388
+#: ../libqalculate/Calculator-calculate.cc:1459
+#, c-format
+msgid "Original value (%s) was not found."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:649
+#: ../libqalculate/BuiltinFunctions-util.cc:653
+#, c-format
+msgid "Too few elements (%s) in vector (%s required)"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:699
+#, c-format
+msgid "Object %s does not exist."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:717
+#, c-format
+msgid "Invalid variable name (%s)."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:734
+msgid ""
+"A global unit or variable was deactivated. It will be restored after the new "
+"variable has been removed."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:749
+#, c-format
+msgid "Register %s does not exist. Returning zero."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:818
+#: ../libqalculate/BuiltinFunctions-util.cc:832
+msgid "Matrix"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:843
+#: ../libqalculate/BuiltinFunctions-util.cc:893
+msgid "Vector"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:858
+#: ../libqalculate/BuiltinFunctions-util.cc:904
+#: ../libqalculate/Calculator-plot.cc:135
+msgid "Unable to generate plot data with current min, max and step size."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:860
+#: ../libqalculate/BuiltinFunctions-util.cc:906
+msgid "Sampling rate must be a positive integer."
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:869
+#: ../libqalculate/BuiltinFunctions-util.cc:915
+#: ../libqalculate/Calculator-plot.cc:105
+msgid "Unable to generate plot data with current min, max and sampling rate."
+msgstr ""
+
+#: ../libqalculate/Calculator-calculate.cc:303
+#: ../libqalculate/Calculator-calculate.cc:428
+msgid "Stack is empty. Filling remaining function arguments with zeroes."
+msgstr ""
+
+#: ../libqalculate/Calculator-calculate.cc:1089
+msgid "calculating..."
+msgstr ""
+
+#. "where"-operator
+#: ../libqalculate/Calculator-calculate.cc:1262
+#: ../libqalculate/Calculator-calculate.cc:1264
+#: ../libqalculate/Calculator-calculate.cc:1283
+#: ../libqalculate/Calculator-calculate.cc:1285
+#: ../libqalculate/Calculator.cc:1327
+msgid "where"
+msgstr ""
+
+#: ../libqalculate/Calculator-calculate.cc:1481
+#, c-format
+msgid "Unhandled \"where\" expression: %s"
+msgstr ""
+
+#: ../libqalculate/Calculator-calculate.cc:1719
+#: ../libqalculate/Calculator-calculate.cc:1766
+msgid "timed out"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:233 ../libqalculate/Calculator.cc:461
+msgid "per"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:235 ../libqalculate/Calculator.cc:463
+msgid "times"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:237 ../libqalculate/Calculator.cc:465
+msgid "plus"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:239 ../libqalculate/Calculator.cc:467
+msgid "minus"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:241 ../libqalculate/Calculator.cc:469
+#: ../libqalculate/MathStructure-print.cc:3418 ../libqalculate/Function.cc:1361
+#: ../libqalculate/Function.cc:1369 ../libqalculate/Function.cc:1802
+#: ../libqalculate/Function.cc:1964 ../libqalculate/Function.cc:1972
+msgid "and"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:612
+msgid "Gradians unit is missing. Creating one for this session."
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:613 ../libqalculate/Calculator.cc:621
+#: ../libqalculate/Calculator.cc:629
+msgid "Angle/Plane Angle"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:620
+msgid "Radians unit is missing. Creating one for this session."
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:628
+msgid "Degrees unit is missing. Creating one for this session."
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:1703 ../libqalculate/Calculator.cc:1704
+#: ../libqalculate/Calculator.cc:1708
+#: ../libqalculate/Calculator-definitions.cc:3339
+#: ../libqalculate/Calculator-definitions.cc:3527
+#: ../libqalculate/Calculator-definitions.cc:3585
+msgid "Currency"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:2643
+#, c-format
+msgid ""
+"\"%s\" is not allowed in names anymore. Please change the name of \"%s\", or "
+"the variable will be lost."
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:2661
+#, c-format
+msgid ""
+"\"%s\" is not allowed in names anymore. Please change the name \"%s\", or "
+"the function will be lost."
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:2678
+#, c-format
+msgid ""
+"\"%s\" is not allowed in names anymore. Please change the name \"%s\", or "
+"the unit will be lost."
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:2885
+#, c-format
+msgid "Name \"%s\" is in use. Replacing with \"%s\"."
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:793 ../libqalculate/DataSet.cc:571
+#, c-format
+msgid "File not identified as Qalculate! definitions file: %s."
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:2900
+#: ../libqalculate/DataSet.cc:366
+msgid "Object"
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:2909
+#: ../libqalculate/DataSet.cc:367
+msgid "Property"
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:3208
+msgid "column"
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:3211
+msgid "Column "
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:3704
+#: ../libqalculate/Calculator-definitions.cc:3705
+#: ../libqalculate/Calculator-definitions.cc:3709
+#: ../libqalculate/Calculator-definitions.cc:3712
+#: ../libqalculate/Calculator-definitions.cc:3744
+#: ../libqalculate/Calculator-definitions.cc:3745
+#: ../libqalculate/Calculator-definitions.cc:3748
+#: ../libqalculate/Calculator-definitions.cc:3767
+#: ../libqalculate/Calculator-definitions.cc:3768
+#: ../libqalculate/Calculator-definitions.cc:3771
+#: ../libqalculate/Calculator-definitions.cc:3791
+#: ../libqalculate/Calculator-definitions.cc:3792
+#: ../libqalculate/Calculator-definitions.cc:3795
+#, c-format
+msgid "Failed to download exchange rates from %s: %s."
+msgstr ""
+
+#. ignore operators
+#: ../libqalculate/Calculator-parse.cc:1785
+#: ../libqalculate/Calculator-parse.cc:1838
+#: ../libqalculate/Calculator-parse.cc:1842
+#: ../libqalculate/Calculator-parse.cc:3043
+#: ../libqalculate/Calculator-parse.cc:3052
+#: ../libqalculate/Calculator-parse.cc:3126
+#: ../libqalculate/Calculator-parse.cc:3209
+#: ../libqalculate/Calculator-parse.cc:3231
+#: ../libqalculate/Calculator-parse.cc:3232
+#: ../libqalculate/Calculator-parse.cc:3233
+#, c-format
+msgid "Misplaced operator(s) \"%s\" ignored"
+msgstr ""
+
+#. ignore operators
+#: ../libqalculate/Calculator-parse.cc:1834
+#: ../libqalculate/Calculator-parse.cc:3234
+#, c-format
+msgid "Misplaced '%c' ignored"
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:1876 ../libqalculate/Function.cc:1519
+#: ../libqalculate/Function.cc:1550
+#, c-format
+msgid "Internal id %s does not exist."
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:1896
+#, c-format
+msgid "\"%s\" is not a valid variable/function/unit."
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:1911
+#, c-format
+msgid ""
+"Trailing characters \"%s\" (not a valid variable/function/unit) in number "
+"\"%s\" was ignored."
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:2189
+msgid "RPN syntax error. Values left at the end of the RPN expression."
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:2192
+#: ../libqalculate/Calculator-parse.cc:2283
+msgid "Unused stack values."
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:2325
+#: ../libqalculate/Calculator-parse.cc:2533
+#, c-format
+msgid "RPN syntax error. Operator '%c' not supported."
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:2371
+msgid "RPN syntax error. Stack is empty."
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:2392
+msgid "RPN syntax error. Operator ignored as there where only one stack value."
+msgstr ""
+
+#: ../libqalculate/Calculator-parse.cc:3077
+#: ../libqalculate/Calculator-parse.cc:3153
+msgid ""
+"The expression is ambiguous (be careful when combining implicit "
+"multiplication and division)."
+msgstr ""
+
+#: ../libqalculate/Calculator-plot.cc:101
+#: ../libqalculate/Calculator-plot.cc:131
+#: ../libqalculate/Calculator-plot.cc:161
+#: ../libqalculate/Calculator-plot.cc:498
+msgid "It took too long to generate the plot data."
+msgstr ""
+
+#: ../libqalculate/Calculator-plot.cc:193
+msgid "No extension in file name. Saving as PNG image."
+msgstr ""
+
+#: ../libqalculate/Calculator-plot.cc:212
+msgid "Unknown extension in file name. Saving as PNG image."
+msgstr ""
+
+#: ../libqalculate/Calculator-plot.cc:429
+#, c-format
+msgid "Could not create temporary file %s"
+msgstr ""
+
+#: ../libqalculate/Calculator-plot.cc:545
+msgid ""
+"Failed to invoke gnuplot. Make sure that you have gnuplot installed in your "
+"path."
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:392
+#, c-format
+msgid "Object %s not available in data set."
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:402
+#, c-format
+msgid "Property %s not available in data set."
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:407
+#, c-format
+msgid "Property %s not defined for object %s."
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:548 ../libqalculate/DataSet.cc:556
+#, c-format
+msgid "Unable to load data objects in %s."
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1074
+msgid "data property"
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1076
+msgid "name of a data property"
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1084 ../libqalculate/DataSet.cc:1100
+msgid "no properties available"
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1134
+#, c-format
+msgid ""
+"Data set \"%s\" has no object key that supports the provided argument type."
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1139
+msgid "data object"
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1142
+msgid "an object from"
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1169
+msgid "use"
+msgstr ""
+
+#: ../libqalculate/MathStructure-calculate.cc:76
+#, c-format
+msgid "Required assumption: %s."
+msgstr ""
+
+#: ../libqalculate/MathStructure-calculate.cc:95
+#: ../libqalculate/MathStructure-calculate.cc:117
+#: ../libqalculate/MathStructure-calculate.cc:148
+#: ../libqalculate/MathStructure-integrate.cc:7087
+#, c-format
+msgid "To avoid division by zero, the following must be true: %s."
+msgstr ""
+
+#: ../libqalculate/MathStructure-calculate.cc:1662
+#: ../libqalculate/MathStructure-calculate.cc:1684
+#, c-format
+msgid ""
+"The second matrix must have as many rows (was %s) as the first has columns "
+"(was %s) for matrix multiplication."
+msgstr ""
+
+#: ../libqalculate/MathStructure-calculate.cc:6123
+#: ../libqalculate/MathStructure-calculate.cc:6164
+#: ../libqalculate/MathStructure-calculate.cc:6197
+#: ../libqalculate/MathStructure-calculate.cc:6264
+#: ../libqalculate/MathStructure-calculate.cc:6292
+#: ../libqalculate/MathStructure-calculate.cc:6311
+#: ../libqalculate/MathStructure-calculate.cc:6330
+#: ../libqalculate/MathStructure-calculate.cc:6349
+#: ../libqalculate/MathStructure-calculate.cc:6457
+#: ../libqalculate/MathStructure-factor.cc:413
+#: ../libqalculate/MathStructure-factor.cc:1304
+msgid "This is a bug. Please report it."
+msgstr ""
+
+#: ../libqalculate/MathStructure-calculate.cc:6546
+#: ../libqalculate/Function.cc:557
+msgid "No unknown variable/symbol was found."
+msgstr ""
+
+#: ../libqalculate/MathStructure-convert.cc:262
+msgid ""
+"Calculations involving conversion of units without proportional linear "
+"relationship (e.g. with multiple temperature units), might give unexpected "
+"results and is not recommended."
+msgstr ""
+
+#: ../libqalculate/MathStructure-eval.cc:754
+msgid "Interval potentially calculated wide."
+msgstr ""
+
+#: ../libqalculate/MathStructure-eval.cc:2088
+msgid ""
+"Calculation of uncertainty propagation partially failed (using interval "
+"arithmetic instead when necessary)."
+msgstr ""
+
+#: ../libqalculate/MathStructure-eval.cc:2234
+msgid ""
+"Calculation of uncertainty propagation failed (using interval arithmetic "
+"instead)."
+msgstr ""
+
+#: ../libqalculate/MathStructure-factor.cc:3160
+msgid ""
+"Because of time constraints only a limited number of combinations of terms "
+"were tried during factorization. Repeat factorization to try other random "
+"combinations."
+msgstr ""
+
+#: ../libqalculate/MathStructure-integrate.cc:7669
+#: ../libqalculate/MathStructure-integrate.cc:7744
+msgid "Unable to integrate the expression exact."
+msgstr ""
+
+#: ../libqalculate/MathStructure-integrate.cc:7708
+msgid "Definite integral was approximated."
+msgstr ""
+
+#: ../libqalculate/MathStructure-isolatex.cc:999
+#: ../libqalculate/MathStructure-isolatex.cc:1176
+#: ../libqalculate/MathStructure-isolatex.cc:1815
+#: ../libqalculate/MathStructure-isolatex.cc:2335
+#: ../libqalculate/MathStructure-isolatex.cc:2401
+#: ../libqalculate/MathStructure-isolatex.cc:2451
+#: ../libqalculate/MathStructure-isolatex.cc:2472
+#: ../libqalculate/MathStructure-isolatex.cc:2530
+#: ../libqalculate/MathStructure-isolatex.cc:2656
+#: ../libqalculate/MathStructure-isolatex.cc:2801
+#, c-format
+msgid "Interval arithmetic was disabled during calculation of %s."
+msgstr ""
+
+#: ../libqalculate/MathStructure-isolatex.cc:2800
+#, c-format
+msgid "Not all complex roots were calculated for %s."
+msgstr ""
+
+#: ../libqalculate/MathStructure-isolatex.cc:4394
+#, c-format
+msgid "Only one or two of the roots where calculated for %s."
+msgstr ""
+
+#: ../libqalculate/MathStructure-limit.cc:967
+#: ../libqalculate/MathStructure-limit.cc:972
+#, c-format
+msgid "Limit for %s determined graphically."
+msgstr ""
+
+#: ../libqalculate/MathStructure-matrixvector.cc:62
+#, c-format
+msgid "Unsolvable comparison at element %s when trying to rank vector."
+msgstr ""
+
+#: ../libqalculate/MathStructure-matrixvector.cc:112
+#, c-format
+msgid "Unsolvable comparison at element %s when trying to sort vector."
+msgstr ""
+
+#: ../libqalculate/MathStructure-matrixvector.cc:537
+msgid "The determinant can only be calculated for square matrices."
+msgstr ""
+
+#: ../libqalculate/MathStructure-matrixvector.cc:600
+msgid "The permanent can only be calculated for square matrices."
+msgstr ""
+
+#: ../libqalculate/MathStructure-matrixvector.cc:687
+msgid "Inverse of singular matrix."
+msgstr ""
+
+#: ../libqalculate/MathStructure-matrixvector.cc:817
+#: ../libqalculate/MathStructure-matrixvector.cc:860
+msgid "Too many data points"
+msgstr ""
+
+#: ../libqalculate/MathStructure-matrixvector.cc:824
+msgid ""
+"The selected min and max do not result in a positive, finite number of data "
+"points"
+msgstr ""
+
+#: ../libqalculate/MathStructure-matrixvector.cc:857
+msgid ""
+"The selected min, max and step size do not result in a positive, finite "
+"number of data points"
+msgstr ""
+
+#: ../libqalculate/MathStructure-print.cc:3627
+msgid "undefined"
+msgstr ""
+
+#: ../libqalculate/Function.cc:185
+#, c-format
+msgid "%s() requires that %s"
+msgstr ""
+
+#: ../libqalculate/Function.cc:351 ../libqalculate/Function.cc:413
+#: ../libqalculate/Function.cc:474
+#, c-format
+msgid ""
+"Additional arguments for function %s() was ignored. Function can only use %s "
+"argument(s)."
+msgstr ""
+
+#: ../libqalculate/Function.cc:495
+#, c-format
+msgid "You need at least %s argument(s) (%s) in function %s()."
+msgstr ""
+
+#: ../libqalculate/Function.cc:497
+#, c-format
+msgid "You need at least %s argument(s) in function %s()."
+msgstr ""
+
+#: ../libqalculate/Function.cc:1351
+msgid "a free value"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1356
+msgid "that is nonzero"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1364
+msgid "that is rational (polynomial)"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1372
+msgid "that fulfills the condition:"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1439
+#, c-format
+msgid "Argument %s in %s() must be %s."
+msgstr ""
+
+#: ../libqalculate/Function.cc:1441
+#, c-format
+msgid "Argument %s, %s, in %s() must be %s."
+msgstr ""
+
+#: ../libqalculate/Function.cc:1783
+msgid "a rational number"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1785
+msgid "a number"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1787
+msgid "a real number"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1792 ../libqalculate/Function.cc:1945
+#: ../libqalculate/Function.cc:1950
+msgid ">="
+msgstr ""
+
+#: ../libqalculate/Function.cc:1794
+msgid ">"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1806 ../libqalculate/Function.cc:1967
+#: ../libqalculate/Function.cc:1974
+msgid "<="
+msgstr ""
+
+#: ../libqalculate/Function.cc:1808
+msgid "<"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1942
+msgid "an integer"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1999
+msgid "symbol"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2000
+msgid "an unknown variable/symbol"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2013
+msgid "text"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2014
+msgid "a text string"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2036
+msgid "date"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2037
+msgid "a date"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2086
+msgid "a vector with "
+msgstr ""
+
+#: ../libqalculate/Function.cc:2098
+msgid "a vector"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2147
+msgid "a square matrix"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2149
+msgid "a matrix"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2164
+msgid "object"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2165
+msgid "a valid function, unit or variable name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2179
+msgid "a valid function name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2192
+msgid "unit"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2193
+msgid "a valid unit name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2207
+msgid "a valid variable name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2220
+msgid "file"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2221
+msgid "a valid file name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2234
+msgid "boolean"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2235
+msgid "a boolean (0 or 1)"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2246
+msgid "an angle or a number (using the default angle unit)"
+msgstr ""
+
+#: ../libqalculate/Number.cc:267 ../libqalculate/Number.cc:10424
+msgid ""
+"Cannot display numbers greater than 9999 or less than -9999 as roman "
+"numerals."
+msgstr ""
+
+#: ../libqalculate/Number.cc:367
+#, c-format
+msgid "Character '%s' was ignored in the number \"%s\" in bijective base-26."
+msgstr ""
+
+#. digit value is higher than allowed by the base: show a warning, but use anyway
+#. digit value is higher than allowed by base: show a warning, but use anyway
+#: ../libqalculate/Number.cc:468 ../libqalculate/Number.cc:518
+#: ../libqalculate/Number.cc:548
+#, c-format
+msgid "Digit '%s' is too high for number base."
+msgstr ""
+
+#: ../libqalculate/Number.cc:605
+msgid ""
+"Assuming the unusual practice of letting a last capital I mean 2 in a roman "
+"numeral."
+msgstr ""
+
+#: ../libqalculate/Number.cc:689 ../libqalculate/Number.cc:716
+#: ../libqalculate/Number.cc:721
+#, c-format
+msgid "Error in roman numerals: %s."
+msgstr ""
+
+#: ../libqalculate/Number.cc:726
+#, c-format
+msgid "Unknown roman numeral: %c."
+msgstr ""
+
+#: ../libqalculate/Number.cc:784
+#, c-format
+msgid ""
+"Errors in roman numerals: \"%s\". Interpreted as %s, which should be written "
+"as %s."
+msgstr ""
+
+#: ../libqalculate/Number.cc:887
+msgid "Too large exponent."
+msgstr ""
+
+#. only allow decimals after last ":"
+#: ../libqalculate/Number.cc:923
+msgid "':' in decimal number ignored (decimal point detected)."
+msgstr ""
+
+#: ../libqalculate/Number.cc:2048 ../libqalculate/Number.cc:2173
+msgid "Floating point division by zero exception"
+msgstr ""
+
+#: ../libqalculate/Number.cc:2049 ../libqalculate/Number.cc:2176
+msgid "Floating point not a number exception"
+msgstr ""
+
+#: ../libqalculate/Number.cc:2050 ../libqalculate/Number.cc:2174
+msgid "Floating point range exception"
+msgstr ""
+
+#: ../libqalculate/Number.cc:3649
+msgid "Division by zero."
+msgstr ""
+
+#. 0^0
+#: ../libqalculate/Number.cc:3655
+msgid "0^0 might be considered undefined"
+msgstr ""
+
+#: ../libqalculate/Number.cc:3662
+msgid "The result of 0^i is possibly undefined"
+msgstr ""
+
+#: ../libqalculate/Number.cc:3711 ../libqalculate/Number.cc:6140
+#: ../libqalculate/Number.cc:6251 ../libqalculate/Number.cc:6575
+#: ../libqalculate/Number.cc:6583 ../libqalculate/Number.cc:6616
+#: ../libqalculate/Number.cc:6713 ../libqalculate/Number.cc:6862
+#: ../libqalculate/Number.cc:6974
+msgid "Interval calculated wide."
+msgstr ""
+
+#: ../libqalculate/Number.cc:5163 ../libqalculate/Number.cc:5389
+#: ../libqalculate/Number.cc:5476 ../libqalculate/Number.cc:5760
+#: ../libqalculate/Number.cc:5846 ../libqalculate/Number.cc:5932
+#: ../libqalculate/Number.cc:7179 ../libqalculate/Number.cc:7197
+#: ../libqalculate/Number.cc:7216 ../libqalculate/Number.cc:7552
+#: ../libqalculate/Number.cc:7599 ../libqalculate/Number.cc:7744
+#: ../libqalculate/Number.cc:8077 ../libqalculate/Number.cc:8233
+#: ../libqalculate/Number.cc:8665 ../libqalculate/Number.cc:9060
+#, c-format
+msgid "%s() lacks proper support interval arithmetic."
+msgstr ""
+
+#: ../libqalculate/Number.cc:9670
+#, c-format
+msgid "The value is too high for the number of floating point bits (%s)."
+msgstr ""
+
+#: ../libqalculate/Number.cc:9920
+msgid "Unsupported base"
+msgstr ""
+
+#: ../libqalculate/Number.cc:10421
+msgid "Can only display rational numbers as roman numerals."
+msgstr ""
+
+#: ../libqalculate/Number.cc:10908 ../libqalculate/Number.cc:10916
+msgid "infinity"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "January"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "February"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "March"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "April"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "May"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "June"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "July"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "August"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "September"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "October"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "November"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "December"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Thout"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Paopi"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Hathor"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Koiak"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Tobi"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Meshir"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Paremhat"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Parmouti"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Pashons"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Paoni"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Epip"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Mesori"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Pi Kogi Enavot"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Mäskäräm"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ṭəqəmt"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ḫədar"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Taḫśaś"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ṭərr"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Yäkatit"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Mägabit"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Miyazya"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Gənbo"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Säne"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ḥamle"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Nähase"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ṗagume"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Muḥarram"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Ṣafar"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Rabī‘ al-awwal"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Rabī‘ ath-thānī"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Jumādá al-ūlá"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Jumādá al-ākhirah"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Rajab"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Sha‘bān"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Ramaḍān"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Shawwāl"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Dhū al-Qa‘dah"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Dhū al-Ḥijjah"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Farvardin"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Ordibehesht"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Khordad"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Tir"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Mordad"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Shahrivar"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Mehr"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Aban"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Azar"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Dey"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Bahman"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Esfand"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Chaitra"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Vaishākha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Jyēshtha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Āshādha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Shrāvana"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Bhaadra"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Āshwin"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Kārtika"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Agrahayana"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Pausha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Māgha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Phalguna"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Wood"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Fire"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Earth"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Metal"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Water"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Rat"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Ox"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Tiger"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Rabbit"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Dragon"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Snake"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Horse"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Goat"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Monkey"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Rooster"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Dog"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Pig"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:354
+msgid "now"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:358
+msgid "today"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:362
+msgid "tomorrow"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:367
+msgid "yesterday"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:2611
+msgid "leap month"
+msgstr ""
+
+#: ../libqalculate/Unit.cc:1100
+msgid "Error(s) in unitexpression."
+msgstr ""
+
+#: ../libqalculate/Variable.cc:502
+#, c-format
+msgid "Recursive variable: %s = %s"
+msgstr ""
+
+#: ../libqalculate/util.cc:172
+msgid "Yes"
+msgstr ""
+
+#: ../libqalculate/util.cc:173
+msgid "No"
+msgstr ""
+
+#: ../libqalculate/util.cc:180
+msgid "True"
+msgstr ""
+
+#: ../libqalculate/util.cc:181
+msgid "False"
+msgstr ""
+
+#: ../libqalculate/util.cc:188
+msgid "On"
+msgstr ""
+
+#: ../libqalculate/util.cc:189
+msgid "Off"
+msgstr ""


### PR DESCRIPTION
Translated definitions (names), not commands (it's weird translating things like "sqrt"), nor references (the suggestions work well for an unit you don't know the symbol of, although making the search ignore accents would be nice).