### PR TITLE
Split pre-compiled definitions into .h and .c file

### DIFF
--- a/libqalculate/Calculator-definitions.cc
+++ b/libqalculate/Calculator-definitions.cc
@@ -83,12 +83,7 @@ using std::queue;
 
 #ifdef COMPILED_DEFINITIONS
 
-#	include "prefixes_xml.h"
-#	include "currencies_xml.h"
-#	include "units_xml.h"
-#	include "functions_xml.h"
-#	include "datasets_xml.h"
-#	include "variables_xml.h"
+#	include "definitions.h"
 
 bool Calculator::loadGlobalDefinitions() {
 	bool b = true;
@@ -3337,10 +3332,6 @@ bool Calculator::exportCSV(const MathStructure &mstruct, const char *file_name, 
 	return true;
 }
 
-#ifdef COMPILED_DEFINITIONS
-#	include "eurofxref_daily_xml.h"
-#	include "rates_json.h"
-#endif
 
 bool Calculator::loadExchangeRates() {
 

--- a/libqalculate/DataSet.cc
+++ b/libqalculate/DataSet.cc
@@ -439,8 +439,7 @@ const string &DataSet::defaultDataFile() const {
 #	define FILE_SEPARATOR_CHAR '/'
 #endif
 #ifdef COMPILED_DEFINITIONS
-#	include "planets_xml.h"
-#	include "elements_xml.h"
+#	include "definitions.h"
 #endif
 bool DataSet::loadObjects(const char *file_name, bool is_user_defs) {
 	if(file_name) {

--- a/libqalculate/Makefile.am
+++ b/libqalculate/Makefile.am
@@ -9,6 +9,31 @@ if COMPILED_DEFINITIONS_GIO
 definitions.c : $(top_srcdir)/data/definitions.gresource.xml $(top_srcdir)/data/*.xml
 	glib-compile-resources --generate-source --target=$@ --sourcedir=$(top_srcdir)/data $(top_srcdir)/data/definitions.gresource.xml
 
+libqalculate_compiled_def_sources = definitions.c
+endif
+
+if COMPILED_DEFINITIONS
+definitions.c: ${top_srcdir}/data/*.xml ${top_srcdir}/data/*.json
+	echo > $@ || (rm $@;exit 1)
+	for FILE in $+; do \
+		printf "const char * " >> $@ || (rm $@;exit 1); \
+		basename -- $$FILE | sed 's/[.-]/_/g' >> $@ || (rm $@;exit 1); \
+		printf " = " >> $@ || (rm $@;exit 1); \
+		sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $$FILE >>$@ || (rm $@;exit 1); \
+		printf ';\n\n' >>$@ || (rm $@;exit 1); \
+	done
+
+libqalculate_compiled_def_sources = definitions.c
+libqalculate_compiled_def_headers = definitions.h
+endif
+
+libqalculateinclude_HEADERS = \
+	Function.h Calculator.h DataSet.h Variable.h \
+	ExpressionItem.h Number.h MathStructure.h Prefix.h \
+	util.h includes.h Unit.h BuiltinFunctions.h \
+	QalculateDateTime.h qalculate.h \
+	$(libqalculate_compiled_def_headers)
+
 libqalculate_la_SOURCES = \
 	Function.cc Calculator.cc Calculator-plot.cc Calculator-parse.cc \
 	Calculator-definitions.cc Calculator-calculate.cc Calculator-convert.cc \
@@ -24,91 +49,10 @@ libqalculate_la_SOURCES = \
 	MathStructure-matrixvector.cc MathStructure-print.cc \
 	MathStructure-differentiate.cc MathStructure-calculate.cc MathStructure-eval.cc \
 	MathStructure-convert.cc MathStructure-decompose.cc MathStructure-limit.cc \
-	definitions.c
-else
-libqalculate_la_SOURCES = \
-	Function.cc Calculator.cc Calculator-plot.cc Calculator-parse.cc \
-	Calculator-definitions.cc Calculator-calculate.cc Calculator-convert.cc \
-	DataSet.cc Variable.cc ExpressionItem.cc Number.cc MathStructure.cc \
-	Prefix.cc support.h util.cc Unit.cc QalculateDateTime.cc \
-	BuiltinFunctions-util.cc BuiltinFunctions-trigonometry.cc BuiltinFunctions-matrixvector.cc \
-	BuiltinFunctions-datetime.cc BuiltinFunctions-statistics.cc \
-	BuiltinFunctions-explog.cc BuiltinFunctions-special.cc BuiltinFunctions-algebra.cc \
-	BuiltinFunctions-calculus.cc BuiltinFunctions-number.cc \
-	BuiltinFunctions-combinatorics.cc BuiltinFunctions-logical.cc \
-	MathStructure-factor.cc MathStructure-gcd.cc MathStructure-integrate.cc \
-	MathStructure-isolatex.cc MathStructure-polynomial.cc \
-	MathStructure-matrixvector.cc MathStructure-print.cc \
-	MathStructure-differentiate.cc MathStructure-calculate.cc MathStructure-eval.cc \
-	MathStructure-convert.cc MathStructure-decompose.cc MathStructure-limit.cc
-endif
+	$(libqalculate_compiled_def_sources)
+
 
 libqalculateincludedir = $(includedir)/libqalculate
-
-if COMPILED_DEFINITIONS
-prefixes_xml.h: ${top_srcdir}/data/prefixes.xml
-	echo "const char * prefixes_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-currencies_xml.h: ${top_srcdir}/data/currencies.xml
-	echo "const char * currencies_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-functions_xml.h: ${top_srcdir}/data/functions.xml
-	echo "const char * functions_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-variables_xml.h: ${top_srcdir}/data/variables.xml
-	echo "const char * variables_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-units_xml.h: ${top_srcdir}/data/units.xml
-	echo "const char * units_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-datasets_xml.h: ${top_srcdir}/data/datasets.xml
-	echo "const char * datasets_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-planets_xml.h: ${top_srcdir}/data/planets.xml
-	echo "const char * planets_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-elements_xml.h: ${top_srcdir}/data/elements.xml
-	echo "const char * elements_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-eurofxref_daily_xml.h: ${top_srcdir}/data/eurofxref-daily.xml
-	echo "const char * eurofxref_daily_xml = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-rates_json.h: ${top_srcdir}/data/rates.json
-	echo "const char * rates_json = " >$@ || (rm $@;exit 1)
-	sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e 's/^/\"/' -e 's/$$/\\n\"/' $< >>$@ || (rm $@;exit 1)
-	echo ';' >>$@ || (rm $@;exit 1)
-
-libqalculateinclude_HEADERS = \
-	Function.h Calculator.h DataSet.h Variable.h \
-	ExpressionItem.h Number.h MathStructure.h Prefix.h \
-	util.h includes.h Unit.h BuiltinFunctions.h \
-	QalculateDateTime.h qalculate.h \
-	prefixes_xml.h units_xml.h currencies_xml.h functions_xml.h variables_xml.h datasets_xml.h planets_xml.h elements_xml.h eurofxref_daily_xml.h rates_json.h
-else
-libqalculateinclude_HEADERS = \
-	Function.h Calculator.h DataSet.h Variable.h \
-	ExpressionItem.h Number.h MathStructure.h Prefix.h \
-	util.h includes.h Unit.h BuiltinFunctions.h \
-	QalculateDateTime.h qalculate.h
-endif
 
 noinst_HEADERS = MathStructure-support.h Calculator_p.h bernoulli_numbers.h
 

--- a/libqalculate/definitions.h
+++ b/libqalculate/definitions.h
@@ -1,0 +1,11 @@
+extern const char * currencies_xml;
+extern const char * datasets_xml;
+extern const char * definitions_gresource_xml;
+extern const char * elements_xml;
+extern const char * eurofxref_daily_xml;
+extern const char * functions_xml;
+extern const char * planets_xml;
+extern const char * prefixes_xml;
+extern const char * units_xml;
+extern const char * variables_xml;
+extern const char * rates_json;


### PR DESCRIPTION
This is so that parallel builds work properly. Otherwise, we'd have to
somehow add a dependency in the makefile from Calculator-definitions.cc
to the various generated headers, which I don't quite understand how to
do.

The naming & location of the generated files was not very carefully
chosen--I'd appreciate it if you'd take a look and let me know where
you'd like them to go.

(See #225)