### PR TITLE
Allow docs to be built out-of-tree

### DIFF
--- a/docs/reference/Doxyfile
+++ b/docs/reference/Doxyfile
@@ -160,7 +160,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = ../../
+STRIP_FROM_PATH        =
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which
@@ -813,7 +813,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../../libqalculate
+INPUT                  = $(top_srcdir)/libqalculate
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -855,9 +855,9 @@ RECURSIVE              = NO
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ../../libqalculate/BuiltinFunctions.h \
-                         ../../libqalculate/Calculator_p.h \
-                         ../../libqalculate/MathStructure-support.h
+EXCLUDE                = $(top_srcdir)/libqalculate/BuiltinFunctions.h \
+                         $(top_srcdir)/libqalculate/Calculator_p.h \
+                         $(top_srcdir)/libqalculate/MathStructure-support.h
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/docs/reference/Makefile.am
+++ b/docs/reference/Makefile.am
@@ -3,24 +3,24 @@
 #
 
 EXTRA_DIST = \
-		$(top_srcdir)/docs/reference/Doxyfile
+		$(srcdir)/Doxyfile
 
 if HAVE_DOXYGEN
 
 referencedir = $(docdir)/reference/html
 reference_DATA = \
-		$(top_srcdir)/docs/reference/html/*.html \
-		$(top_srcdir)/docs/reference/html/*.png \
-		$(top_srcdir)/docs/reference/html/*.css \
-		$(top_srcdir)/docs/reference/html/*.js
+		$(builddir)/html/*.html \
+		$(builddir)/html/*.png \
+		$(builddir)/html/*.css \
+		$(builddir)/html/*.js
 
 .PHONY: docs
 docs:
-	$(DOXYGEN) Doxyfile
+	top_srcdir=$(top_srcdir) $(DOXYGEN) $(srcdir)/Doxyfile
 
-$(top_srcdir)/docs/reference/html/*.html:
-	$(DOXYGEN) Doxyfile
+$(builddir)/html/*.html: $(srcdir)/Doxyfile
+	top_srcdir=$(top_srcdir) $(DOXYGEN) $(srcdir)/Doxyfile
 
-$(top_srcdir)/docs/reference/html/*.png $(top_srcdir)/docs/reference/html/*.css $(top_srcdir)/docs/reference/html/*.js:
+$(builddir)/html/*.png $(builddir)/html/*.css $(builddir)/html/*.js:
 
 endif


### PR DESCRIPTION
This removes some assumptions and relative paths from the documentation build, which allows them to be built when doing an out-of-tree build.