### PR TITLE
Allow disabling gnuplot from build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -140,6 +140,11 @@ AS_IF([test "x$with_icu" = "xyes"], [
 	AC_SUBST(ICU_LIBS)
 ])
 
+AC_ARG_WITH([gnuplot-call], AS_HELP_STRING([--with-gnuplot-call], [support for calling out to an external gnuplot binary]), [], [with_gnuplot_call=yes])
+AS_IF([test "x$with_gnuplot_call" = "xyes"], [
+	AC_DEFINE([HAVE_GNUPLOT_CALL], [1], [Call to external gnuplot])
+])
+
 PKG_CHECK_MODULES(LIBXML, [libxml-2.0 >= 2.3.8])
 AC_SUBST(LIBXML_CFLAGS)
 AC_SUBST(LIBXML_LIBS)

--- a/libqalculate/Calculator-plot.cc
+++ b/libqalculate/Calculator-plot.cc
@@ -54,6 +54,7 @@ PlotDataParameters::PlotDataParameters() {
 }
 
 bool Calculator::canPlot() {
+#ifdef HAVE_GNUPLOT_CALL
 #ifdef _WIN32
 	LPSTR lpFilePart;
 	char filename[MAX_PATH];
@@ -62,6 +63,9 @@ bool Calculator::canPlot() {
 	FILE *pipe = popen("gnuplot - 2>/dev/null", "w");
 	if(!pipe) return false;
 	return pclose(pipe) == 0;
+#endif
+#else
+    return false;
 #endif
 }
 


### PR DESCRIPTION
This is necessary for building for WASM, since emscripten does not
support the popen function