### PR TITLE
Add Catalan translation

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -269,7 +269,7 @@ AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE,"$GETTEXT_PACKAGE",[The package name for gettext])
 
 dnl Please keep this in alphabetical order
-ALL_LINGUAS="de es fr nl ru sv zh_CN"
+ALL_LINGUAS="ca de es fr nl ru sv zh_CN"
 AM_GNU_GETTEXT(external)
 AM_GNU_GETTEXT_VERSION([0.19.8])
 

--- a/po-defs/Makefile.am
+++ b/po-defs/Makefile.am
@@ -11,4 +11,4 @@ fixpo$(BUILD_EXEEXT): remove-untranslated.cc
 	$(LINK_FOR_BUILD.cpp) $^ $(LOADLIBES_FOR_BUILD) $(LDLIBS_FOR_BUILD) -o $@
 
 EXTRA_DIST = \
-	remove-untranslated.cc POTFILES.in es.po fr.po nl.po ru.po sv.po zh_CN.po
+	remove-untranslated.cc POTFILES.in ca.po es.po fr.po nl.po ru.po sv.po zh_CN.po

--- a/po-defs/ca.po
+++ b/po-defs/ca.po
@@ -1,0 +1,11484 @@
+# Catalan translations for libqalculate package.
+# Copyright (C) 2021 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the libqalculate package.
+# Alex Henrie <alexhenrie24@gmail.com>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: libqalculate-defs\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-25 02:11-0600\n"
+"PO-Revision-Date: 2021-05-25 09:48-0600\n"
+"Last-Translator: Alex Henrie <alexhenrie24@gmail.com>\n"
+"Language-Team: Catalan <ca@dodds.net>\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 2.4.3\n"
+
+#: ../data/currencies.xml.in.h:1
+msgid "Currency"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:2
+msgid "European Euro"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:3
+msgid "a-cr:EUR,au:&#x20AC;,euro,p:euros"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:4
+msgid ""
+"Andorra, Austria, Belgium, Cyprus, Estonia, Finland, France, Germany, "
+"Greece, Ireland, Italy, Latvia, Lithuania, Luxembourg, Malta, Netherlands, "
+"Portugal, San Marino, Slovakia, Slovenia, Spain, Vatican City"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:5
+msgid "U.S. Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:6
+msgid "a:$,a-cr:USD,dollar,p:dollars"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:7
+msgid ""
+"United States, East Timor, Ecuador, El Salvador, Micronesia, Marshall "
+"Islands, Palau, Zimbabwe"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:8
+msgid "Japanese Yen"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:9
+msgid "a-cr:JPY,au:&#xA5;,yen"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:10
+msgid "Japan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:11
+msgid "Danish Krone"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:12
+msgid "a-cr:DKK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:13
+msgid "Denmark"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:14
+msgid "British Pound"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:15
+msgid "a-cr:GBP,au:&#xA3;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:16
+msgid "United Kingdom"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:17
+msgid "Thai Baht"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:18
+msgid "a-cr:THB"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:19
+msgid "Thailand"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:20
+msgid "Swedish Krona"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:21
+msgid "a-cr:SEK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:22
+msgid "Sweden"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:23
+msgid "Swiss Franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:24
+msgid "a-cr:CHF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:25
+msgid "Switzerland"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:26
+msgid "Norwegian Krone"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:27
+msgid "a-cr:NOK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:28
+msgid "Norway"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:29
+msgid "Bulgarian Lev"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:30
+msgid "lev,a-cr:BGN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:31
+msgid "Bulgaria"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:32
+msgid "Russian Ruble"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:33
+msgid "a-cr:RUB,au:&#x20BD;,ruble"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:34
+msgid "Russia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:35
+msgid "Philippine Peso"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:36
+msgid "a-cr:PHP,au:&#x20B1;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:37
+msgid "Philippines"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:38
+msgid "Malaysian Ringgit"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:39
+msgid "a-cr:MYR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:40
+msgid "Malaysia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:41
+msgid "Croatian Kuna"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:42
+msgid "a-cr:HRK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:43
+msgid "Croatia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:44
+msgid "Chinese Yuan Renminbi"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:45
+msgid "a-cr:CNY"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:46
+msgid "China"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:47
+msgid "Indonesian Rupiah"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:48
+msgid "a-cr:IDR,rupiah"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:49
+msgid "Indonesia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:50
+msgid "Czech Koruna"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:51
+msgid "a-cr:CZK,au-c:K&#x10D;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:52
+msgid "Czech Republic"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:53
+msgid "Hungarian Forint"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:54
+msgid "forint,a-cr:HUF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:55
+msgid "Hungary"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:56
+msgid "Polish Zloty"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:57
+msgid "a-cr:PLN,au:z&#x0142;,zloty"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:58
+msgid "Poland"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:59
+msgid "Romanian Leu"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:60
+msgid "a-cr:RON"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:61
+msgid "Romania"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:62
+msgid "Turkish New Lira"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:63
+msgid "a-cr:TRY,au:&#x20BA;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:64
+msgid "Turkey"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:65
+msgid "Australian Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:66
+msgid "a-cr:AUD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:67
+msgid "Australia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:68
+msgid "Canadian Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:69
+msgid "a-cr:CAD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:70
+msgid "Canada"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:71
+msgid "Hong Kong Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:72
+msgid "a-cr:HKD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:73
+msgid "New Zealand Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:74
+msgid "a-cr:NZD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:75
+msgid "New Zealand"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:76
+msgid "Singapore Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:77
+msgid "a-cr:SGD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:78
+msgid "Singapore"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:79
+msgid "South Korean Won"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:80
+msgid "a-cr:KRW,au:&#x20A9;,won"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:81
+msgid "South Korea"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:82
+msgid "South African Rand"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:83
+msgid "a-cr:ZAR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:84
+msgid "South Africa"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:85
+msgid "Indian Rupee"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:86
+msgid "a-cr:INR,au:&#x20B9;,rupee"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:87
+msgid "India"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:88
+msgid "Israeli New Sheqel"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:89
+msgid "a-cr:ILS,au:&#x20AA;,sheqel"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:90
+msgid "Israel"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:91
+msgid "Mexican Peso"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:92
+msgid "a-cr:MXN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:93
+msgid "Mexico"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:94
+msgid "Brazilian Real"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:95
+msgid "a-cr:BRL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:96
+msgid "Brazil"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:97
+msgid "Icelandic Krónur"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:98
+msgid "a-cr:ISK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:99
+msgid "Iceland"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:100
+msgid "Bitcoin"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:101
+msgid "a-cr:BTC,au:&#x20BF;,a:XBT,bitcoin,p:bitcoins"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:102
+msgid "Kenya Shilling"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:103
+msgid "a-cr:KES"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:104
+msgid "Kenya"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:105
+msgid "Afghan Afghani"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:106
+msgid "a-cr:AFN,aiu:&#x060B;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:107
+msgid "Afghanistan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:108
+msgid "Albanian Lek"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:109
+msgid "a-cr:ALL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:110
+msgid "Albania"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:111
+msgid "Algerian Dinar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:112
+msgid "a-cr:DZD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:113
+msgid "Algeria"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:114
+msgid "Angolan Kwanza"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:115
+msgid "a-cr:AOA"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:116
+msgid "Angola"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:117
+msgid "Eastern Caribbean Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:118
+msgid "a-cr:XCD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:119
+msgid ""
+"Antigua and Barbuda, Dominica, Grenada, Montserrat, Saint Kitts and Nevis, "
+"Saint Lucia, Saint Vincent and the Grenadines, Anguilla"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:120
+msgid "Argentine Peso"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:121
+msgid "a-cr:ARS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:122
+msgid "Argentina"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:123
+msgid "Armenian Dram"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:124
+msgid "a-cr:AMD,au:&#x058F;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:125
+msgid "Armenia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:126
+msgid "Aruban Florin"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:127
+msgid "a-cr:AWG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:128
+msgid "Aruba"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:129
+msgid "Netherlands Antillean Guilder"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:130
+msgid "a-cr:ANG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:131
+msgid "Curaçao, Sint Maarten"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:132
+msgid "Azerbaijani Manat"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:133
+msgid "a-cr:AZN,au:&#x20BC;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:134
+msgid "Azerbaijan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:135
+msgid "Bahamian Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:136
+msgid "a-cr:BSD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:137
+msgid "Bahamas"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:138
+msgid "Bahraini Dinar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:139
+msgid "a-cr:BHD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:140
+msgid "Bahrain"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:141
+msgid "Bangladeshi Taka"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:142
+msgid "a-cr:BDT,au:&#x09F3;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:143
+msgid "Bangladesh"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:144
+msgid "Barbadian Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:145
+msgid "a-cr:BBD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:146
+msgid "Barbados"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:147
+msgid "Belarusian Ruble"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:148
+msgid "a-cr:BYN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:149
+msgid "Belarus"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:150
+msgid "Belarusian Ruble p. (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:151
+msgid "a-cr:BYR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:152
+msgid "Belize Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:153
+msgid "a-cr:BZD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:154
+msgid "Belize"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:155
+msgid "West African CFA Franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:156
+msgid "a-cr:XOF,a:CFA"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:157
+msgid ""
+"Benin, Burkina Faso, Guinea-Bissau, Ivory Coast, Mali, Niger, Senegal, Togo"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:158
+msgid "Bermudian Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:159
+msgid "a-cr:BMD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:160
+msgid "Bermuda"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:161
+msgid "Bolivian Boliviano Bs"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:162
+msgid "a-cr:BOB"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:163
+msgid "Bolivia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:164
+msgid "Bosnia and Herzegovina Convertible Mark"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:165
+msgid "a-cr:BAM"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:166
+msgid "Bosnia and Herzegovina"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:167
+msgid "Botswana Pula"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:168
+msgid "a-cr:BWP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:169
+msgid "Botswana"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:170
+msgid "Brunei Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:171
+msgid "a-cr:BND"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:172
+msgid "Brunei"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:173
+msgid "Burundian Franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:174
+msgid "a-cr:BIF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:175
+msgid "Burundi"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:176
+msgid "Cambodian Riel"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:177
+msgid "a-cr:KHR,aiu:&#x17DB;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:178
+msgid "Cambodia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:179
+msgid "Central African CFA Franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:180
+msgid "a-cr:XAF,a:FCFA"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:181
+msgid ""
+"Cameroon, Central African Republic, Chad, Republic of the Congo, Equatorial "
+"Guinea, Gabon"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:182
+msgid "Cape Verdean Escudo"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:183
+msgid "a-cr:CVE"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:184
+msgid "Cape Verde"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:185
+msgid "Cayman Islands Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:186
+msgid "a-cr:KYD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:187
+msgid "Cayman Islands"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:188
+msgid "Chilean Peso"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:189
+msgid "a-cr:CLP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:190
+msgid "Chile"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:191
+msgid "Colombian Peso"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:192
+msgid "a-cr:COP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:193
+msgid "Colombia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:194
+msgid "Comorian Franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:195
+msgid "a-cr:KMF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:196
+msgid "Comoros"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:197
+msgid "Democratic Republic of the Congo (Congolese Franc)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:198
+msgid "a-cr:CDF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:199
+msgid "Democratic Republic of the Congo"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:200
+msgid "Costa Rican colón"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:201
+msgid "a-cr:CRC"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:202
+msgid "Costa Rica"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:203
+msgid "Cuban Peso"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:204
+msgid "acr:CUP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:205
+msgid "Cuba"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:206
+msgid "Djiboutian Franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:207
+msgid "a-cr:DJF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:208
+msgid "Djibouti"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:209
+msgid "Dominican Peso"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:210
+msgid "a-cr:DOP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:211
+msgid "Dominican Republic"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:212
+msgid "Egyptian Pound"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:213
+msgid "a-cr:EGP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:214
+msgid "Egypt"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:215
+msgid "El Salvadoran Colon (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:216
+msgid "a-cr:SVC"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:217
+msgid "Eritrean Nafka"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:218
+msgid "a-cr:ERN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:219
+msgid "Eritrea"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:220
+msgid "Ethiopian Birr"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:221
+msgid "a-cr:ETB"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:222
+msgid "Ethiopia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:223
+msgid "Falkland Islands Pound"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:224
+msgid "a-cr:FKP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:225
+msgid "Falkland Islands"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:226
+msgid "Fijian Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:227
+msgid "a-cr:FJD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:228
+msgid "Fiji"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:229
+msgid "CFP franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:230
+msgid "a-cr:XPF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:231
+msgid "French Polynesia, New Caledonia, Wallis and Futuna"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:232
+msgid "Gambian Dalasi"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:233
+msgid "a-cr:GMD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:234
+msgid "Gambia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:235
+msgid "Georgian Lari"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:236
+msgid "a-cr:GEL,au:&#x20BE;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:237
+msgid "Georgia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:238
+msgid "Ghanaian Cedi"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:239
+msgid "a-cr:GHS,au:&#x20B5;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:240
+msgid "Ghana"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:241
+msgid "Gibraltar Pound"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:242
+msgid "a-cr:GIP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:243
+msgid "Gibraltar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:244
+msgid "Guatemalan Quetzal"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:245
+msgid "a-cr:GTQ"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:246
+msgid "Guatemala"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:247
+msgid "Guernsey Pound"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:248
+msgid "a-cr:GGP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:249
+msgid "Guernsey"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:250
+msgid "Guinean Franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:251
+msgid "a-cr:GNF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:252
+msgid "Guinea"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:253
+msgid "Guyanese Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:254
+msgid "a-cr:GYD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:255
+msgid "Guyana"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:256
+msgid "Haitian Gourde"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:257
+msgid "a-cr:HTG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:258
+msgid "Haiti"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:259
+msgid "Honduran Lempira"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:260
+msgid "a-cr:HNL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:261
+msgid "Honduras"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:262
+msgid "Iranian Rial"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:263
+msgid "a-cr:IRR,aiu:&#xFDFC;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:264
+msgid "Iran"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:265
+msgid "Iraqi Dinar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:266
+msgid "a-cr:IQD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:267
+msgid "Iraq"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:268
+msgid "Jamaican Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:269
+msgid "a-cr:JMD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:270
+msgid "Jamaica"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:271
+msgid "Jordanian Dinar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:272
+msgid "a-cr:JOD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:273
+msgid "Jordan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:274
+msgid "Kazakhstani Tenge"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:275
+msgid "a-cr:KZT,au:&#x20B8;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:276
+msgid "Kazakhstan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:277
+msgid "North Korean Won"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:278
+msgid "a-cr:KPW"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:279
+msgid "North Korea"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:280
+msgid "Kuwaiti Dinar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:281
+msgid "a-cr:KWD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:282
+msgid "Kuwait"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:283
+msgid "Kyrgyzstani Som"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:284
+msgid "acr:KGS,au:&#x0441;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:285
+msgid "Kyrgyzstan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:286
+msgid "Lao Kip"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:287
+msgid "a-cr:LAK,au:&#x20AD;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:288
+msgid "Laos"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:289
+msgid "Lebanese Pound"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:290
+msgid "a-cr:LBP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:291
+msgid "Lebanon"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:292
+msgid "Lesotho Loti"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:293
+msgid "a-cr:LSL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:294
+msgid "Lesotho"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:295
+msgid "Liberian Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:296
+msgid "a-cr:LRD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:297
+msgid "Liberia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:298
+msgid "Libyan Dinar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:299
+msgid "a-cr:LYD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:300
+msgid "Libya"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:301
+msgid "Macanese Pataca"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:302
+msgid "a-cr:MOP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:303
+msgid "Macau"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:304
+msgid "Macedonian Denar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:305
+msgid "a-cr:MKD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:306
+msgid "Macedonia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:307
+msgid "Malagasy Ariary"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:308
+msgid "a-cr:MGA"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:309
+msgid "Madagascar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:310
+msgid "Malawian Kwacha"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:311
+msgid "a-cr:MWK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:312
+msgid "Malawi"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:313
+msgid "Maldivian Rufiyaa"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:314
+msgid "a-cr:MVR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:315
+msgid "Maldives"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:316
+msgid "Mauritanian Ouguiya (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:317
+msgid "a-cr:MRO"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:318
+msgid "Mauritian Rupee"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:319
+msgid "a-cr:MUR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:320
+msgid "Mauritius"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:321
+msgid "Moldovan Leu"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:322
+msgid "a-cr:MDL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:323
+msgid "Moldova"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:324
+msgid "Mongolian Tögrög"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:325
+msgid "a-cr:MNT,au:&#x20AE;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:326
+msgid "Mongolia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:327
+msgid "Moroccan Dirham"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:328
+msgid "a-cr:MAD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:329
+msgid "Morocco"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:330
+msgid "Mozambican Metical"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:331
+msgid "a-cr:MZN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:332
+msgid "Mozambique"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:333
+msgid "Myanmar (Burmese Kyat)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:334
+msgid "a-cr:MMK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:335
+msgid "Myanmar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:336
+msgid "Namibian Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:337
+msgid "a-cr:NAD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:338
+msgid "Namibia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:339
+msgid "Nepalese Rupee"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:340
+msgid "a-cr:NPR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:341
+msgid "Nepal"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:342
+msgid "Nicaraguan Córdoba"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:343
+msgid "a-cr:NIO"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:344
+msgid "Nicaragua"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:345
+msgid "Nigerian Naira"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:346
+msgid "a-cr:NGN,au:&#x20A6;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:347
+msgid "Nigeria"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:348
+msgid "Omani Rial"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:349
+msgid "a-cr:OMR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:350
+msgid "Oman"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:351
+msgid "Pakistani Rupee"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:352
+msgid "a-cr:PKR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:353
+msgid "Pakistan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:354
+msgid "Panamaian Balboa"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:355
+msgid "a-cr:PAB"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:356
+msgid "Panama"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:357
+msgid "Papua New Guinean Kina"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:358
+msgid "a-cr:PGK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:359
+msgid "Papua New Guinea"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:360
+msgid "Paraguayan Guaraní"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:361
+msgid "a-cr:PYG,au:&#x20B2;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:362
+msgid "Paraguay"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:363
+msgid "Peruvian Sol"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:364
+msgid "a-cr:PEN"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:365
+msgid "Peru"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:366
+msgid "Qatari Riyal"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:367
+msgid "a-cr:QAR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:368
+msgid "Qatar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:369
+msgid "Rwandan Franc"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:370
+msgid "a-cr:RWF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:371
+msgid "Rwanda"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:372
+msgid "São Tomé and Príncipe Dobra"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:373
+msgid "a-cr:STD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:374
+msgid "Sao Tome and Principe"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:375
+msgid "Saudi Riyal"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:376
+msgid "a-cr:SAR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:377
+msgid "Saudi Arabia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:378
+msgid "Serbian Dinar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:379
+msgid "a-cr:RSD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:380
+msgid "Serbia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:381
+msgid "Seychellois Rupee"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:382
+msgid "a-cr:SCR"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:383
+msgid "Seychelles"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:384
+msgid "Sierra Leonean Leone"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:385
+msgid "a-cr:SLL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:386
+msgid "Sierra Leone"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:387
+msgid "Solomon Islands Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:388
+msgid "a-cr:SBD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:389
+msgid "Solomon Islands"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:390
+msgid "Somali Shilling"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:391
+msgid "a-cr:SOS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:392
+msgid "Somalia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:393
+msgid "Sri Lankan Rupee"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:394
+msgid "a-cr:LKR,au:&#x0BF9;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:395
+msgid "Sri Lanka"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:396
+msgid "Sudanese Pound"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:397
+msgid "a-cr:SDG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:398
+msgid "Sudan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:399
+msgid "Surinamese Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:400
+msgid "a-cr:SRD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:401
+msgid "Suriname"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:402
+msgid "Swazi Lilangeni"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:403
+msgid "a-cr:SZL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:404
+msgid "Swaziland"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:405
+msgid "Syrian Pound"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:406
+msgid "a-cr:SYP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:407
+msgid "Syria"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:408
+msgid "New Taiwan Dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:409
+msgid "a-cr:TWD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:410
+msgid "Taiwan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:411
+msgid "Tajikistani Somoni"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:412
+msgid "a-cr:TJS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:413
+msgid "Tajikistan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:414
+msgid "Tanzanian Shilling"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:415
+msgid "a-cr:TZS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:416
+msgid "Tanzania"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:417
+msgid "Tongan Paʻanga"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:418
+msgid "a-cr:TOP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:419
+msgid "Tonga"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:420
+msgid "Trinidad and Tobago dollar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:421
+msgid "a-cr:TTD"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:422
+msgid "Trinidad and Tobago"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:423
+msgid "Tunisian Dinar"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:424
+msgid "a-cr:TND"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:425
+msgid "Tunisia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:426
+msgid "Turkmenistan Manat"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:427
+msgid "a-cr:TMT"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:428
+msgid "Turkmenistan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:429
+msgid "Ugandan Shilling"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:430
+msgid "a-cr:UGX"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:431
+msgid "Uganda"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:432
+msgid "Ukrainian Hryvnia"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:433
+msgid "a-cr:UAH,au:&#x20B4;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:434
+msgid "Ukraine"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:435
+msgid "United Arab Emirates Dirham"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:436
+msgid "a-cr:AED"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:437
+msgid "United Arab Emirates"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:438
+msgid "Uruguayan Peso"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:439
+msgid "a-cr:UYU"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:440
+msgid "Uruguay"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:441
+msgid "Uzbekistan Soʻm"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:442
+msgid "a-cr:UZS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:443
+msgid "Uzbekistan"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:444
+msgid "Vanuatu Vatu"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:445
+msgid "a-cr:VUV"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:446
+msgid "Vanuatu"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:447
+msgid "Venezuelan Bolívar (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:448
+msgid "a-cr:VEF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:449
+msgid "Vietnamese Đồng"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:450
+msgid "a-cr:VND,au:&#x20AB;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:451
+msgid "Vietnam"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:452
+msgid "Yemeni Rial"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:453
+msgid "a-cr:YER"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:454
+msgid "Yemen"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:455
+msgid "Zambian Kwacha (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:456
+msgid "a-cr:ZMK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:457
+msgid "Euro Cent"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:458
+msgid "r:eurocent,p:eurocents"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:459
+msgid "Cent (USD)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:460
+msgid "au:&#xA2;,r:cent,p:cents"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:461
+msgid "Belgian Franc (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:462
+msgid "a-cr:BEF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:463
+msgid "Greek Drachma (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:464
+msgid "a-cr:GRD,au:&#x20AF;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:465
+msgid "French Franc (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:466
+msgid "a-cr:FRF,au:&#x20A3;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:467
+msgid "Italian Lira (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:468
+msgid "a-cr:ITL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:469
+msgid "Dutch Guilder (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:470
+msgid "a-cr:NLG"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:471
+msgid "Portuguese Escudo (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:472
+msgid "a-cr:PTE"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:473
+msgid "Deutsche Mark (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:474
+msgid "a-cr:DEM"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:475
+msgid "Spanish Peseta (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:476
+msgid "a-cr:ESP,au:&#x20A7;"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:477
+msgid "Irish Pound (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:478
+msgid "a-cr:IEP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:479
+msgid "Luxembourg Franc (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:480
+msgid "a-cr:LUF"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:481
+msgid "Austrian Schilling (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:482
+msgid "a-cr:ATS"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:483
+msgid "Finnish Markka (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:484
+msgid "a-cr:FIM"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:485
+msgid "Slovenian Tolar (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:486
+msgid "a-cr:SIT"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:487
+msgid "Cypriot Pound (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:488
+msgid "a-cr:CYP"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:489
+msgid "Estonian Kroon (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:490
+msgid "a-cr:EEK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:491
+msgid "Slovak Koruna (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:492
+msgid "a-cr:SKK"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:493
+msgid "Maltese Lira (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:494
+msgid "a-cr:MTL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:495
+msgid "Latvian Lats (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:496
+msgid "a-cr:LVL"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:497
+msgid "Lithuanian Litas (obsolete)"
+msgstr ""
+
+#: ../data/currencies.xml.in.h:498
+msgid "a-cr:LTL"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:1
+msgid "Data Sets"
+msgstr ""
+
+#. Data set for chemical elements
+#: ../data/datasets.xml.in.h:3
+msgid "!datasets!Elements"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:4
+msgid "r:atom"
+msgstr ""
+
+#. Object argument for chemical elements data set
+#: ../data/datasets.xml.in.h:6
+msgid "!datasets!Element"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:7
+msgid "Symbol"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:8
+msgid "r:symbol"
+msgstr ""
+
+#. Chemical elements number
+#: ../data/datasets.xml.in.h:10
+msgid "!datasets!Number"
+msgstr ""
+
+#. Chemical elements number
+#: ../data/datasets.xml.in.h:12
+msgid "!datasets!r:number"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:13 ../data/functions.xml.in.h:817
+msgid "Name"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:14
+msgid "r:name"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:15
+msgid "Classification"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:16
+msgid ""
+"A number representing an element group:&#10;1 Alkali Metal&#10;2 Alkaline-"
+"Earth Metal&#10;3 Lanthanide&#10;4 Actinide&#10;5 Transition Metal&#10;6 "
+"Metal&#10;7 Metalloid&#10;8 Polyatomic Non-Metal&#10;9 Diatomic Non-"
+"Metal&#10;10 Noble Gas&#10;11 Unknown chemical properties"
+msgstr ""
+"Un número que representa un grup d'elements:&#10;1 Metall alcalí&#10;2 "
+"Alcalinoterri&#10;3 Lantanoide&#10;4 Actinoide&#10;5 Metall de "
+"transició&#10;6 Metall&#10;7 Metal·loide&#10;8 Poliatòmic no metall&#10;9 "
+"Diatòmic no metall&#10;10 Gas noble&#10;11 Propietats químiques desconegudes"
+
+#: ../data/datasets.xml.in.h:17
+msgid "r:class"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:18 ../data/units.xml.in.h:131
+msgid "Atomic Mass"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:19
+msgid ""
+"The property uses standard atomic weight, when determined, or the mass "
+"number."
+msgstr ""
+"La propietat usa el pes estàndard atòmic, quan sigui determinat, o el nombre "
+"de massa."
+
+#: ../data/datasets.xml.in.h:20
+msgid "r:mass,r:weight"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:21
+msgid "Boiling Point"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:22
+msgid "r:boiling"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:23
+msgid "Melting Point"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:24
+msgid "r:melting"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:25 ../data/units.xml.in.h:127
+msgid "Density"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:26
+msgid "Density at STP (gases) or near room temperature"
+msgstr "Densitat a STP (gasos) o prop de la temperatura ambient"
+
+#: ../data/datasets.xml.in.h:27
+msgid "r:density"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:28
+msgid "X Position"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:29
+msgid "r:x_pos"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:30
+msgid "Y Position"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:31
+msgid "r:y_pos"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:32
+msgid "Planets"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:33
+msgid "r:planet"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:34
+msgid "Planet"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:35
+msgid "Orbital Period (Year)"
+msgstr ""
+
+#. Orbital period for planet
+#: ../data/datasets.xml.in.h:37
+msgid "!datasets!r:year"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:38
+msgid "Average Orbital Speed"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:39
+msgid "r:speed"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:40
+msgid "Eccentricity"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:41
+msgid "r:eccentricity"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:42
+msgid "Inclination (to ecliptic)"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:43
+msgid "r:inclination"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:44
+msgid "Number of Satellites"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:45
+msgid "r:satellites"
+msgstr ""
+
+#. Planet mass
+#: ../data/datasets.xml.in.h:47
+msgid "!datasets!Mass"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:48
+msgid "r:mass"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:49
+msgid "Mean Density"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:50
+msgid "Surface Area"
+msgstr ""
+
+#. Surface area of planet
+#: ../data/datasets.xml.in.h:52
+msgid "!datasets!r:area"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:53
+msgid "Equatorial Gravity"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:54
+msgid "r:gravity"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:55
+msgid "Mean Surface Temperature"
+msgstr ""
+
+#: ../data/datasets.xml.in.h:56
+msgid "r:temperature"
+msgstr ""
+
+#: ../data/elements.xml.in.h:1
+msgid "Hydrogen"
+msgstr ""
+
+#: ../data/elements.xml.in.h:2
+msgid "Helium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:3
+msgid "Lithium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:4
+msgid "Beryllium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:5
+msgid "Boron"
+msgstr ""
+
+#: ../data/elements.xml.in.h:6
+msgid "Carbon"
+msgstr ""
+
+#: ../data/elements.xml.in.h:7
+msgid "Nitrogen"
+msgstr ""
+
+#: ../data/elements.xml.in.h:8
+msgid "Oxygen"
+msgstr ""
+
+#: ../data/elements.xml.in.h:9
+msgid "Fluorine"
+msgstr ""
+
+#: ../data/elements.xml.in.h:10
+msgid "Neon"
+msgstr ""
+
+#: ../data/elements.xml.in.h:11
+msgid "Sodium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:12
+msgid "Magnesium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:13
+msgid "Aluminum"
+msgstr ""
+
+#: ../data/elements.xml.in.h:14
+msgid "Silicon"
+msgstr ""
+
+#: ../data/elements.xml.in.h:15
+msgid "Phosphorus"
+msgstr ""
+
+#: ../data/elements.xml.in.h:16
+msgid "Sulfur"
+msgstr ""
+
+#: ../data/elements.xml.in.h:17
+msgid "Chlorine"
+msgstr ""
+
+#: ../data/elements.xml.in.h:18
+msgid "Argon"
+msgstr ""
+
+#: ../data/elements.xml.in.h:19
+msgid "Potassium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:20
+msgid "Calcium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:21
+msgid "Scandium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:22
+msgid "Titanium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:23
+msgid "Vanadium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:24
+msgid "Chromium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:25
+msgid "Manganese"
+msgstr ""
+
+#: ../data/elements.xml.in.h:26
+msgid "Iron"
+msgstr ""
+
+#: ../data/elements.xml.in.h:27
+msgid "Cobalt"
+msgstr ""
+
+#: ../data/elements.xml.in.h:28
+msgid "Nickel"
+msgstr ""
+
+#: ../data/elements.xml.in.h:29
+msgid "Copper"
+msgstr ""
+
+#: ../data/elements.xml.in.h:30
+msgid "Zinc"
+msgstr ""
+
+#: ../data/elements.xml.in.h:31
+msgid "Gallium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:32
+msgid "Germanium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:33
+msgid "Arsenic"
+msgstr ""
+
+#: ../data/elements.xml.in.h:34
+msgid "Selenium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:35
+msgid "Bromine"
+msgstr ""
+
+#: ../data/elements.xml.in.h:36
+msgid "Krypton"
+msgstr ""
+
+#: ../data/elements.xml.in.h:37
+msgid "Rubidium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:38
+msgid "Strontium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:39
+msgid "Yttrium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:40
+msgid "Zirconium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:41
+msgid "Niobium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:42
+msgid "Molybdenum"
+msgstr ""
+
+#: ../data/elements.xml.in.h:43
+msgid "Technetium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:44
+msgid "Ruthenium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:45
+msgid "Rhodium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:46
+msgid "Palladium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:47
+msgid "Silver"
+msgstr ""
+
+#: ../data/elements.xml.in.h:48
+msgid "Cadmium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:49
+msgid "Indium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:50
+msgid "Tin"
+msgstr ""
+
+#: ../data/elements.xml.in.h:51
+msgid "Antimony"
+msgstr ""
+
+#: ../data/elements.xml.in.h:52
+msgid "Tellurium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:53
+msgid "Iodine"
+msgstr ""
+
+#: ../data/elements.xml.in.h:54
+msgid "Xenon"
+msgstr ""
+
+#: ../data/elements.xml.in.h:55
+msgid "Cesium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:56
+msgid "Barium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:57
+msgid "Lanthanum"
+msgstr ""
+
+#: ../data/elements.xml.in.h:58
+msgid "Cerium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:59
+msgid "Praseodymium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:60
+msgid "Neodymium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:61
+msgid "Promethium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:62
+msgid "Samarium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:63
+msgid "Europium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:64
+msgid "Gadolinium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:65
+msgid "Terbium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:66
+msgid "Dysprosium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:67
+msgid "Holmium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:68
+msgid "Erbium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:69
+msgid "Thulium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:70
+msgid "Ytterbium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:71
+msgid "Lutetium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:72
+msgid "Hafnium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:73
+msgid "Tantalum"
+msgstr ""
+
+#: ../data/elements.xml.in.h:74
+msgid "Tungsten"
+msgstr ""
+
+#: ../data/elements.xml.in.h:75
+msgid "Rhenium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:76
+msgid "Osmium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:77
+msgid "Iridium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:78
+msgid "Platinum"
+msgstr ""
+
+#: ../data/elements.xml.in.h:79
+msgid "Gold"
+msgstr ""
+
+#. Chemical element
+#: ../data/elements.xml.in.h:81
+msgid "!elements!Mercury"
+msgstr ""
+
+#: ../data/elements.xml.in.h:82
+msgid "Thallium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:83
+msgid "Lead"
+msgstr ""
+
+#: ../data/elements.xml.in.h:84
+msgid "Bismuth"
+msgstr ""
+
+#: ../data/elements.xml.in.h:85
+msgid "Polonium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:86
+msgid "Astatine"
+msgstr ""
+
+#: ../data/elements.xml.in.h:87
+msgid "Radon"
+msgstr ""
+
+#: ../data/elements.xml.in.h:88
+msgid "Francium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:89
+msgid "Radium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:90
+msgid "Actinium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:91
+msgid "Thorium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:92
+msgid "Protactinium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:93
+msgid "Uranium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:94
+msgid "Neptunium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:95
+msgid "Plutonium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:96
+msgid "Americium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:97
+msgid "Curium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:98
+msgid "Berkelium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:99
+msgid "Californium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:100
+msgid "Einsteinium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:101
+msgid "Fermium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:102
+msgid "Mendelevium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:103
+msgid "Nobelium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:104
+msgid "Lawrencium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:105
+msgid "Rutherfordium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:106
+msgid "Dubnium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:107
+msgid "Seaborgium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:108
+msgid "Bohrium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:109
+msgid "Hassium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:110
+msgid "Meitnerium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:111
+msgid "Darmstadtium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:112
+msgid "Roentgenium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:113
+msgid "Copernicium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:114
+msgid "Nihonium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:115
+msgid "Flerovium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:116
+msgid "Moscovium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:117
+msgid "Livermorium"
+msgstr ""
+
+#: ../data/elements.xml.in.h:118
+msgid "Tennessine"
+msgstr ""
+
+#: ../data/elements.xml.in.h:119
+msgid "Oganesson"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1
+msgid "Matrices &amp; Vectors"
+msgstr ""
+
+#: ../data/functions.xml.in.h:2
+msgid "Construct Vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:3
+msgid "r:vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:4
+msgid "Returns a vector with listed elements."
+msgstr "Retorna un vector amb els elements llistats."
+
+#. Vector/matrix elements
+#: ../data/functions.xml.in.h:6
+msgid "Elements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:7
+msgid "Generate Vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:8
+msgid "r:genvector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:9
+msgid ""
+"Returns a vector generated from a function with a variable (default x) "
+"running from min to max. The fourth argument is either the requested number "
+"of elements if the sixth argument is false (default) or the step between "
+"each value of the variable."
+msgstr ""
+"Retorna un vector generat d'una funció amb una variable (per defecte x) des "
+"del mínim al màxim. El quart argument és o el nombre d'elements demanat si "
+"el sisè argument és false (el predeterminat) o el pas entre cada valor de la "
+"variable."
+
+#: ../data/functions.xml.in.h:10
+msgid "Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:11
+msgid "Min"
+msgstr ""
+
+#: ../data/functions.xml.in.h:12
+msgid "Max"
+msgstr ""
+
+#: ../data/functions.xml.in.h:13
+msgid "Dimension / Step size"
+msgstr ""
+
+#: ../data/functions.xml.in.h:14
+msgid "Variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:15
+msgid "Use step size"
+msgstr ""
+
+#: ../data/functions.xml.in.h:16
+msgid "Sort"
+msgstr ""
+
+#: ../data/functions.xml.in.h:17
+msgid "r:sort"
+msgstr ""
+
+#: ../data/functions.xml.in.h:18
+msgid "Returns a sorted vector."
+msgstr "Retorna un vector ordenat."
+
+#: ../data/functions.xml.in.h:19
+msgid "Vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:20
+msgid "Ascending"
+msgstr ""
+
+#: ../data/functions.xml.in.h:21
+msgid "Rank"
+msgstr ""
+
+#: ../data/functions.xml.in.h:22
+msgid "r:rank"
+msgstr ""
+
+#: ../data/functions.xml.in.h:23
+msgid ""
+"Returns a vector with values of elements replaced with their mutual ranks."
+msgstr ""
+"Retorna un vector amb els valors dels elements reemplaçats amb el seus rangs "
+"mutuals."
+
+#: ../data/functions.xml.in.h:24
+msgid "Vector Limits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:25
+msgid "r:limits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:26
+msgid "Returns a part of a vector between two positions."
+msgstr "Retorna una part d'un vector entre dos posicions."
+
+#: ../data/functions.xml.in.h:27
+msgid "Lower limit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:28
+msgid "Upper limit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:29
+msgid "Dimension"
+msgstr ""
+
+#: ../data/functions.xml.in.h:30
+msgid "r:dimension"
+msgstr ""
+
+#: ../data/functions.xml.in.h:31
+msgid "Returns the number of elements in a vector."
+msgstr "Retorna el nombre d'elements en un vector."
+
+#: ../data/functions.xml.in.h:32
+msgid "Merge Vectors"
+msgstr ""
+
+#: ../data/functions.xml.in.h:33
+msgid "r:mergevectors"
+msgstr ""
+
+#: ../data/functions.xml.in.h:34
+msgid "Returns a vector with the elements from two vectors."
+msgstr "Retorna un vector amb els elements de dos vectors."
+
+#: ../data/functions.xml.in.h:35
+msgid "Vector 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:36
+msgid "Vector 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:37
+msgid "Construct Matrix"
+msgstr ""
+
+#: ../data/functions.xml.in.h:38
+msgid "r:matrix"
+msgstr ""
+
+#: ../data/functions.xml.in.h:39
+msgid ""
+"Returns a matrix with specified dimensions and listed elements. Omitted "
+"elements are set to zero."
+msgstr ""
+"Retorna una matriu amb les dimensions especificades i els elements llistats. "
+"S'estableixen les elements omesos a zero."
+
+#: ../data/functions.xml.in.h:40
+msgid "Rows"
+msgstr ""
+
+#: ../data/functions.xml.in.h:41
+msgid "Columns"
+msgstr ""
+
+#: ../data/functions.xml.in.h:42
+msgid "Convert Matrix to Vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:43
+msgid "r:matrix2vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:44
+msgid "Puts each element of a matrix in vertical order in a vector."
+msgstr "Posa cada element d'una matriu en ordre vertical en un vector."
+
+#: ../data/functions.xml.in.h:45
+msgid "Matrix"
+msgstr ""
+
+#: ../data/functions.xml.in.h:46
+msgid "Matrix Area"
+msgstr ""
+
+#. Matrix area
+#: ../data/functions.xml.in.h:48
+msgid "r:area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:49
+msgid "Returns a part of a matrix."
+msgstr "Retorna una part d'una matriu."
+
+#: ../data/functions.xml.in.h:50
+msgid "Start row"
+msgstr ""
+
+#: ../data/functions.xml.in.h:51
+msgid "Start column"
+msgstr ""
+
+#: ../data/functions.xml.in.h:52
+msgid "End row"
+msgstr ""
+
+#: ../data/functions.xml.in.h:53
+msgid "End column"
+msgstr ""
+
+#: ../data/functions.xml.in.h:54
+msgid "r:rows"
+msgstr ""
+
+#: ../data/functions.xml.in.h:55
+msgid "Returns the number of rows in a matrix."
+msgstr "Retorna el nombre de files en una matriu."
+
+#: ../data/functions.xml.in.h:56
+msgid "r:columns"
+msgstr ""
+
+#: ../data/functions.xml.in.h:57
+msgid "Returns the number of columns in a matrix."
+msgstr "Retorna el nombre de columnes en una matriu."
+
+#: ../data/functions.xml.in.h:58
+msgid "Extract row as vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:59
+msgid "r:row"
+msgstr ""
+
+#: ../data/functions.xml.in.h:60
+msgid "Returns a row in a matrix as a vector."
+msgstr "Retorna una fila d'una matriu com a vector."
+
+#: ../data/functions.xml.in.h:61
+msgid "Row"
+msgstr ""
+
+#: ../data/functions.xml.in.h:62
+msgid "Extract Column as Vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:63
+msgid "r:column"
+msgstr ""
+
+#: ../data/functions.xml.in.h:64
+msgid "Returns a column in a matrix as a vector."
+msgstr "Retorna una columna d'una matriu com a vector."
+
+#: ../data/functions.xml.in.h:65
+msgid "Column"
+msgstr ""
+
+#: ../data/functions.xml.in.h:66
+msgid "r:elements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:67
+msgid "Returns the number of elements in a matrix or vector."
+msgstr "Retorna el nombre d'elements en una matriu o en un vector."
+
+#: ../data/functions.xml.in.h:68
+msgid "Matrix or vector"
+msgstr ""
+
+#. Vector/matrix element
+#: ../data/functions.xml.in.h:70
+msgid "Element"
+msgstr ""
+
+#: ../data/functions.xml.in.h:71
+msgid "r:element"
+msgstr ""
+
+#: ../data/functions.xml.in.h:72
+msgid ""
+"Returns the element at specified position in a matrix (row and column) or "
+"vector (index)."
+msgstr ""
+"Retorna l'element a la posició especificada en una matriu (fila i columna) o "
+"vector (índex)."
+
+#: ../data/functions.xml.in.h:73
+msgid "Matrix/vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:74
+msgid "Row/index"
+msgstr ""
+
+#: ../data/functions.xml.in.h:75
+msgid "Transpose"
+msgstr ""
+
+#: ../data/functions.xml.in.h:76
+msgid "r:transpose"
+msgstr ""
+
+#: ../data/functions.xml.in.h:77
+msgid "Returns the transpose of a matrix."
+msgstr "Retorna la transposició d'una matriu."
+
+#: ../data/functions.xml.in.h:78
+msgid "Identity"
+msgstr ""
+
+#: ../data/functions.xml.in.h:79
+msgid "r:identity"
+msgstr ""
+
+#: ../data/functions.xml.in.h:80
+msgid ""
+"Returns the identity matrix of a matrix or with specified number of rows/"
+"columns."
+msgstr ""
+"Retorna la matriu d'identitat d'una matriu o amb el nombre especificat de "
+"files/columnes."
+
+#: ../data/functions.xml.in.h:81
+msgid "Matrix or rows/columns"
+msgstr ""
+
+#: ../data/functions.xml.in.h:82
+msgid "Determinant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:83
+msgid "r:det"
+msgstr ""
+
+#: ../data/functions.xml.in.h:84
+msgid "Calculates the determinant of a matrix."
+msgstr "Calcula el determinant d'una matriu."
+
+#: ../data/functions.xml.in.h:85
+msgid "Permanent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:86
+msgid "r:permanent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:87
+msgid ""
+"Calculates the permanent of a matrix. The permanent differs from a "
+"determinant in that all signs in the expansion by minors are taken as "
+"positive."
+msgstr ""
+"Calcula el permanent d'una matriu. El permanent difereix del determinant en "
+"que tots els signes en la expansió per menors es fan positius."
+
+#: ../data/functions.xml.in.h:88
+msgid "Adjugate (Adjoint)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:89
+msgid "r:adj"
+msgstr ""
+
+#: ../data/functions.xml.in.h:90
+msgid "Calculates the adjugate or adjoint of a matrix."
+msgstr "Calcula la matriu d'adjunts d'una matriu."
+
+#: ../data/functions.xml.in.h:91
+msgid "Cofactor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:92
+msgid "r:cofactor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:93
+msgid "Calculates the cofactor of the element at specified position."
+msgstr "Calcula el cofactor de l'element a la posició especificada."
+
+#: ../data/functions.xml.in.h:94
+msgid "Matrix Inverse"
+msgstr ""
+
+#: ../data/functions.xml.in.h:95
+msgid "r:inverse"
+msgstr ""
+
+#: ../data/functions.xml.in.h:96
+msgid ""
+"Calculates the inverse of a matrix. The inverse is the matrix that "
+"multiplied by the original matrix equals the identity matrix (AB = BA = I)."
+msgstr ""
+"Calcula la inversa d'una matriu. La inversa és la matriu que, quan es "
+"multiplica per la matriu original, és igual a la matriu d'identitat (AB = BA "
+"= I)."
+
+#: ../data/functions.xml.in.h:97
+msgid "Load CSV File"
+msgstr ""
+
+#: ../data/functions.xml.in.h:98
+msgid "r:load"
+msgstr ""
+
+#: ../data/functions.xml.in.h:99
+msgid "Returns a matrix imported from a CSV data file."
+msgstr "Retorna una matriu importada d'un fitxer de dades CSV."
+
+#: ../data/functions.xml.in.h:100
+msgid "Filename"
+msgstr ""
+
+#: ../data/functions.xml.in.h:101
+msgid "First data row"
+msgstr ""
+
+#: ../data/functions.xml.in.h:102
+msgid "Separator"
+msgstr ""
+
+#: ../data/functions.xml.in.h:103
+msgid "Export To CSV File"
+msgstr ""
+
+#: ../data/functions.xml.in.h:104
+msgid "r:export"
+msgstr ""
+
+#: ../data/functions.xml.in.h:105
+msgid "Exports a matrix to a CSV data file."
+msgstr "Exporta una matriu a un fitxer de dades CSV."
+
+#: ../data/functions.xml.in.h:106
+msgid "Magnitude"
+msgstr ""
+
+#: ../data/functions.xml.in.h:107
+msgid "r:magnitude"
+msgstr ""
+
+#: ../data/functions.xml.in.h:108
+msgid ""
+"Calculates the magnitude of a value. This function returns the same value as "
+"abs() for all values except vectors."
+msgstr ""
+"Calcula la magnitud d'un valor. Aquesta funció retorna el mateix valor que "
+"abs() per tots els valors excepte els vectors."
+
+#: ../data/functions.xml.in.h:109
+msgid "Value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:110
+msgid "Hadamard Product"
+msgstr ""
+
+#: ../data/functions.xml.in.h:111
+msgid "r:hadamard"
+msgstr ""
+
+#: ../data/functions.xml.in.h:112
+msgid ""
+"Mulitplies each separate element in matrix 1 with the corresponding element "
+"in matrix 2."
+msgstr ""
+"Multiplica cada element distint en la matriu 1 amb l'element corresponent en "
+"la matriu 2."
+
+#: ../data/functions.xml.in.h:113
+msgid "Matrix 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:114
+msgid "Matrix 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:115
+msgid "Matrix Rank"
+msgstr ""
+
+#: ../data/functions.xml.in.h:116
+msgid "r:rk"
+msgstr ""
+
+#: ../data/functions.xml.in.h:117
+msgid "Reduced Row Echelon Form"
+msgstr ""
+
+#: ../data/functions.xml.in.h:118
+msgid "r:rref"
+msgstr ""
+
+#: ../data/functions.xml.in.h:119
+msgid "Entrywise Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:120
+msgid "r:entrywise"
+msgstr ""
+
+#: ../data/functions.xml.in.h:121
+msgid ""
+"Calculates a new matrix or vector using each separate element in matrix/"
+"vector 1 and the corresponding (in the same row and column) elements in "
+"matrix/vector 2. An unlimited number of matrices/vectors can be specified, "
+"with each matrix/vector argument followed by the corresponding variable used "
+"in the function argument."
+msgstr ""
+"Calcula una matriu nova o un vector nou usant cada element distint en matriu/"
+"vector 1 i els elements corresponents (en la mateixa fila i la mateixa "
+"columna) en matriu/vector 2. Es pot especificar un nombre il·limitat de "
+"matrius/vectors, amb cada argument de matriu/vector seguit amb el variable "
+"corresponent que s'usa en l'argument de funció."
+
+#: ../data/functions.xml.in.h:122
+msgid "Matrices/vectors and variables"
+msgstr ""
+
+#: ../data/functions.xml.in.h:123
+msgid "Norm (length)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:124
+msgid "r:norm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:125
+msgid "Calculates the norm/length of a vector."
+msgstr "Calcula la longitud d'un vector."
+
+#: ../data/functions.xml.in.h:126
+msgid "Dot Product"
+msgstr ""
+
+#: ../data/functions.xml.in.h:127
+msgid "r:dot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:128
+msgid "Calculates the dot product of two vectors."
+msgstr "Calcula el producte escalar de dos vectors."
+
+#: ../data/functions.xml.in.h:129
+msgid "Cross Product"
+msgstr ""
+
+#: ../data/functions.xml.in.h:130
+msgid "r:cross"
+msgstr ""
+
+#: ../data/functions.xml.in.h:131
+msgid "Calculates the cross product of two 3-dimensional vectors."
+msgstr "Calcula el producte vectorial de dos vectors de 3 dimensiones."
+
+#: ../data/functions.xml.in.h:132
+msgid "Combinatorics"
+msgstr ""
+
+#: ../data/functions.xml.in.h:133
+msgid "Factorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:134
+msgid ""
+"Calculates the factorial of an integer. Multiplies the argument with every "
+"lesser positive integer (n(n-1)(n-2)...2*1). Can also be entered as a number "
+"followed by one exclamation mark."
+msgstr ""
+"Calcula el factorial d'un enter. Multiplica l'argument amb cada enter "
+"positiu menor (n(n-1)(n-2)...2*1). També es pot introduir com a un nombre "
+"seguit per un signe d'exclamació."
+
+#: ../data/functions.xml.in.h:135
+msgid "r:factorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:136
+msgid "Double Factorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:137
+msgid "r:factorial2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:138
+msgid ""
+"Calculates the double factorial of an integer. Multiplies the argument with "
+"every second lesser positive integer (n(n-2)(n-4)...). Can also be entered "
+"as a number followed by two exclamation marks."
+msgstr ""
+"Calcula el factorial doble d'un enter. Multiplica l'argument amb cada segon "
+"enter positiu menor (n(n-2)(n-4)...). També es pot introduir com a un nombre "
+"seguit per dos signes d'exclamació."
+
+#: ../data/functions.xml.in.h:139
+msgid "Multifactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:140
+msgid "r:multifactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:141
+msgid ""
+"Calculates the multifactorial of an integer. Multiplies the argument with "
+"every x lesser positive integer (n(n-x)(n-2x)...). Can also be entered as a "
+"number followed by three or more exclamation marks."
+msgstr ""
+"Calcula el multifactorial d'un enter. Multiplica l'argument amb cada x enter "
+"positiu menor (n(n-x)(n-2x)...). També es pot introduir com a un nombre "
+"seguit per tres o més signes d'exclamació."
+
+#: ../data/functions.xml.in.h:142
+msgid "Binomial Coefficient"
+msgstr ""
+
+#: ../data/functions.xml.in.h:143
+msgid "r:binomial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:144
+msgid "Hyperfactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:145
+msgid "r:hyperfactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:146
+msgid ""
+"Calculates the hyperfactorial of an integer. Multiplies the argument raised "
+"by itself with every lesser positive integer raised by themselves (1^1 * "
+"2^2 ... n^n)."
+msgstr ""
+"Calcula el hiperfactorial d'un enter. Multiplica l'argument potenciat al seu "
+"mateix amb cada enter positiu menor potenciat als seu mateix (1^1 * 2^2 ... "
+"n^n)."
+
+#: ../data/functions.xml.in.h:147
+msgid "Superfactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:148
+msgid "r:superfactorial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:149
+msgid ""
+"Calculates the superfactorial of an integer. Multiplies the factorial of the "
+"argument with the factorial of every lesser positive integer (1! * 2! ... "
+"n!)."
+msgstr ""
+"Calcula el superfactorial d'un enter. Multiplica el factorial de l'argument "
+"amb el factorial de cada enter positiu menor (1! * 2! ... n!)."
+
+#: ../data/functions.xml.in.h:150
+msgid "Permutations (Variations)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:151
+msgid "r:perm,variations"
+msgstr ""
+
+#: ../data/functions.xml.in.h:152
+msgid ""
+"Returns the number of possible arrangements of an ordered list with a number "
+"of objects to choose from and a list size. If there are three objects (1, 2 "
+"and 3) that are put in a list with two positions, the alternatives are [1, "
+"2], [2, 1], [1, 3], [3, 1], [2, 3] and [3, 2], and thus the number of "
+"permutations is 6."
+msgstr ""
+"Retorna el nombre d'arranjaments possibles d'una llista ordenada amb un "
+"nombre d'objectes dels quals triar i una mida de llista. Si hi ha tres "
+"objectes (1, 2 i 3) que es ponen en una llista amb dos posicions, les "
+"possibilitats són [1, 2], [2, 1], [1, 3], [3, 1], [2, 3] i [3, 2], i així el "
+"nombre de permutacions és 6."
+
+#: ../data/functions.xml.in.h:153
+msgid "Objects"
+msgstr ""
+
+#: ../data/functions.xml.in.h:154
+msgid "Size"
+msgstr ""
+
+#: ../data/functions.xml.in.h:155
+msgid "Combinations"
+msgstr ""
+
+#: ../data/functions.xml.in.h:156
+msgid "r:comb"
+msgstr ""
+
+#: ../data/functions.xml.in.h:157
+msgid ""
+"Returns the number of possible arrangements of an unordered list with a "
+"number of objects to choose from and a list size. If there are three objects "
+"(1, 2 and 3) that are put in a list with place for two, the alternatives are "
+"[1, 2], [1, 3], and [2, 3], and thus the number of combinations is 3."
+msgstr ""
+"Retorna el nombre d'arranjaments possibles d'una llista no ordenada amb un "
+"nombre d'objectes dels quals triar i una mida de llista. Si hi ha tres "
+"objectes (1, 2 i 3) que es ponen en una llista amb espai per a dos, les "
+"possibilitats són [1, 2], [1, 3] i [2, 3], i així el nombre de combinacions "
+"és 3."
+
+#: ../data/functions.xml.in.h:158
+msgid "Derangements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:159
+msgid "r:derangements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:160
+msgid ""
+"Returns the number of possible rearrangements of an ordered list, of a "
+"certain size, where none of the objects are in their original positions. If "
+"the original list is [1, 2, 3], the possible derangements are [2, 3, 1] and "
+"[3, 1, 2], and thus the number of derangements is 2."
+msgstr ""
+"Retorna el nombre de rearranjaments possibles d'una llista ordenada, de una "
+"mida particular, on ningú dels objectes siguin en les seves posicions "
+"originals. Si la llista original és [1, 2, 3], els desarranjaments possibles "
+"són [2, 3, 1] i [3, 1, 2], i així el nombre de desarranjaments és 2."
+
+#: ../data/functions.xml.in.h:161
+msgid "Number of elements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:162
+msgid "Number Theory"
+msgstr ""
+
+#: ../data/functions.xml.in.h:163
+msgid "Absolute Value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:164
+msgid "r:abs"
+msgstr ""
+
+#: ../data/functions.xml.in.h:165
+msgid "Arithmetic"
+msgstr ""
+
+#: ../data/functions.xml.in.h:166
+msgid "Signum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:167
+msgid "r:sgn"
+msgstr ""
+
+#. A numerical value
+#: ../data/functions.xml.in.h:169
+msgid "Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:170
+msgid "Value for zero"
+msgstr ""
+
+#: ../data/functions.xml.in.h:171
+msgid "Numerator"
+msgstr ""
+
+#: ../data/functions.xml.in.h:172
+msgid "r:numerator"
+msgstr ""
+
+#: ../data/functions.xml.in.h:173
+msgid "Denominator"
+msgstr ""
+
+#: ../data/functions.xml.in.h:174
+msgid "r:denominator"
+msgstr ""
+
+#: ../data/functions.xml.in.h:175
+msgid "Remainder"
+msgstr ""
+
+#: ../data/functions.xml.in.h:176
+msgid "r:rem"
+msgstr ""
+
+#: ../data/functions.xml.in.h:177
+msgid "Modulus"
+msgstr ""
+
+#: ../data/functions.xml.in.h:178
+msgid "r:mod"
+msgstr ""
+
+#: ../data/functions.xml.in.h:179
+msgid "Integer Division"
+msgstr ""
+
+#: ../data/functions.xml.in.h:180
+msgid "r:div"
+msgstr ""
+
+#: ../data/functions.xml.in.h:181
+msgid "Negate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:182
+msgid "r:neg"
+msgstr ""
+
+#: ../data/functions.xml.in.h:183
+msgid "Reciprocal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:184
+msgid "r:inv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:185
+msgid "Multiply"
+msgstr ""
+
+#: ../data/functions.xml.in.h:186
+msgid "r:multiply"
+msgstr ""
+
+#: ../data/functions.xml.in.h:187
+msgid "Factors"
+msgstr ""
+
+#: ../data/functions.xml.in.h:188
+msgid "Add"
+msgstr ""
+
+#: ../data/functions.xml.in.h:189
+msgid "r:add"
+msgstr ""
+
+#: ../data/functions.xml.in.h:190
+msgid "Terms"
+msgstr ""
+
+#: ../data/functions.xml.in.h:191
+msgid "Subtract"
+msgstr ""
+
+#: ../data/functions.xml.in.h:192
+msgid "r:subtract"
+msgstr ""
+
+#: ../data/functions.xml.in.h:193
+msgid "Divide"
+msgstr ""
+
+#: ../data/functions.xml.in.h:194
+msgid "r:divide"
+msgstr ""
+
+#: ../data/functions.xml.in.h:195
+msgid "Raise"
+msgstr ""
+
+#: ../data/functions.xml.in.h:196
+msgid "r:raise"
+msgstr ""
+
+#: ../data/functions.xml.in.h:197
+msgid "Base"
+msgstr ""
+
+#: ../data/functions.xml.in.h:198
+msgid "Exponent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:199
+msgid "Polynomials"
+msgstr ""
+
+#: ../data/functions.xml.in.h:200
+msgid "Coefficient"
+msgstr ""
+
+#: ../data/functions.xml.in.h:201
+msgid "r:coeff"
+msgstr ""
+
+#: ../data/functions.xml.in.h:202
+msgid "Polynomial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:203
+msgid "Leading Coefficient"
+msgstr ""
+
+#: ../data/functions.xml.in.h:204
+msgid "r:lcoeff"
+msgstr ""
+
+#: ../data/functions.xml.in.h:205
+msgid "Trailing Coefficient"
+msgstr ""
+
+#: ../data/functions.xml.in.h:206
+msgid "r:tcoeff"
+msgstr ""
+
+#: ../data/functions.xml.in.h:207
+msgid "Polynomial Degree"
+msgstr ""
+
+#: ../data/functions.xml.in.h:208
+msgid "r:degree"
+msgstr ""
+
+#: ../data/functions.xml.in.h:209
+msgid "Lowest Degree (Valuation)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:210
+msgid "r:ldegree"
+msgstr ""
+
+#: ../data/functions.xml.in.h:211
+msgid "Content Part"
+msgstr ""
+
+#: ../data/functions.xml.in.h:212
+msgid "r:pcontent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:213
+msgid "Primitive Part"
+msgstr ""
+
+#: ../data/functions.xml.in.h:214
+msgid "r:primpart"
+msgstr ""
+
+#: ../data/functions.xml.in.h:215
+msgid "Unit Part"
+msgstr ""
+
+#: ../data/functions.xml.in.h:216
+msgid "r:punit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:217
+msgid "Greatest Common Divisor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:218
+msgid "rc:gcd,c:GCD"
+msgstr ""
+
+#: ../data/functions.xml.in.h:219
+msgid "1st value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:220
+msgid "2nd value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:221
+msgid "Least Common Multiple"
+msgstr ""
+
+#: ../data/functions.xml.in.h:222
+msgid "r:lcm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:223
+msgid "Bernoulli Number/Polynomial"
+msgstr ""
+
+#: ../data/functions.xml.in.h:224
+msgid ""
+"Returns the nth Bernoulli number or polynomial (if the second argument is "
+"non-zero)."
+msgstr ""
+"Retorna el nombre o polinomi n de Bernoulli (si el segon argument no és "
+"zero)."
+
+#: ../data/functions.xml.in.h:225
+msgid "r:bernoulli"
+msgstr ""
+
+#: ../data/functions.xml.in.h:226
+msgid "Index (n)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:227
+msgid "Euler's Totient Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:228
+msgid ""
+"Counts the positive integers up to a given integer n that are relatively "
+"prime to n."
+msgstr ""
+"Compta els enters positius fins un enter donat n que li siguin coprimers a n."
+
+#: ../data/functions.xml.in.h:229
+msgid "r:totient,au:&#x3C6;,phi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:230
+msgid "n"
+msgstr ""
+
+#: ../data/functions.xml.in.h:231
+msgid "Fibonacci Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:232
+msgid "r:fibonacci"
+msgstr ""
+
+#: ../data/functions.xml.in.h:233
+msgid "Returns the n-th term of the Fibonacci sequence."
+msgstr "Retorna el termini n de la successió de Fibonacci."
+
+#: ../data/functions.xml.in.h:234
+msgid "Rounding"
+msgstr ""
+
+#: ../data/functions.xml.in.h:235
+msgid "Round"
+msgstr ""
+
+#: ../data/functions.xml.in.h:236
+msgid "r:round"
+msgstr ""
+
+#: ../data/functions.xml.in.h:237
+msgid ""
+"Round to nearest integer or decimal. If the second argument is zero, the "
+"value is rounded towards the nearest integer, otherwise the value is rounded "
+"to the corresponding number of digits to the right (if positive) or left (if "
+"negative) of the decimal point. If the third argument is true, halfway "
+"numbers are rounded toward the nearest even integer/digit, otherwise away "
+"from zero."
+msgstr ""
+"Arrodoneix al enter o decimal més proper. Si el segon argument és zero, el "
+"valor s'arrodoneix cap al enter més proper, d'altre manera el valor "
+"s'arrodoneix al nombre corresponent de xifres a la dreta (si és positiu) o a "
+"l'esquerra (si és negatiu) de la coma decimal. Si el tercer argument és "
+"cert, els nombres a mig camí s'arrodoneixen al enter parell més proper o a "
+"la xifra parella més propera, d'altre manera al lluny de zero."
+
+#: ../data/functions.xml.in.h:238
+msgid "Number of decimals"
+msgstr ""
+
+#: ../data/functions.xml.in.h:239
+msgid "Round halfway to even"
+msgstr ""
+
+#: ../data/functions.xml.in.h:240
+msgid "Round Downwards"
+msgstr ""
+
+#: ../data/functions.xml.in.h:241
+msgid "r:floor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:242
+msgid "Round Upwards"
+msgstr ""
+
+#: ../data/functions.xml.in.h:243
+msgid "r:ceil"
+msgstr ""
+
+#: ../data/functions.xml.in.h:244
+msgid "Round Towards Zero"
+msgstr ""
+
+#: ../data/functions.xml.in.h:245
+msgid "r:trunc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:246
+msgid "Integer Part"
+msgstr ""
+
+#: ../data/functions.xml.in.h:247
+msgid "r:int"
+msgstr ""
+
+#: ../data/functions.xml.in.h:248
+msgid "Fractional Part"
+msgstr ""
+
+#: ../data/functions.xml.in.h:249
+msgid "r:frac"
+msgstr ""
+
+#: ../data/functions.xml.in.h:250
+msgid "Number Bases"
+msgstr ""
+
+#: ../data/functions.xml.in.h:251
+msgid "Number Base"
+msgstr ""
+
+#: ../data/functions.xml.in.h:252
+msgid "r:base"
+msgstr ""
+
+#: ../data/functions.xml.in.h:253
+msgid ""
+"Returns a value from an expression using the specified number base (radix). "
+"For bases between -62 and 62 full mathematical expressions (including "
+"operators and functions) are supported, while for other bases the specified "
+"expression is converted to a single number.&#10;&#10;Bases ≤ 36 use digits "
+"0-9 and A-Z (case insensitive).&#10;&#10;Bases between 37 and 62 uses case "
+"sensitive letters (0-9, A-Z, a-z) as digits ('z' equals 61).&#10;&#10;Bases "
+"over 62 use Unicode characters as digits, with the character code as value "
+"(e.g. '0' equals 48). Escaped characters are in this case supported (e.g. "
+"'\\0' = 0, '\\523' = 523, '\\x7f' = 127).&#10;&#10;Negative bases use the "
+"same digits as the corresponding positive bases and the digits used for non-"
+"integer bases are determined by rounding the base away from zero. Bases that "
+"are not real numbers by default use digits 0-9 and A-Z.&#10;&#10;The set of "
+"digits used can be selected using the third argument (defaults to 0 for "
+"automatic selection). Set it to 1 for digits 0-9 and A-Z, 2 for 0-9, A-Z and "
+"a-z, 3 for Unicode digits, and 4 for phonewords (e.g. ABC=2, CDE=3, etc.), "
+"or enter a text string with all digits placed in ascending order (e.g. "
+"\"0123456789\") and optionally separated by semicolon (to enable multple "
+"equivalent digits, e.g. \"0;aA1;bB2;cC3\"). When the set of digits is "
+"manually selected, the specified expression is always converted to a single "
+"number."
+msgstr ""
+"Retorna un valor d'una expressió usant la base numèrica especificada. Per a "
+"les bases entre -62 i 62 s'admeten expressions matemàtiques plenes (incloent "
+"operadors i funcions), mentre per a les altres bases es converteix "
+"l'expressió especificada a un sol nombre.&#10;&#10;Les bases ≤ 36 usen les "
+"xifres 0-9 i A-Z (majúscules o minúscules).&#10;&#10;Les bases entre 37 i 62 "
+"usen lletres majúscules i minúscules (0-9, A-Z, a-z) com a xifres ('z' és "
+"61).&#10;&#10;Les bases superiors a 62 usen caràcters d'Unicode com a "
+"xifres, amb el codi del caràcter com el valor (per exemple '0' és 48). Els "
+"caràcters escapats es permeten en aquest cas (per exemple '\\0' = 0, '\\523' "
+"= 523, '\\x7f' = 127).&#10;&#10;Les bases negatives usen les mateixes xifres "
+"que les bases positives corresponents i les xifres usades per a les bases no "
+"enters es determinen arrodonint la base al lluny de zero. Les bases que no "
+"són nombres reals per defecte usen les xifres 0-9 i A-Z.&#10;&#10;El conjunt "
+"de xifres usades es pot seleccionar mitjançant el tercer argument (per "
+"defecte 0 per selecció automàtica). Establiu-el a 1 per als xifres 0-9 i A-"
+"z, 2 per 0-9, A-z i a-z, 3 per xifres d'Unicode i 4 per paraules de telèfon "
+"(per exemple ABC=2, CDE=3, etc.), o introduïu una cadena de text amb totes "
+"les xifres col·locades en ordre ascendent (per exemple \"0123456789\") i "
+"opcionalment separades per punt i coma (per a habilitar múltiples xifres "
+"equivalents, per exemple \"0;aA1;bB2;cC3\"). Quan se selecciona el conjunt "
+"de xifres manualment, sempre es converteix l'expressió especificada en un "
+"sol nombre."
+
+#: ../data/functions.xml.in.h:254
+msgid "Set of digits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:255
+msgid "Binary"
+msgstr ""
+
+#: ../data/functions.xml.in.h:256
+msgid "r:bin"
+msgstr ""
+
+#: ../data/functions.xml.in.h:257
+msgid ""
+"Returns a value from a binary expression. If two's complement is true, "
+"numbers beginning with '1' are interpreted as negative binary numbers using "
+"two's complement."
+msgstr ""
+"Retorna un valor d'una expressió binària. Si el complement a dos està "
+"activat, els nombres començant amb '1' s'interpreten com nombres binaris "
+"negatius mitjançant complement a dos."
+
+#: ../data/functions.xml.in.h:258
+msgid "Binary number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:259
+msgid "Two's complement"
+msgstr ""
+
+#: ../data/functions.xml.in.h:260
+msgid "Octal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:261
+msgid "r:oct"
+msgstr ""
+
+#: ../data/functions.xml.in.h:262
+msgid "Returns a value from an octal expression."
+msgstr "Retorna el valor d'una expressió octal."
+
+#: ../data/functions.xml.in.h:263
+msgid "Octal number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:264
+msgid "Decimal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:265
+msgid "r:dec"
+msgstr ""
+
+#: ../data/functions.xml.in.h:266
+msgid "Returns a value from a decimal expression."
+msgstr "Retorna el valor d'una expressió decimal."
+
+#: ../data/functions.xml.in.h:267
+msgid "Decimal number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:268
+msgid "Hexadecimal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:269
+msgid "r:hex"
+msgstr ""
+
+#: ../data/functions.xml.in.h:270
+msgid ""
+"Returns a value from a hexadecimal expression. If two's complement is true, "
+"numbers beginning with 8 or higher are interpreted as negative hexadecimal "
+"numbers using two's complement."
+msgstr ""
+"Retorna un valor d'una expressió hexadecimal. Si el complement a dos està "
+"activat, els nombres començant amb 8 o superior s'interpreten com a nombres "
+"hexadecimals negatius mitjançant complement a dos."
+
+#: ../data/functions.xml.in.h:271
+msgid "Hexadecimal number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:272
+msgid "Bijective base-26"
+msgstr ""
+
+#: ../data/functions.xml.in.h:273
+msgid "r:bijective"
+msgstr ""
+
+#: ../data/functions.xml.in.h:274
+msgid ""
+"Returns a value from an expression in bijective base-26. Conversion in the "
+"opposite direction is also supported."
+msgstr ""
+"Retorna un valor d'una expressió en base 26 bijectiu. També s'admet la "
+"conversió en la direcció oposada."
+
+#: ../data/functions.xml.in.h:275
+msgid "Bijective base-26 number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:276
+msgid "Integers"
+msgstr ""
+
+#: ../data/functions.xml.in.h:277
+msgid "Even"
+msgstr ""
+
+#: ../data/functions.xml.in.h:278
+msgid "r:even"
+msgstr ""
+
+#: ../data/functions.xml.in.h:279
+msgid "Odd"
+msgstr ""
+
+#: ../data/functions.xml.in.h:280
+msgid "r:odd"
+msgstr ""
+
+#: ../data/functions.xml.in.h:281
+msgid "Special Functions"
+msgstr ""
+
+#: ../data/functions.xml.in.h:282
+msgid "Gamma Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:283
+msgid "r:gamma"
+msgstr ""
+
+#: ../data/functions.xml.in.h:284
+msgid "Digamma Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:285
+msgid "r:digamma,psi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:286
+msgid "Beta Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:287
+msgid "r:beta"
+msgstr ""
+
+#: ../data/functions.xml.in.h:288
+msgid "Error Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:289
+msgid "r:erf"
+msgstr ""
+
+#: ../data/functions.xml.in.h:290
+msgid "Complementary Error Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:291
+msgid "r:erfc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:292
+msgid "Imaginary Error Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:293
+msgid "r:erfi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:294
+msgid "Inverse Error Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:295
+msgid "r:erfinv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:296
+msgid "Polylogarithm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:297
+msgid "rc:Li,polylog"
+msgstr ""
+
+#: ../data/functions.xml.in.h:298
+msgid "Order"
+msgstr ""
+
+#: ../data/functions.xml.in.h:299
+msgid "Argument"
+msgstr ""
+
+#: ../data/functions.xml.in.h:300
+msgid "Airy Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:301
+msgid "r:airy"
+msgstr ""
+
+#: ../data/functions.xml.in.h:302
+msgid "Bessel Function of the First Kind"
+msgstr ""
+
+#: ../data/functions.xml.in.h:303
+msgid "r:besselj"
+msgstr ""
+
+#: ../data/functions.xml.in.h:304
+msgid "Bessel Function of the Second Kind"
+msgstr ""
+
+#: ../data/functions.xml.in.h:305
+msgid "r:bessely"
+msgstr ""
+
+#: ../data/functions.xml.in.h:306
+msgid "Riemann Zeta"
+msgstr ""
+
+#: ../data/functions.xml.in.h:307
+msgid "Calculates Hurwitz zeta function if the second argument is not 1."
+msgstr "Calcula la funció de zeta de Hurwitz si el segon argument no és 1."
+
+#: ../data/functions.xml.in.h:308
+msgid "r:zeta"
+msgstr ""
+
+#: ../data/functions.xml.in.h:309
+msgid "Integral point"
+msgstr ""
+
+#: ../data/functions.xml.in.h:310
+msgid "Hurwitz zeta argument"
+msgstr ""
+
+#: ../data/functions.xml.in.h:311
+msgid "Kronecker Delta"
+msgstr ""
+
+#: ../data/functions.xml.in.h:312
+msgid "r:kronecker"
+msgstr ""
+
+#: ../data/functions.xml.in.h:313
+msgid "Returns 0 if i != j and 1 if i = j."
+msgstr "Retorna 0 si i != j i 1 si i = j."
+
+#: ../data/functions.xml.in.h:314
+msgid "Value 1 (i)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:315
+msgid "Value 2 (j)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:316
+msgid "Logit Transformation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:317
+msgid "r:logit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:318
+msgid "Probit Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:319
+msgid "r:probit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:320
+msgid "Sigmoid Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:321
+msgid "r:sigmoid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:322
+msgid "Step Functions"
+msgstr ""
+
+#: ../data/functions.xml.in.h:323
+msgid "Heaviside Step Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:324
+msgid "r:heaviside,au:&#x03B8;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:325
+msgid ""
+"Discontinuous function also known as \"unit step function\". Returns 0 if x "
+"&lt; 0, 1 if x &gt; 0, and 1/2 if x = 0."
+msgstr ""
+"Una funció discontinua, també coneguda com a \"funció de passos d'una unitat"
+"\". Retorna 0 si x &lt; 0, 1 si x &gt; 0 i 1/2 si x = 0."
+
+#: ../data/functions.xml.in.h:326
+msgid "Dirac Delta Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:327
+msgid "r:dirac,au:&#x3B4;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:328
+msgid "Returns 0 if x is non-zero, and infinity if x is zero."
+msgstr "Retorna 0 si x no és zero, i infinit si x és zero."
+
+#: ../data/functions.xml.in.h:329
+msgid "Ramp Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:330
+msgid "r:ramp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:331
+msgid "Rectangular Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:332
+msgid "r:rectangular"
+msgstr ""
+
+#: ../data/functions.xml.in.h:333
+msgid "Triangular Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:334
+msgid "r:triangular"
+msgstr ""
+
+#: ../data/functions.xml.in.h:335
+msgid "Complex Numbers"
+msgstr ""
+
+#: ../data/functions.xml.in.h:336
+msgid "Real Part"
+msgstr ""
+
+#: ../data/functions.xml.in.h:337
+msgid "r:re,au:&#x211C;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:338
+msgid "Complex number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:339
+msgid "Imaginary Part"
+msgstr ""
+
+#: ../data/functions.xml.in.h:340
+msgid "r:im,au:&#x2111;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:341
+msgid "Principal Argument"
+msgstr ""
+
+#: ../data/functions.xml.in.h:342
+msgid "r:arg"
+msgstr ""
+
+#: ../data/functions.xml.in.h:343
+msgid "Complex Conjugate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:344
+msgid "r:conj"
+msgstr ""
+
+#: ../data/functions.xml.in.h:345
+msgid "Exponents &amp; Logarithms"
+msgstr ""
+
+#: ../data/functions.xml.in.h:346
+msgid "Square Root"
+msgstr ""
+
+#: ../data/functions.xml.in.h:347
+msgid "au:&#x221A;,r:sqrt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:348
+msgid ""
+"Returns the principal square root (for positive values the positive root is "
+"returned)."
+msgstr ""
+"Retorna l'arrel quadrada principal (pels valors positius, es retorna l'arrel "
+"positiva)."
+
+#: ../data/functions.xml.in.h:349
+msgid "Cube Root"
+msgstr ""
+
+#: ../data/functions.xml.in.h:350
+msgid "r:cbrt,aou:&#x221B;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:351
+msgid "Returns the third real root."
+msgstr "Retorna la tercera arrel real."
+
+#: ../data/functions.xml.in.h:352
+msgid "Nth root"
+msgstr ""
+
+#: ../data/functions.xml.in.h:353
+msgid "r:root"
+msgstr ""
+
+#: ../data/functions.xml.in.h:354
+msgid ""
+"Returns the real root. For negative values the degree must be odd. Complex "
+"values are not allowed."
+msgstr ""
+"Retorna l'arrel real. Per a valors negatius, el grau ha de ser imparell. No "
+"s'admeten valors complexes."
+
+#: ../data/functions.xml.in.h:355 ../data/units.xml.in.h:64
+msgid "Degree"
+msgstr ""
+
+#: ../data/functions.xml.in.h:356
+msgid "Square"
+msgstr ""
+
+#: ../data/functions.xml.in.h:357
+msgid "r:sq"
+msgstr ""
+
+#: ../data/functions.xml.in.h:358
+msgid "Exponential (e^x)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:359
+msgid "r:exp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:360
+msgid "Natural Logarithm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:361
+msgid "r:ln"
+msgstr ""
+
+#: ../data/functions.xml.in.h:362
+msgid "Base-N Logarithm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:363
+msgid "r:log"
+msgstr ""
+
+#: ../data/functions.xml.in.h:364
+msgid "Lambert W Function (Omega Function, Product Log)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:365
+msgid "r:lambertw,productlog"
+msgstr ""
+
+#: ../data/functions.xml.in.h:366
+msgid ""
+"Returns the inverse function for mx*e^x as ln() does for e^x. Only the "
+"principal branch and real valued results are currently supported."
+msgstr ""
+"Retorna la funció inversa per a mx*e^x tal com ln() fa per a e^x. Actualment "
+"s'admeten només la rama principal i resultats de valor real."
+
+#: ../data/functions.xml.in.h:367
+msgid "Branch"
+msgstr ""
+
+#: ../data/functions.xml.in.h:368
+msgid "Complex Exponential (Cis)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:369
+msgid "r:cis"
+msgstr ""
+
+#: ../data/functions.xml.in.h:370
+msgid "Base-2 Logarithm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:371
+msgid "rs:log2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:372
+msgid "Returns the base n logarithm."
+msgstr "Retorna el logaritme de base n."
+
+#: ../data/functions.xml.in.h:373
+msgid "Base-10 Logarithm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:374
+msgid "rs:log10"
+msgstr ""
+
+#: ../data/functions.xml.in.h:375
+msgid "2 raised to the power X"
+msgstr ""
+
+#: ../data/functions.xml.in.h:376
+msgid "rs:exp2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:377
+msgid "10 raised to the power X"
+msgstr ""
+
+#: ../data/functions.xml.in.h:378
+msgid "rs:exp10"
+msgstr ""
+
+#: ../data/functions.xml.in.h:379
+msgid "X raised to the power Y"
+msgstr ""
+
+#: ../data/functions.xml.in.h:380
+msgid "r:pow"
+msgstr ""
+
+#: ../data/functions.xml.in.h:381
+msgid "Square root (x * pi)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:382
+msgid "r:sqrtpi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:383
+msgid "Returns the non-negative square root of x * pi"
+msgstr "Retorna l'arrel quadrada no negativa de x * pi"
+
+#: ../data/functions.xml.in.h:384
+msgid "Non-negative value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:385
+msgid "Trigonometry"
+msgstr ""
+
+#: ../data/functions.xml.in.h:386
+msgid "Sine"
+msgstr ""
+
+#: ../data/functions.xml.in.h:387
+msgid "r:sin"
+msgstr ""
+
+#: ../data/functions.xml.in.h:388
+msgid "Angle"
+msgstr ""
+
+#: ../data/functions.xml.in.h:389
+msgid "Cosine"
+msgstr ""
+
+#: ../data/functions.xml.in.h:390
+msgid "r:cos"
+msgstr ""
+
+#: ../data/functions.xml.in.h:391
+msgid "Tangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:392
+msgid "r:tan"
+msgstr ""
+
+#: ../data/functions.xml.in.h:393
+msgid "Inverse Sine"
+msgstr ""
+
+#: ../data/functions.xml.in.h:394
+msgid "r:arcsin, r:asin"
+msgstr ""
+
+#: ../data/functions.xml.in.h:395
+msgid "Inverse Cosine"
+msgstr ""
+
+#: ../data/functions.xml.in.h:396
+msgid "r:arccos, r:acos"
+msgstr ""
+
+#: ../data/functions.xml.in.h:397
+msgid "Inverse Tangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:398
+msgid "r:arctan, r:atan"
+msgstr ""
+
+#: ../data/functions.xml.in.h:399
+msgid "Hyperbolic Sine"
+msgstr ""
+
+#: ../data/functions.xml.in.h:400
+msgid "r:sinh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:401
+msgid "Hyperbolic Cosine"
+msgstr ""
+
+#: ../data/functions.xml.in.h:402
+msgid "r:cosh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:403
+msgid "Hyperbolic Tangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:404
+msgid "r:tanh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:405
+msgid "Inverse Hyperbolic Sine"
+msgstr ""
+
+#: ../data/functions.xml.in.h:406
+msgid "r:arsinh, r:asinh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:407
+msgid "Inverse Hyperbolic Cosine"
+msgstr ""
+
+#: ../data/functions.xml.in.h:408
+msgid "r:arcosh, r:acosh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:409
+msgid "Inverse Hyperbolic Tangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:410
+msgid "r:artanh, r:atanh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:411
+msgid "Four-quadrant Inverse Tangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:412
+msgid "r:atan2, arctan2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:413
+msgid ""
+"Computes the principal value of the argument function applied to the complex "
+"number x+iy."
+msgstr ""
+"Computa el valor principal de la funció d'argument aplicada al nombre "
+"complex x+iy."
+
+#: ../data/functions.xml.in.h:414
+msgid "Y"
+msgstr ""
+
+#: ../data/functions.xml.in.h:415
+msgid "X"
+msgstr ""
+
+#: ../data/functions.xml.in.h:416
+msgid "Cardinal Sine (Sinc Function)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:417
+msgid "r:sinc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:418
+msgid "Radians to Default Angle Unit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:419
+msgid "r:radtodef"
+msgstr ""
+
+#: ../data/functions.xml.in.h:420
+msgid "Radians"
+msgstr ""
+
+#: ../data/functions.xml.in.h:421
+msgid "Default Angle Unit to Radians"
+msgstr ""
+
+#: ../data/functions.xml.in.h:422
+msgid "r:deftorad"
+msgstr ""
+
+#: ../data/functions.xml.in.h:423
+msgid "Secant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:424
+msgid "r:sec"
+msgstr ""
+
+#: ../data/functions.xml.in.h:425
+msgid "Cosecant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:426
+msgid "r:csc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:427
+msgid "Cotangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:428
+msgid "r:cot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:429
+msgid "Hyperbolic Secant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:430
+msgid "r:sech"
+msgstr ""
+
+#: ../data/functions.xml.in.h:431
+msgid "Hyperbolic Cosecant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:432
+msgid "r:csch"
+msgstr ""
+
+#: ../data/functions.xml.in.h:433
+msgid "Hyperbolic Cotangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:434
+msgid "r:coth"
+msgstr ""
+
+#: ../data/functions.xml.in.h:435
+msgid "Inverse Secant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:436
+msgid "r:arcsec, r:asec"
+msgstr ""
+
+#: ../data/functions.xml.in.h:437
+msgid "Inverse Cosecant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:438
+msgid "r:arccsc, r:acsc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:439
+msgid "Inverse Cotangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:440
+msgid "r:arccot, r:acot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:441
+msgid "Inverse Hyperbolic Secant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:442
+msgid "r:arsech, r:asech"
+msgstr ""
+
+#: ../data/functions.xml.in.h:443
+msgid "Inverse Hyperbolic Cosecant"
+msgstr ""
+
+#: ../data/functions.xml.in.h:444
+msgid "r:arcsch, r:acsch"
+msgstr ""
+
+#: ../data/functions.xml.in.h:445
+msgid "Inverse Hyperbolic Cotangent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:446
+msgid "r:arcoth, r:acoth"
+msgstr ""
+
+#: ../data/functions.xml.in.h:447
+msgid "Miscellaneous"
+msgstr ""
+
+#: ../data/functions.xml.in.h:448
+msgid "IEEE 754 Floating-Point"
+msgstr ""
+
+#: ../data/functions.xml.in.h:449
+msgid "r:float"
+msgstr ""
+
+#: ../data/functions.xml.in.h:450
+msgid ""
+"Reads a number in a IEEE 754 floating-point format. The number will be read "
+"as a binary number, unless it contains digits other than 1 or 0. If the "
+"third argument (exponent bits) is set to zero, the standard number of "
+"exponent bits will be used (e.g. 8 for 32-bit format)."
+msgstr ""
+"Llegeix un nombre en format de punt flotant IEEE 754. Es llegeix el nombre "
+"com a nombre binari, a menys que contingui xifres apart de 1 o 0. Si el "
+"tercer argument (els bits d'exponent) és zero, s'usa el nombre estàndard de "
+"bits d'exponent (per exemple 8 per al format de 32 bits)."
+
+#: ../data/functions.xml.in.h:451
+msgid "Floating-point number (binary)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:452
+msgid "Number of bits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:453
+msgid "Number of exponent bits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:454
+msgid "IEEE 754 Floating-Point Bits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:455
+msgid "r:floatBits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:456
+msgid ""
+"Converts a value to a number in a IEEE 754 floating-point format and returns "
+"the number corresponding to the binary representation. If the third argument "
+"(exponent bits) is set to zero, the standard number of exponent bits will be "
+"used (e.g. 8 for 32-bit format)."
+msgstr ""
+"Converteix un valor a un nombre en format de punt flotant IEEE 754 i retorna "
+"el nombre corresponent a la representació binària. Si el tercer argument "
+"(els bits d'exponent) és zero, s'usa el nombre estàndard de bits d'exponent "
+"(per exemple 8 per al format de 32 bits)."
+
+#: ../data/functions.xml.in.h:457
+msgid "IEEE 754 Floating-Point Error"
+msgstr ""
+
+#: ../data/functions.xml.in.h:458
+msgid "r:floatError"
+msgstr ""
+
+#: ../data/functions.xml.in.h:459
+msgid ""
+"Calculates the error (the difference between the original and the converted "
+"value) when converting a value to a IEEE 754 floating-point format. If the "
+"third argument (exponent bits) is set to zero, the standard number of "
+"exponent bits will be used (e.g. 8 for 32-bit format)."
+msgstr ""
+"Calcula l'error (la diferència entre el valor original i el convertit) quan "
+"es converteix un valor a un format de punt flotant IEEE 754. Si el tercer "
+"argument (els bits d'exponent) és zero, s'usa el nombre estàndard de bits "
+"d'exponent (per exemple 8 per al format de 32 bits)."
+
+#: ../data/functions.xml.in.h:460
+msgid "IEEE 754 Floating-Point Components"
+msgstr ""
+
+#: ../data/functions.xml.in.h:461
+msgid "r:floatParts"
+msgstr ""
+
+#: ../data/functions.xml.in.h:462
+msgid ""
+"Converts a value to a number in a IEEE 754 floating-point format and returns "
+"sign, exponent, and significand in a vector. If the third argument (exponent "
+"bits) is set to zero, the standard number of exponent bits will be used (e."
+"g. 8 for 32-bit format)."
+msgstr ""
+"Converteix un valor a un nombre en un format IEEE 754 i retorna el signe, "
+"l'exponent i la mantissa en un vector. Si el tercer argument (els bits "
+"d'exponent) és zero, s'usa el nombre estàndard de bits d'exponent (per "
+"exemple 8 per al format de 32 bits)."
+
+#: ../data/functions.xml.in.h:463
+msgid "IEEE 754 Floating-Point Value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:464
+msgid "r:floatValue"
+msgstr ""
+
+#: ../data/functions.xml.in.h:465
+msgid ""
+"Returns the closest value that can be represented by a IEEE 754 floating-"
+"point format. If the third argument (exponent bits) is set to zero, the "
+"standard number of exponent bits will be used (e.g. 8 for 32-bit format)."
+msgstr ""
+"Retorna el valor més proper que es pot representar en un format de punt "
+"flotant IEEE 754. Si el tercer argument (els bits d'exponent) és zero, s'usa "
+"el nombre estàndard de bits d'exponent (per exemple 8 per al format de 32 "
+"bits)."
+
+#: ../data/functions.xml.in.h:466
+msgid "Roman Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:467
+msgid "r:roman"
+msgstr ""
+
+#: ../data/functions.xml.in.h:468
+msgid "Returns the value of a roman number."
+msgstr "Retorna el valor d'un nombre romà."
+
+#: ../data/functions.xml.in.h:469
+msgid "Roman number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:470
+msgid "Distance Between GPS Coordinates"
+msgstr ""
+
+#: ../data/functions.xml.in.h:471
+msgid "r:geodistance,gpsdistance"
+msgstr ""
+
+#: ../data/functions.xml.in.h:472
+msgid ""
+"Calculates the distance between two geodetic coordinates using Vincenty's "
+"formulae (with datum WGS 84), or, in case of failure, the Haversine forumla. "
+"Each coordinate can be specified using a numerical value (representing "
+"decimal degrees), an angle (e.g. with degree unit), or a text string ending "
+"with N, S, E, or W (S for negative latitude, W for negative longitude)."
+msgstr ""
+"Calcula la distància entre dos coordinats geodèsics usant les fórmules de "
+"Vincenty (amb dada WGS 84), o, en case de fall, la fórmula de Haversine. Es "
+"pot especificar cada coordinat usant un valor numèric (representant graus "
+"decimals), un angle (per exemple, amb unitat de graus) o una cadena de text "
+"que termina amb N, S, E, or W (S per latitud negativa, W per longitud "
+"negativa)."
+
+#: ../data/functions.xml.in.h:473
+msgid "Latitude 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:474
+msgid "Longitude 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:475
+msgid "Latitude 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:476
+msgid "Longitude 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:477
+msgid "Body Mass Index (BMI)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:478
+msgid "-r:bmi"
+msgstr ""
+
+#: ../data/functions.xml.in.h:479
+msgid ""
+"Calculates the Body Mass Index. The resulting BMI-value is sometimes "
+"interpreted as follows (although varies with age, sex, etc.):&#10;&#10;"
+"Underweight &lt; 18.5&#10;Normal weight 18.5-25&#10;Overweight 25-30&#10;"
+"Obesity &gt; 30&#10;&#10;Note that you must use units for weight (ex. 59kg) "
+"and length (ex. 174cm)."
+msgstr ""
+"Calcula l'Índex de Massa Corporal. El resultant valor IMC a vegades "
+"s'interpreta com ho següent (encara que varia amb edat, sexe etc.):&#10;&#10;"
+"Pes beix &lt; 18.5&#10;Pes normal 18.5-25&#10;Pes alt 25-30&#10;Obesitat "
+"&gt; 30&#10;&#10;Tingueu en compte que heu d'usar unitats de pes (per "
+"exemple 59kg) i d'alçada (per exemple 174cm)."
+
+#: ../data/functions.xml.in.h:480
+msgid "Weight"
+msgstr ""
+
+#: ../data/functions.xml.in.h:481
+msgid "Length"
+msgstr ""
+
+#: ../data/functions.xml.in.h:482
+msgid "RAID Space"
+msgstr ""
+
+#: ../data/functions.xml.in.h:483
+msgid "r:raid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:484
+msgid ""
+"Calculates RAID array disk capacity usable for data storage. If the "
+"combination of number of disks and RAID level is invalid, zero is returned. "
+"Supported RAID levels are 0, 1, 2, 3, 4, 5, 6, 1+0/10, 0+1, 5+0/50, 6+0/60, "
+"and 1+6. Stripes are optional and only used for nested RAID levels (except "
+"1+0)."
+msgstr ""
+"Calcula la capacitat d'una matriu de discos RAID que es pot usar per a "
+"emmagatzematge de dades. Si la combinació de nombre de discos i el nivell "
+"RAID no és vàlid, es retorna zero. Els nivells RAID admesos són 0, 1, 2, 3, "
+"4, 5, 6, 1+0/10, 0+1, 5+0/50, 6+0/60 i 1+6. Les estries són opcionals i "
+"només s'usen en nivells RAID imbricats (excepte 1+0)."
+
+#: ../data/functions.xml.in.h:485
+msgid "RAID level"
+msgstr ""
+
+#: ../data/functions.xml.in.h:486
+msgid "Capacity of each disk"
+msgstr ""
+
+#: ../data/functions.xml.in.h:487
+msgid "Number of disks"
+msgstr ""
+
+#: ../data/functions.xml.in.h:488
+msgid "Stripes"
+msgstr ""
+
+#: ../data/functions.xml.in.h:489
+msgid "Depth of Field"
+msgstr ""
+
+#: ../data/functions.xml.in.h:490
+msgid "r:dof"
+msgstr ""
+
+#: ../data/functions.xml.in.h:491
+msgid ""
+"Returns the estimated distance between the nearest and the farthest objects "
+"that are in acceptably sharp focus in a photo. Enter focal length (e.g. 50 "
+"mm) and distance (e.g. 5 m) with units, and f-stop without unit (2.8, 4.0, "
+"5.6, etc.). Specify either a cicle of confusion diameter limit (e.g. 0.05 "
+"mm) or the sensor size of the camera - 0=\"35mm\", 1=\"APS-H\", 2=\"APS-CN"
+"\" (Nikon, Pentax, Sony), 3=\"APS-C\" (Canon), 4=\"4/3\" (Four Thirds "
+"System), or 5='1\"' (Nikon 1, Sony RX10, Sony RX100) - for a diameter based "
+"on d/1500."
+msgstr ""
+"Retorna la distància estimada entre els objectes més proper i més lluny que "
+"estan en enfocament acceptable en una foto. Introduïu la distància focal "
+"(per exemple 50 mm) i la distancia al subjecte (per exemple 5 m) amb "
+"unitats, i el nombre f sense unitat (2.8, 4.0, 5.6, etc.). Especifiqueu o un "
+"límit del diàmetre dels cercles de confusió (per exemple 0.05 mm) o la mida "
+"de sensor de la càmera- 0=\"35mm\", 1=\"APS-H\", 2=\"APS-CN\" (Nikon, "
+"Pentax, Sony), 3=\"APS-C\" (Canon), 4=\"4/3\" (sistema de quatre terços) o "
+"5='1\"' (Nikon 1, Sony RX10, Sony RX100) - per un diàmetre basat en d/1500."
+
+#: ../data/functions.xml.in.h:492
+msgid "Focal Length"
+msgstr ""
+
+#: ../data/functions.xml.in.h:493
+msgid "F-stop (aperture)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:494
+msgid "Distance"
+msgstr ""
+
+#: ../data/functions.xml.in.h:495
+msgid "Circle of confusion or sensor size"
+msgstr ""
+
+#: ../data/functions.xml.in.h:496
+msgid "American Wire Gauge Cross-Section Area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:497
+msgid "r:awg"
+msgstr ""
+
+#: ../data/functions.xml.in.h:498
+msgid ""
+"For gauges larger than 0000 (4/0), please use negative values (00=-1, "
+"000=-2, 0000=-3, 00000=-4, etc). For conversion to AWG, use an equation (e."
+"g. awg(x) = 20 mm^2)."
+msgstr ""
+"Per a calibres superiors a 0000 (4/0), si us plau, useu valors negatius "
+"(00=-1, 000=-2, 0000=-3, 00000=-4, etc). Per a conversió a AWG, useu una "
+"equació (per exemple awg(x) = 20 mm^2)."
+
+#: ../data/functions.xml.in.h:499
+msgid "American Wire Gauge Diameter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:500
+msgid "r:awgd"
+msgstr ""
+
+#: ../data/functions.xml.in.h:501
+msgid ""
+"For gauges larger than 0000 (4/0), please use negative values (00=-1, "
+"000=-2, 0000=-3, 00000=-4, etc). For conversion to AWG, use an equation (e."
+"g. awgd(x) = 5 mm)."
+msgstr ""
+"Per a calibres superiors a 0000 (4/0), si us plau, useu valors negatius "
+"(00=-1, 000=-2, 0000=-3, 00000=-4, etc). Per a conversió a AWG, useu una "
+"equació (per exemple awgd(x) = 5 mm)."
+
+#: ../data/functions.xml.in.h:502
+msgid "Statistics"
+msgstr ""
+
+#: ../data/functions.xml.in.h:503
+msgid "Descriptive Statistics"
+msgstr ""
+
+#: ../data/functions.xml.in.h:504
+msgid "Sum (total)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:505
+msgid "r:total"
+msgstr ""
+
+#: ../data/functions.xml.in.h:506
+msgid "Data"
+msgstr ""
+
+#: ../data/functions.xml.in.h:507
+msgid "Percentile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:508
+msgid "r:percentile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:510
+#, no-c-format
+msgid "Percentile (%)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:511
+msgid "Quantile algorithm (as in R)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:512
+msgid "r:min"
+msgstr ""
+
+#: ../data/functions.xml.in.h:513
+msgid "Returns the lowest value."
+msgstr "Retorna el valor més baix."
+
+#: ../data/functions.xml.in.h:514
+msgid "r:max"
+msgstr ""
+
+#: ../data/functions.xml.in.h:515
+msgid "Returns the highest value."
+msgstr "Retorna el valor més alt."
+
+#: ../data/functions.xml.in.h:516
+msgid "Mode"
+msgstr ""
+
+#: ../data/functions.xml.in.h:517
+msgid "r:mode"
+msgstr ""
+
+#: ../data/functions.xml.in.h:518
+msgid "Returns the most frequently occurring value."
+msgstr "Retorna el valor que ocorr amb la més freqüència."
+
+#: ../data/functions.xml.in.h:519
+msgid "Range"
+msgstr ""
+
+#: ../data/functions.xml.in.h:520
+msgid "r:range"
+msgstr ""
+
+#: ../data/functions.xml.in.h:521
+msgid "Calculates the difference between the min and max value."
+msgstr "Calcula la diferència entre el valor mínim i el màxim."
+
+#: ../data/functions.xml.in.h:522
+msgid "Median"
+msgstr ""
+
+#: ../data/functions.xml.in.h:523
+msgid "r:median"
+msgstr ""
+
+#: ../data/functions.xml.in.h:524
+msgid "Quartile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:525
+msgid "r:quartile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:526
+msgid "Quantile Algorithm (as in R)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:527
+msgid "Decile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:528
+msgid "r:decile"
+msgstr ""
+
+#: ../data/functions.xml.in.h:529
+msgid "Interquartile Range"
+msgstr ""
+
+#: ../data/functions.xml.in.h:530
+msgid "r:iqr"
+msgstr ""
+
+#: ../data/functions.xml.in.h:531
+msgid "Calculates the difference between the first and third quartile."
+msgstr "Calcula la diferència entre el primer quartil i el tercer."
+
+#: ../data/functions.xml.in.h:532
+msgid "Number of Samples"
+msgstr ""
+
+#. Number of samples
+#: ../data/functions.xml.in.h:534
+msgid "r:number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:535
+msgid "Returns the number of samples."
+msgstr "Retorna el nombre de mostres."
+
+#: ../data/functions.xml.in.h:536
+msgid "Random Numbers"
+msgstr ""
+
+#: ../data/functions.xml.in.h:537
+msgid "Random Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:538
+msgid "r:rand"
+msgstr ""
+
+#: ../data/functions.xml.in.h:539
+msgid ""
+"Generates a pseudo-random number. Returns a real number between 0 and 1, if "
+"ceil is zero (default), or an integer between 1 and (including) ceil."
+msgstr ""
+"Genera un nombre pseudo-aleatori. Retorna un nombre real entre 0 i 1, si el "
+"límit és zero (per defecte), o un enter entre 1 i (incloent) el límit."
+
+#: ../data/functions.xml.in.h:540
+msgid "Ceil"
+msgstr ""
+
+#: ../data/functions.xml.in.h:541
+msgid "Number of values"
+msgstr ""
+
+#: ../data/functions.xml.in.h:542
+msgid "Normally Distributed Random Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:543
+msgid "r:randnorm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:544
+msgid "Mean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:545
+msgid "Standard deviation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:546
+msgid "Poisson Distributed Random Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:547
+msgid "r:randpoisson"
+msgstr ""
+
+#: ../data/functions.xml.in.h:548
+msgid "Uniformly Distributed Random Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:549
+msgid "r:randuniform"
+msgstr ""
+
+#: ../data/functions.xml.in.h:550
+msgid "Random Number Between Limits"
+msgstr ""
+
+#: ../data/functions.xml.in.h:551
+msgid "r:randbetween"
+msgstr ""
+
+#: ../data/functions.xml.in.h:552
+msgid "Returns an integer between (including) bottom and top."
+msgstr "Retorna un enter entre (incloent) el fons i el cim."
+
+#: ../data/functions.xml.in.h:553
+msgid "Bottom"
+msgstr ""
+
+#: ../data/functions.xml.in.h:554
+msgid "Top"
+msgstr ""
+
+#: ../data/functions.xml.in.h:555
+msgid "Exponential Random Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:556
+msgid "r:randexp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:557
+msgid "Rate parameter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:558
+msgid "Rayleigh Distributed Random Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:559
+msgid "r:randrayleigh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:560
+msgid "Sigma"
+msgstr ""
+
+#: ../data/functions.xml.in.h:561
+msgid "Means"
+msgstr ""
+
+#: ../data/functions.xml.in.h:562
+msgid "r:mean,average,au:x&#x0304;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:563
+msgid "Harmonic Mean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:564
+msgid "r:harmmean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:565
+msgid "Geometric Mean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:566
+msgid "r:geomean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:567
+msgid "Trimmed Mean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:568
+msgid "r:trimmean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:569
+msgid "Trimmed percentage (at each end)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:570
+msgid "Winsorized Mean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:571
+msgid "r:winsormean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:572
+msgid "Winsorized percentage (at each end)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:573
+msgid "Weighted Mean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:574
+msgid "r:weighmean"
+msgstr ""
+
+#: ../data/functions.xml.in.h:575
+msgid "Weights"
+msgstr ""
+
+#: ../data/functions.xml.in.h:576
+msgid "Quadratic Mean (RMS)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:577
+msgid "r:rms"
+msgstr ""
+
+#: ../data/functions.xml.in.h:578
+msgid "Moments"
+msgstr ""
+
+#: ../data/functions.xml.in.h:579
+msgid "Standard Deviation (entire population)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:580
+msgid "r:stdevp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:581
+msgid "Standard Deviation (random sampling)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:582
+msgid "r:stdev"
+msgstr ""
+
+#: ../data/functions.xml.in.h:583
+msgid "Variance (entire population)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:584
+msgid "r:varp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:585
+msgid "Variance (random sampling)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:586
+msgid "r:var"
+msgstr ""
+
+#: ../data/functions.xml.in.h:587
+msgid "Standard Error"
+msgstr ""
+
+#: ../data/functions.xml.in.h:588
+msgid "r:stderr"
+msgstr ""
+
+#: ../data/functions.xml.in.h:589
+msgid "Mean Deviation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:590
+msgid "r:meandev"
+msgstr ""
+
+#: ../data/functions.xml.in.h:591
+msgid "Covariance"
+msgstr ""
+
+#: ../data/functions.xml.in.h:592
+msgid "r:cov,r:covar"
+msgstr ""
+
+#: ../data/functions.xml.in.h:593
+msgid "Data 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:594
+msgid "Data 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:595
+msgid "Pooled Variance"
+msgstr ""
+
+#: ../data/functions.xml.in.h:596
+msgid "r:poolvar"
+msgstr ""
+
+#: ../data/functions.xml.in.h:597
+msgid "Regression"
+msgstr ""
+
+#: ../data/functions.xml.in.h:598
+msgid "Statistical Correlation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:599
+msgid "r:cor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:600
+msgid "Pearson's Correlation Coefficient"
+msgstr ""
+
+#: ../data/functions.xml.in.h:601
+msgid "r:pearson,r:correl"
+msgstr ""
+
+#: ../data/functions.xml.in.h:602
+msgid "Spearman's Rho"
+msgstr ""
+
+#: ../data/functions.xml.in.h:603
+msgid "r:spearman"
+msgstr ""
+
+#: ../data/functions.xml.in.h:604
+msgid "Statistical Tests"
+msgstr ""
+
+#: ../data/functions.xml.in.h:605
+msgid "Unpaired T-Test"
+msgstr ""
+
+#: ../data/functions.xml.in.h:606
+msgid "r:ttest"
+msgstr ""
+
+#: ../data/functions.xml.in.h:607
+msgid "Paired T-Test"
+msgstr ""
+
+#: ../data/functions.xml.in.h:608
+msgid "r:pttest"
+msgstr ""
+
+#: ../data/functions.xml.in.h:609
+msgid "Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:610
+msgid "Binomial Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:611
+msgid "r:binomdist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:612
+msgid ""
+"Returns the probability mass or cumulative distribution function of the "
+"binomial distribution."
+msgstr ""
+"Retorna la massa de probabilitat o funció de distribució acumulada de la "
+"distribució binomial."
+
+#: ../data/functions.xml.in.h:613
+msgid "Number of successes (k)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:614
+msgid "Number of trials (n)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:615
+msgid "Probability (p)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:616
+msgid "Cumulative"
+msgstr ""
+
+#: ../data/functions.xml.in.h:617
+msgid "Exponential Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:618
+msgid "r:expondist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:619
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"exponential distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució exponencial."
+
+#: ../data/functions.xml.in.h:620
+msgid "Rate (λ)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:621
+msgid "Exponential Inverse Cumulative Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:622
+msgid "r:expinv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:623
+msgid "P"
+msgstr ""
+
+#: ../data/functions.xml.in.h:624
+msgid "Logistic Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:625
+msgid "r:logistic"
+msgstr ""
+
+#: ../data/functions.xml.in.h:626
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"logistic distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució logística."
+
+#: ../data/functions.xml.in.h:627
+msgid "Scale (s)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:628
+msgid "Location (μ)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:629
+msgid "Normal Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:630
+msgid "r:normdist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:631
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"normal distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució normal."
+
+#: ../data/functions.xml.in.h:632
+msgid "Mean (μ)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:633
+msgid "Standard deviation (σ)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:634
+msgid "Inverse Normal Cumulative Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:635
+msgid "r:normdistinv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:636
+msgid "Pareto Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:637
+msgid "r:pareto"
+msgstr ""
+
+#: ../data/functions.xml.in.h:638
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"Pareto distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució de Pareto."
+
+#: ../data/functions.xml.in.h:639
+msgid "Shape (α)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:640
+msgid "Scale (x_m)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:641
+msgid "Poisson Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:642
+msgid "r:poisson"
+msgstr ""
+
+#: ../data/functions.xml.in.h:643
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"Poisson distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució de Poisson."
+
+#: ../data/functions.xml.in.h:644
+msgid "Rayleigh Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:645
+msgid "r:rayleigh"
+msgstr ""
+
+#: ../data/functions.xml.in.h:646
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"Rayleigh distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució de Rayleigh."
+
+#: ../data/functions.xml.in.h:647
+msgid "Scale (σ)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:648
+msgid "Rayleigh Tail Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:649
+msgid "r:rayleightail"
+msgstr ""
+
+#: ../data/functions.xml.in.h:650
+msgid ""
+"Returns the probability density p(x) at x for a Rayleigh tail distribution "
+"with scale parameter sigma and a lower limit. (from Gnumeric)"
+msgstr ""
+"Retorna la densitat de probabilitat p(x) a x d'una distribució de Rayleigh "
+"amb paràmetre d'escala sigma i un límit inferior. (del Gnumeric)"
+
+#: ../data/functions.xml.in.h:651
+msgid "Gamma Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:652
+msgid "r:gammadist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:653
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"gamma distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució de gamma."
+
+#: ../data/functions.xml.in.h:654
+msgid "Shape (k)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:655
+msgid "Scale (θ)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:656
+msgid "Chi-Square Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:657
+msgid "r:chisqdist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:658
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"chi-square distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució khi quadrat."
+
+#: ../data/functions.xml.in.h:659
+msgid "Degrees of freedom (k)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:660
+msgid "Inverse of Chi-Square Cumulative Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:661
+msgid "r:chisqdistinv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:662
+msgid "Weibull Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:663
+msgid "r:weibulldist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:664
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"Weibull distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució de Weibull."
+
+#: ../data/functions.xml.in.h:665
+msgid "Scale (λ)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:666
+msgid "Weibull Inverse Cumulative Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:667
+msgid "r:wblinv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:668
+msgid "Beta Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:669
+msgid "r:betadist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:670
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"beta distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució de beta."
+
+#: ../data/functions.xml.in.h:671
+msgid "Shape (β)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:672
+msgid "Student's t-distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:673
+msgid "r:tdist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:674
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"Student's t distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució t de Student."
+
+#: ../data/functions.xml.in.h:675
+msgid "Degrees of freedom (v)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:676
+msgid "Inverse Cumulative Student's t-distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:677
+msgid "r:tdistinv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:678
+msgid "F-distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:679
+msgid "r:fdist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:680
+msgid ""
+"Returns the probability density or cumulative distribution function of the F-"
+"distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució F."
+
+#: ../data/functions.xml.in.h:681
+msgid "Degrees of freedom (numerator)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:682
+msgid "Degrees of freedom (denominator)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:683
+msgid "Inverse Cumulative F-distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:684
+msgid "r:fdistinv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:685
+msgid "Cauchy Distribution"
+msgstr ""
+
+#: ../data/functions.xml.in.h:686
+msgid "r:cauchydist"
+msgstr ""
+
+#: ../data/functions.xml.in.h:687
+msgid ""
+"Returns the probability density or cumulative distribution function of the "
+"Cauchy distribution."
+msgstr ""
+"Retorna la densitat de probabilitat o funció de distribució acumulada de la "
+"distribució de Cauchy."
+
+#: ../data/functions.xml.in.h:688
+msgid "Location (x_0)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:689
+msgid "Scale (γ)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:690 ../data/variables.xml.in.h:205
+msgid "Date &amp; Time"
+msgstr ""
+
+#: ../data/functions.xml.in.h:691
+msgid "Construct Date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:692
+msgid "r:date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:693
+msgid ""
+"Returns a date. Available calendars are gregorian (1), hebrew (2), islamic "
+"(3), persian (4), indian (5), chinese (6), julian (7), milankovic (8), "
+"coptic (9), ethiopian (10), egyptian (11). The Chinese year uses an epoch of "
+"2697 BCE and chinese leap months are indicated by adding 12 to the month "
+"number (e.g. leap month 4 = 16)."
+msgstr ""
+"Retorna una data. Els calendaris disponibles són gregorian (1), hebrew (2), "
+"islamic (3), persian (4), indian (5), chinese (6), julian (7), milankovic "
+"(8), coptic (9), ethiopian (10), egyptian (11). El any xinés usa una època "
+"de 2697 a.c.e. i els mesos de traspàs xinès s'indiquen addicionant 12 al "
+"nombre de mes (per exemple el mes de traspàs 4 = 16)."
+
+#: ../data/functions.xml.in.h:694
+msgid "Year"
+msgstr ""
+
+#: ../data/functions.xml.in.h:695 ../data/units.xml.in.h:150
+msgid "Month"
+msgstr ""
+
+#: ../data/functions.xml.in.h:696 ../data/units.xml.in.h:142
+msgid "Day"
+msgstr ""
+
+#: ../data/functions.xml.in.h:697
+msgid "Calendar"
+msgstr ""
+
+#: ../data/functions.xml.in.h:698
+msgid "Construct Date and Time"
+msgstr ""
+
+#: ../data/functions.xml.in.h:699
+msgid "r:datetime"
+msgstr ""
+
+#: ../data/functions.xml.in.h:700 ../data/units.xml.in.h:140
+msgid "Hour"
+msgstr ""
+
+#: ../data/functions.xml.in.h:701 ../data/units.xml.in.h:138
+msgid "Minute"
+msgstr ""
+
+#: ../data/functions.xml.in.h:702 ../data/units.xml.in.h:136
+msgid "Second"
+msgstr ""
+
+#: ../data/functions.xml.in.h:703
+msgid "Days between two dates"
+msgstr ""
+
+#: ../data/functions.xml.in.h:704
+msgid "r:days"
+msgstr ""
+
+#: ../data/functions.xml.in.h:705
+msgid ""
+"Returns the number of days between two dates.&#10;&#10;Basis is the type of "
+"day counting you want to use: 0: US 30/360, 1: real days (default), 2: real "
+"days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Retorna el nombre de dies entre dos dates.&#10;&#10;La basi és el tipus de "
+"compte de dies que voleu usar: 0: US 30/360, 1: dies reals (el "
+"predeterminat), 2: dies reals/360, 3: dies reals/365 o 4: Europeu 30/360."
+
+#: ../data/functions.xml.in.h:706
+msgid "First date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:707
+msgid "Second date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:708
+msgid "Day counting basis"
+msgstr ""
+
+#: ../data/functions.xml.in.h:709
+msgid "Financial function mode"
+msgstr ""
+
+#: ../data/functions.xml.in.h:710
+msgid "Years between two dates"
+msgstr ""
+
+#: ../data/functions.xml.in.h:711
+msgid "r:yearfrac"
+msgstr ""
+
+#: ../data/functions.xml.in.h:712
+msgid ""
+"Returns the number of years (fractional) between two dates.&#10;&#10;Basis "
+"is the type of day counting you want to use: 0: US 30/360, 1: real days "
+"(default), 2: real days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Retorna el nombre de anys (fraccional) entre dos dates.&#10;&#10;La basi és "
+"el tipus de compte de dies que voleu usar: 0: US 30/360, 1: dies reals (el "
+"predeterminat), 2: dies reals/360, 3: dies reals/365 o 4: Europeu 30/360."
+
+#: ../data/functions.xml.in.h:713
+msgid "Week of Year"
+msgstr ""
+
+#: ../data/functions.xml.in.h:714
+msgid "r:week"
+msgstr ""
+
+#: ../data/functions.xml.in.h:715
+msgid "Date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:716
+msgid "Week begins on Sunday"
+msgstr ""
+
+#: ../data/functions.xml.in.h:717
+msgid "Day of Week"
+msgstr ""
+
+#: ../data/functions.xml.in.h:718
+msgid "r:weekday"
+msgstr ""
+
+#: ../data/functions.xml.in.h:719
+msgid "r:month"
+msgstr ""
+
+#: ../data/functions.xml.in.h:720
+msgid "Day of Month"
+msgstr ""
+
+#: ../data/functions.xml.in.h:721
+msgid "r:day"
+msgstr ""
+
+#: ../data/functions.xml.in.h:722
+msgid "r:year"
+msgstr ""
+
+#: ../data/functions.xml.in.h:723
+msgid "Day of Year"
+msgstr ""
+
+#: ../data/functions.xml.in.h:724
+msgid "r:yearday"
+msgstr ""
+
+#: ../data/functions.xml.in.h:725
+msgid "Current Time"
+msgstr ""
+
+#: ../data/functions.xml.in.h:726
+msgid "r:time"
+msgstr ""
+
+#: ../data/functions.xml.in.h:727
+msgid "Time Value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:728
+msgid "r:timevalue"
+msgstr ""
+
+#: ../data/functions.xml.in.h:729
+msgid "Returns the time part, in fractional hours, of a date and time value."
+msgstr ""
+"Retorna la part de temps, en hores fraccionals, d'un valor de data i hora."
+
+#: ../data/functions.xml.in.h:730
+msgid "Date to Unix Timestamp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:731
+msgid "r:timestamp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:732
+msgid "Unix Timestamp to Date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:733
+msgid "r:stamptodate,unix2date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:734
+msgid ""
+"Returns the local date and time represented by the specified Unix timestamp "
+"(seconds, excluding leap seconds, since 1970-01-01). Supports time units."
+msgstr ""
+"Retorna la data i hora locals representades per la marca de temps d'Unix "
+"especificada (segons, excloent els segons de traspàs, des de 1970-01-01). "
+"S'admeten unitats de temps."
+
+#: ../data/functions.xml.in.h:735
+msgid "Timestamp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:736
+msgid "Add Days"
+msgstr ""
+
+#: ../data/functions.xml.in.h:737
+msgid "r:addDays"
+msgstr ""
+
+#: ../data/functions.xml.in.h:738
+msgid "Days"
+msgstr ""
+
+#: ../data/functions.xml.in.h:739
+msgid "Add Months"
+msgstr ""
+
+#: ../data/functions.xml.in.h:740
+msgid "r:addMonths"
+msgstr ""
+
+#: ../data/functions.xml.in.h:741
+msgid "Months"
+msgstr ""
+
+#: ../data/functions.xml.in.h:742
+msgid "Add Years"
+msgstr ""
+
+#: ../data/functions.xml.in.h:743
+msgid "r:addYears"
+msgstr ""
+
+#: ../data/functions.xml.in.h:744
+msgid "Years"
+msgstr ""
+
+#: ../data/functions.xml.in.h:745
+msgid "Add Time"
+msgstr ""
+
+#: ../data/functions.xml.in.h:746
+msgid "r:addTime"
+msgstr ""
+
+#: ../data/functions.xml.in.h:747
+msgid ""
+"Adds a time value to a date. The value can be positive or negative, but must "
+"use a unit based on seconds (such as day and year). Fractions of days are "
+"truncated."
+msgstr ""
+"Addiciona un valor de temps a una data. El valor pot ser o positiu o "
+"negatiu, però ha de tenir una unitat basada en segons (com day o year). Es "
+"trunquen les fraccions de dies."
+
+#: ../data/functions.xml.in.h:748 ../data/units.xml.in.h:135
+msgid "Time"
+msgstr ""
+
+#: ../data/functions.xml.in.h:749
+msgid "Lunar Phase"
+msgstr ""
+
+#: ../data/functions.xml.in.h:750
+msgid "r:lunarphase"
+msgstr ""
+
+#: ../data/functions.xml.in.h:751
+msgid ""
+"Returns the lunar phase, as a number between 0 and 1, for the specified "
+"date. This value corresponds to an angle between 0 and 360 degrees. 0 "
+"represents new moon, 0.5 full moon, and 0.25 and 0.75 quarter moons."
+msgstr ""
+"Retorna la fase lunar, com a nombre entre 0 i 1, a la data especificada. "
+"Aquest valor correspon a un angle entre 0 i 360 graus. 0 representa lluna "
+"nova, 0.5 lluna plena i 0.25 i 0.75 quarts de lluna."
+
+#: ../data/functions.xml.in.h:752
+msgid "Find Lunar Phase"
+msgstr ""
+
+#: ../data/functions.xml.in.h:753
+msgid "r:nextlunarphase"
+msgstr ""
+
+#: ../data/functions.xml.in.h:754
+msgid ""
+"Returns the date when the specified lunar phase occurs. The function "
+"searches forward beginning at the specified date. The lunar phase is "
+"specified as a number between 0 and 1, where 0 represents new moon, 0.5 full "
+"moon, and 0.25 and 0.75 quarter moons. Angle values are also allowed (e.g. π "
+"rad = 180° which corresponds to a value of 0.5). Values above 1, without "
+"unit, are interpreted as degrees."
+msgstr ""
+"Retorna la data en la qual ocorr la fase lunar especificada. La funció cerca "
+"endavant començant a la data especificada. S'especifica la fase lunar com a "
+"nombre entre 0 i 1, on 0 representa lluna nova, 0.5 lluna plena i 0.25 i "
+"0.75 quarts de lluna. També es permeten els valors angulars (per exemple π "
+"rad = 180° ho qual correspon a un valor de 0.5). Els valors superiors a 1, "
+"sense unitat, s'interpreten com a graus."
+
+#: ../data/functions.xml.in.h:755
+msgid "Start Date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:756
+msgid "Days in Month"
+msgstr ""
+
+#: ../data/functions.xml.in.h:757
+msgid "r:daysInMonth"
+msgstr ""
+
+#: ../data/functions.xml.in.h:758 ../data/variables.xml.in.h:198
+msgid "Utilities"
+msgstr ""
+
+#: ../data/functions.xml.in.h:759
+msgid "Plot Functions and Vectors"
+msgstr ""
+
+#: ../data/functions.xml.in.h:760
+msgid "r:plot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:761
+msgid "Expression or vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:762
+msgid "Minimum x value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:763
+msgid "Maximum x value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:764
+msgid "Number of samples / Step size"
+msgstr ""
+
+#: ../data/functions.xml.in.h:765
+msgid "X variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:766
+msgid "Persistent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:767
+msgid ""
+"Plots one or more expressions or vectors. Use a vector for the first "
+"argument to plot multiple series. Only the first argument is used for vector "
+"series. It is also possible to plot a matrix where each row is a pair of x "
+"and y values."
+msgstr ""
+"Dibuixa expressions o vectors. Useu un vector pel primer argument per a "
+"dibuixar múltiples sèries. Només el primer argument s'usa per a sèries de "
+"vector. També és possible dibuixar una matriu on cada fila és un par de "
+"valors x i y."
+
+#: ../data/functions.xml.in.h:768
+msgid "Unicode Value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:769
+msgid "r:code"
+msgstr ""
+
+#: ../data/functions.xml.in.h:770
+msgid ""
+"Encodes a Unicode character or text string using the selected format. "
+"Supported encodings are UTF-8 (0), UTF-16 (1), and UTF-32 (2). If the third "
+"argument is true, each separate code unit (8, 16, or 32 bits depending on "
+"encoding) is placed in a vector."
+msgstr ""
+"Codifica un caràcter d'Unicode o una cadena de text usant el format "
+"especificat. Les codificacions admeses són UTF-8 (0), UTF-16 (1) i UTF-32 "
+"(2). Si el tercer argument és cert, cada unitat distinta de codificació (8, "
+"16 o 32 bits depenent de la codificació) es posa en un vector."
+
+#: ../data/functions.xml.in.h:771
+msgid "Character"
+msgstr ""
+
+#: ../data/functions.xml.in.h:772
+msgid "Encoding"
+msgstr ""
+
+#: ../data/functions.xml.in.h:773
+msgid "Use vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:774
+msgid "Unicode Character"
+msgstr ""
+
+#: ../data/functions.xml.in.h:775
+msgid "r:char"
+msgstr ""
+
+#: ../data/functions.xml.in.h:776
+msgid "Length of string"
+msgstr ""
+
+#: ../data/functions.xml.in.h:777
+msgid "r:len"
+msgstr ""
+
+#: ../data/functions.xml.in.h:778
+msgid "Text"
+msgstr ""
+
+#: ../data/functions.xml.in.h:779
+msgid "Concatenate Strings"
+msgstr ""
+
+#: ../data/functions.xml.in.h:780
+msgid "r:concatenate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:781
+msgid "Text string 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:782
+msgid "Text string 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:783
+msgid "Replace"
+msgstr ""
+
+#: ../data/functions.xml.in.h:784
+msgid "r:replace"
+msgstr ""
+
+#: ../data/functions.xml.in.h:785
+msgid ""
+"Replaces a certain value in an expression with a new value. The expression "
+"is calculated before the replacement if the fourth argument is true."
+msgstr ""
+"Reemplaça un valor particular en una expressió amb un valor nou. Es calcula "
+"l'expressió abans que el reemplaçament si el quart argument és cert."
+
+#: ../data/functions.xml.in.h:786
+msgid "Expression"
+msgstr ""
+
+#: ../data/functions.xml.in.h:787
+msgid "Original value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:788
+msgid "New value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:789
+msgid "Precalculate expression"
+msgstr ""
+
+#: ../data/functions.xml.in.h:790
+msgid "Strip Units"
+msgstr ""
+
+#: ../data/functions.xml.in.h:791
+msgid "r:nounit,strip_units"
+msgstr ""
+
+#: ../data/functions.xml.in.h:792
+msgid ""
+"Removes all units from an expression. The expression is calculated before "
+"the removal."
+msgstr ""
+"Elimina totes les unitats d'una expressió. L'expressió es calcula abans de "
+"l'eliminació."
+
+#: ../data/functions.xml.in.h:793
+msgid "Process Vector Elements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:794
+msgid "r:process"
+msgstr ""
+
+#: ../data/functions.xml.in.h:795
+msgid "Element variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:796
+msgid "Index variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:797
+msgid "Vector variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:798
+msgid "Process Matrix Elements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:799
+msgid "r:processm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:800
+msgid "Row variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:801
+msgid "Column variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:802
+msgid "Matrix variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:803
+msgid "Custom Sum of Elements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:804
+msgid "r:csum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:805
+msgid "First element"
+msgstr ""
+
+#: ../data/functions.xml.in.h:806
+msgid "Last element"
+msgstr ""
+
+#: ../data/functions.xml.in.h:807
+msgid "Initial value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:808
+msgid "Value variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:809
+msgid "Select Vector Elements"
+msgstr ""
+
+#: ../data/functions.xml.in.h:810
+msgid "r:select"
+msgstr ""
+
+#: ../data/functions.xml.in.h:811
+msgid "Condition"
+msgstr ""
+
+#: ../data/functions.xml.in.h:812
+msgid "Select first match"
+msgstr ""
+
+#: ../data/functions.xml.in.h:813
+msgid "r:function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:814
+msgid "Arguments"
+msgstr ""
+
+#: ../data/functions.xml.in.h:815
+msgid "Title"
+msgstr ""
+
+#: ../data/functions.xml.in.h:816
+msgid "r:title"
+msgstr ""
+
+#: ../data/functions.xml.in.h:818
+msgid "Display Error"
+msgstr ""
+
+#: ../data/functions.xml.in.h:819
+msgid "r:error"
+msgstr ""
+
+#: ../data/functions.xml.in.h:820
+msgid "Message"
+msgstr ""
+
+#: ../data/functions.xml.in.h:821
+msgid "Display Warning"
+msgstr ""
+
+#: ../data/functions.xml.in.h:822
+msgid "r:warning"
+msgstr ""
+
+#: ../data/functions.xml.in.h:823
+msgid "Display Message"
+msgstr ""
+
+#: ../data/functions.xml.in.h:824
+msgid "r:message"
+msgstr ""
+
+#: ../data/functions.xml.in.h:825
+msgid "Save as Variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:826
+msgid "r:save"
+msgstr ""
+
+#: ../data/functions.xml.in.h:827
+msgid "Category"
+msgstr ""
+
+#: ../data/functions.xml.in.h:828
+msgid "RPN Stack Register"
+msgstr ""
+
+#: ../data/functions.xml.in.h:829
+msgid "r:register"
+msgstr ""
+
+#: ../data/functions.xml.in.h:830
+msgid "Returns the value of a RPN stack register."
+msgstr "Retorna el valor d'un registre de pila NPI."
+
+#: ../data/functions.xml.in.h:831
+msgid "Index"
+msgstr ""
+
+#: ../data/functions.xml.in.h:832
+msgid "RPN Stack Vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:833
+msgid "r:stack"
+msgstr ""
+
+#: ../data/functions.xml.in.h:834
+msgid "Returns the RPN stack as a vector."
+msgstr "Retorna la pila NPI com a vector."
+
+#: ../data/functions.xml.in.h:835
+msgid "Is Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:836
+msgid "r:isNumber"
+msgstr ""
+
+#: ../data/functions.xml.in.h:837
+msgid "Is Real"
+msgstr ""
+
+#: ../data/functions.xml.in.h:838
+msgid "r:isReal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:839
+msgid "Is Rational"
+msgstr ""
+
+#: ../data/functions.xml.in.h:840
+msgid "r:isRational"
+msgstr ""
+
+#: ../data/functions.xml.in.h:841
+msgid "Is Integer"
+msgstr ""
+
+#: ../data/functions.xml.in.h:842
+msgid "r:isInteger"
+msgstr ""
+
+#: ../data/functions.xml.in.h:843
+msgid "Represents Number"
+msgstr ""
+
+#: ../data/functions.xml.in.h:844
+msgid "r:representsNumber"
+msgstr ""
+
+#: ../data/functions.xml.in.h:845
+msgid "Represents Real"
+msgstr ""
+
+#: ../data/functions.xml.in.h:846
+msgid "r:representsReal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:847
+msgid "Represents Rational"
+msgstr ""
+
+#: ../data/functions.xml.in.h:848
+msgid "r:representsRational"
+msgstr ""
+
+#: ../data/functions.xml.in.h:849
+msgid "Represents Integer"
+msgstr ""
+
+#: ../data/functions.xml.in.h:850
+msgid "r:representsInteger"
+msgstr ""
+
+#: ../data/functions.xml.in.h:851
+msgid "Interval"
+msgstr ""
+
+#: ../data/functions.xml.in.h:852
+msgid "r:interval"
+msgstr ""
+
+#: ../data/functions.xml.in.h:853
+msgid "Lower endpoint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:854
+msgid "Upper endpoint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:855
+msgid "Uncertainty"
+msgstr ""
+
+#: ../data/functions.xml.in.h:856
+msgid "r:uncertainty"
+msgstr ""
+
+#: ../data/functions.xml.in.h:857
+msgid "Uncertainty is relative"
+msgstr ""
+
+#: ../data/functions.xml.in.h:858
+msgid "External Command"
+msgstr ""
+
+#: ../data/functions.xml.in.h:859
+msgid "r:command"
+msgstr ""
+
+#: ../data/functions.xml.in.h:860
+msgid "Command"
+msgstr ""
+
+#: ../data/functions.xml.in.h:861
+msgid "Logical"
+msgstr ""
+
+#: ../data/functions.xml.in.h:862
+msgid "For...Do"
+msgstr ""
+
+#: ../data/functions.xml.in.h:863
+msgid "r:for"
+msgstr ""
+
+#: ../data/functions.xml.in.h:864
+msgid "Initial value of counter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:865
+msgid "Counter variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:866
+msgid "For condition"
+msgstr ""
+
+#: ../data/functions.xml.in.h:867
+msgid "Counter update function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:868
+msgid "Do function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:869
+msgid "If...Then...Else"
+msgstr ""
+
+#: ../data/functions.xml.in.h:870
+msgid "r:if"
+msgstr ""
+
+#: ../data/functions.xml.in.h:871
+msgid ""
+"Tests a condition and returns a value depending on the result. Vectors can "
+"be used for argument 1 and 2, instead of nested functions."
+msgstr ""
+"Prova una condició i retorna un valor depenent del resultat. Es poden usar "
+"vectors pels arguments 1 i 2 en lloc de funcions imbricades."
+
+#: ../data/functions.xml.in.h:872
+msgid "Expression if condition is met"
+msgstr ""
+
+#: ../data/functions.xml.in.h:873
+msgid "Expression if condition is NOT met"
+msgstr ""
+
+#: ../data/functions.xml.in.h:874
+msgid "Assume false if not true"
+msgstr ""
+
+#: ../data/functions.xml.in.h:875
+msgid "Bitwise Exclusive OR"
+msgstr ""
+
+#: ../data/functions.xml.in.h:876
+msgid "r:xor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:877
+msgid "Value 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:878
+msgid "Value 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:879
+msgid "Logical Exclusive OR"
+msgstr ""
+
+#: ../data/functions.xml.in.h:880
+msgid "r:lxor"
+msgstr ""
+
+#: ../data/functions.xml.in.h:881
+msgid "Bitwise Shift"
+msgstr ""
+
+#: ../data/functions.xml.in.h:882
+msgid ""
+"Applies logical or arithmetic bitwise shift to an integer. The second "
+"argument specifies the number of steps that each binary bit is shifted to "
+"the left (use negative values for right shift)."
+msgstr ""
+"Aplica desplaçament lògic o de bit a bit a un enter. El segon argument "
+"especifica el nombre de passos pel qual cada bit binari es desplaça a "
+"l'esquerra (useu valors negatius per desplaçament a la dreta)."
+
+#: ../data/functions.xml.in.h:883
+msgid "r:shift"
+msgstr ""
+
+#: ../data/functions.xml.in.h:884
+msgid "Steps"
+msgstr ""
+
+#: ../data/functions.xml.in.h:885
+msgid "Arithmetic shift using two's complement"
+msgstr ""
+
+#: ../data/functions.xml.in.h:886
+msgid "Bitwise Complement (Not)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:887
+msgid ""
+"Applies bitwise NOT to an integer of specified bit width and signedness (use "
+"1 for signed and 0 for unsigned). If bit width is zero, the smallest "
+"necessary number of bits (of 8, 16, 32, 64, 128, ...) will be used."
+msgstr ""
+"Aplica NOT bit a bit a un enter d'amplada en bits i signat especificats "
+"(useu 1 per signat i 0 per no signat). Si l'amplada en bits és zero, s'usa "
+"el nombre més petit de bits necessaris (de 8, 16, 32, 64, 128, ...)."
+
+#: ../data/functions.xml.in.h:888
+msgid "r:bitcmp"
+msgstr ""
+
+#: ../data/functions.xml.in.h:889
+msgid "Bit Width"
+msgstr ""
+
+#: ../data/functions.xml.in.h:890
+msgid "Signed Integer"
+msgstr ""
+
+#: ../data/functions.xml.in.h:891
+msgid "Bit Rotation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:892
+msgid ""
+"Applies circular bitwise shift to an integer of specified bit width and "
+"signedness (use 1 for signed and 0 for unsigned). The second argument "
+"specifies the number of steps that each binary bit is shifted to the left "
+"(use negative values for right shift). If bit width is zero, the smallest "
+"necessary number of bits (of 8, 16, 32, 64, 128, ...) will be used."
+msgstr ""
+"Aplica un desplaçament circular de bit a bit a un enter d'amplada de bits i "
+"signat especificats (useu 1 per signat i 0 per no signat). El segon argument "
+"especifica el nombre de passos pel qual es desplaça cada bit binari a "
+"l'esquerra (useu valors negatius per desplaçament a la dreta). Si l'amplada "
+"de bits és zero, s'usarà el nombre més petit de bits necessaris (de 8, 16, "
+"32, 64, 128, ...)."
+
+#: ../data/functions.xml.in.h:893
+msgid "r:bitrot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:894
+msgid "Algebra"
+msgstr ""
+
+#: ../data/functions.xml.in.h:895
+msgid "Summation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:896
+msgid "au:&#x3A3;,au:&#x2211;,r:sum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:897
+msgid ""
+"Corresponds to the summation symbol. Adds terms for each x ranging from the "
+"lower to the upper limit."
+msgstr ""
+"Correspon al símbol de sumació. Suma terminis per cada x des del límit "
+"inferior al superior."
+
+#: ../data/functions.xml.in.h:898
+msgid "Term expression"
+msgstr ""
+
+#: ../data/functions.xml.in.h:899
+msgid "Lower limit (i)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:900
+msgid "Upper limit (n)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:901
+msgid "Product of a sequence"
+msgstr ""
+
+#: ../data/functions.xml.in.h:902
+msgid "au:&#x3A0;,r:product"
+msgstr ""
+
+#: ../data/functions.xml.in.h:903
+msgid ""
+"Corresponds to the product symbol. Multiplies factors for each x ranging "
+"from the lower to the upper limit."
+msgstr ""
+"Correspon al símbol de producte. Multiplica els factors per cada x des del "
+"límit inferior al superior."
+
+#: ../data/functions.xml.in.h:904
+msgid "Factor expression"
+msgstr ""
+
+#: ../data/functions.xml.in.h:905
+msgid "Solve for multiple variables"
+msgstr ""
+
+#: ../data/functions.xml.in.h:906
+msgid "r:multisolve"
+msgstr ""
+
+#: ../data/functions.xml.in.h:907
+msgid "Equation vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:908
+msgid "Variable vector"
+msgstr ""
+
+#: ../data/functions.xml.in.h:909
+msgid "Solve equation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:910
+msgid "r:solve"
+msgstr ""
+
+#: ../data/functions.xml.in.h:911
+msgid "Equation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:912
+msgid "With respect to"
+msgstr ""
+
+#: ../data/functions.xml.in.h:913
+msgid "Solve differential equation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:914
+msgid "r:dsolve"
+msgstr ""
+
+#: ../data/functions.xml.in.h:915
+msgid "Initial condition: function value (y)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:916
+msgid "Initial condition: argument value (x)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:917
+msgid ""
+"Solves a differential equation and returns the value of y(x). The derivative "
+"in the equation should be in the format diff(y, x). Only first-order "
+"differential equations are currently supported."
+msgstr ""
+"Resol una equació diferencial i retorna el valor de y(x). La derivada en la "
+"equació deu estar en el format diff(y, x). Actualment s'admeten només les "
+"equacions diferencials del primer ordre."
+
+#: ../data/functions.xml.in.h:918
+msgid "Solve using Newton's Method"
+msgstr ""
+
+#: ../data/functions.xml.in.h:919
+msgid "r:newtonsolve"
+msgstr ""
+
+#: ../data/functions.xml.in.h:920
+msgid "Initial estimate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:921 ../data/variables.xml.in.h:199
+msgid "Precision"
+msgstr ""
+
+#: ../data/functions.xml.in.h:922
+msgid "Max iterations"
+msgstr ""
+
+#: ../data/functions.xml.in.h:923
+msgid "Solve using Secant Method"
+msgstr ""
+
+#: ../data/functions.xml.in.h:924
+msgid "r:secantsolve"
+msgstr ""
+
+#: ../data/functions.xml.in.h:925
+msgid "Initial estimate 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:926
+msgid "Initial estimate 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:927
+msgid "Solve for two variables"
+msgstr ""
+
+#: ../data/functions.xml.in.h:928
+msgid "r:solve2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:929
+msgid ""
+"Solves two equations with two unknown variables. Returns the value of the "
+"first variable."
+msgstr ""
+"Resol dos equacions amb dos variables desconegudes. Retorna el valor de la "
+"primera variable."
+
+#: ../data/functions.xml.in.h:930
+msgid "Equation 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:931
+msgid "Equation 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:932
+msgid "Variable 1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:933
+msgid "Variable 2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:934
+msgid "Find Linear Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:935
+msgid "r:linearfunction"
+msgstr ""
+
+#: ../data/functions.xml.in.h:936
+msgid ""
+"Finds the linear function for the straight line between two distinct points."
+msgstr "Troba la funció linear per la línia recta entre dos punts distints."
+
+#: ../data/functions.xml.in.h:937
+msgid "x1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:938
+msgid "y1"
+msgstr ""
+
+#: ../data/functions.xml.in.h:939
+msgid "x2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:940
+msgid "y2"
+msgstr ""
+
+#: ../data/functions.xml.in.h:941
+msgid "Calculus"
+msgstr ""
+
+#: ../data/functions.xml.in.h:942
+msgid "Differentiate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:943
+msgid "r:diff,derivative"
+msgstr ""
+
+#: ../data/functions.xml.in.h:944
+msgid "Variable value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:945
+msgid "Integrate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:946
+msgid "r:integrate,integral,au:&#x222B;"
+msgstr ""
+
+#: ../data/functions.xml.in.h:947
+msgid "Variable of integration"
+msgstr ""
+
+#: ../data/functions.xml.in.h:948
+msgid "Force numerical integration"
+msgstr ""
+
+#: ../data/functions.xml.in.h:949
+msgid "Romberg Integration"
+msgstr ""
+
+#: ../data/functions.xml.in.h:950
+msgid "r:romberg"
+msgstr ""
+
+#: ../data/functions.xml.in.h:951
+msgid "Min iterations"
+msgstr ""
+
+#: ../data/functions.xml.in.h:952
+msgid "Monte Carlo Integration"
+msgstr ""
+
+#: ../data/functions.xml.in.h:953
+msgid "r:montecarlo"
+msgstr ""
+
+#: ../data/functions.xml.in.h:954
+msgid "Number of samples"
+msgstr ""
+
+#: ../data/functions.xml.in.h:955
+msgid "Limit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:956
+msgid ""
+"Returns the two-sided limit of the function if direction is zero, limit from "
+"left (below) if direction is -1, or limit from right (above) if direction is "
+"+1."
+msgstr ""
+"Retorna el límit de dos costats de la funció si la direcció és zero, el "
+"límit de l'esquerra (abaix) si la direcció és -1, o el límit de la dreta "
+"(amunt) si la direcció és +1."
+
+#: ../data/functions.xml.in.h:957
+msgid "r:limit"
+msgstr ""
+
+#: ../data/functions.xml.in.h:958
+msgid "Value to approach"
+msgstr ""
+
+#: ../data/functions.xml.in.h:959
+msgid "Direction"
+msgstr ""
+
+#: ../data/functions.xml.in.h:960
+msgid "Extreme Values"
+msgstr ""
+
+#: ../data/functions.xml.in.h:961
+msgid "r:extremum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:962
+msgid "Named Integrals"
+msgstr ""
+
+#: ../data/functions.xml.in.h:963
+msgid "Logarithmic Integral"
+msgstr ""
+
+#: ../data/functions.xml.in.h:964
+msgid "rc:li,logint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:965
+msgid "The integral of 1/ln(x)."
+msgstr ""
+
+#: ../data/functions.xml.in.h:966
+msgid "Exponential Integral"
+msgstr ""
+
+#: ../data/functions.xml.in.h:967
+msgid "rc:Ei,expint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:968
+msgid "The integral of e^x/x."
+msgstr ""
+
+#: ../data/functions.xml.in.h:969
+msgid "Sine Integral"
+msgstr ""
+
+#: ../data/functions.xml.in.h:970
+msgid "rc:Si,sinint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:971
+msgid "The integral of sin(x)/x."
+msgstr ""
+
+#: ../data/functions.xml.in.h:972
+msgid "Cosine Integral"
+msgstr ""
+
+#: ../data/functions.xml.in.h:973
+msgid "rc:Ci,cosint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:974
+msgid "The integral of cos(x)/x."
+msgstr ""
+
+#: ../data/functions.xml.in.h:975
+msgid "Hyperbolic Sine Integral"
+msgstr ""
+
+#: ../data/functions.xml.in.h:976
+msgid "rc:Shi,sinhint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:977
+msgid "The integral of sinh(x)/x."
+msgstr ""
+
+#: ../data/functions.xml.in.h:978
+msgid "Hyperbolic Cosine Integral"
+msgstr ""
+
+#: ../data/functions.xml.in.h:979
+msgid "rc:Chi,coshint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:980
+msgid "The integral of cosh(x)/x."
+msgstr ""
+
+#: ../data/functions.xml.in.h:981
+msgid "Fresnel Integral S"
+msgstr ""
+
+#: ../data/functions.xml.in.h:982
+msgid "r:fresnels"
+msgstr ""
+
+#: ../data/functions.xml.in.h:983
+msgid "The integral of sin(pi*x^2/2)."
+msgstr ""
+
+#: ../data/functions.xml.in.h:984
+msgid "Fresnel Integral C"
+msgstr ""
+
+#: ../data/functions.xml.in.h:985
+msgid "r:fresnelc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:986
+msgid "The integral of cos(pi*x^2/2)."
+msgstr ""
+
+#: ../data/functions.xml.in.h:987
+msgid "Upper Incomplete Gamma Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:988
+msgid "r:igamma"
+msgstr ""
+
+#: ../data/functions.xml.in.h:989
+msgid "Lower Incomplete Gamma Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:990
+msgid "r:gammainc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:991
+msgid "Regularized Incomplete Beta Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:992
+msgid "r:betainc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:993
+msgid "Inverse Regularized Incomplete Beta Function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:994
+msgid "r:betaincinv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:995
+msgid "Geometry"
+msgstr ""
+
+#: ../data/functions.xml.in.h:996
+msgid "Triangle"
+msgstr ""
+
+#: ../data/functions.xml.in.h:997
+msgid "Hypotenuse"
+msgstr ""
+
+#: ../data/functions.xml.in.h:998
+msgid "r:hypot"
+msgstr ""
+
+#: ../data/functions.xml.in.h:999
+msgid "Side A"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1000
+msgid "Side B"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1001
+msgid "Triangle Area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1002
+msgid "r:triangle"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1003
+msgid "Height"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1004
+msgid "Triangle Perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1005
+msgid "r:triangle_perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1006
+msgid "Side C"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1007
+msgid "Circle"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1008
+msgid "Circle Area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1009
+msgid "r:circle"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1010
+msgid "Calculates the area of a circle using the radius"
+msgstr "Calcula l'àrea d'un cercle mitjançant el radi"
+
+#: ../data/functions.xml.in.h:1011
+msgid "Radius"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1012
+msgid "Circle Circumference"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1013
+msgid "r:circumference"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1014
+msgid "Cylinder"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1015
+msgid "Cylinder Volume"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1016
+msgid "r:cylinder"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1017
+msgid "Surface Area of Cylinder"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1018
+msgid "r:cylinder_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1019
+msgid "Cone"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1020
+msgid "Cone Volume"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1021
+msgid "r:cone"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1022
+msgid "Surface Area of Cone"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1023
+msgid "r:cone_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1024
+msgid "Sphere"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1025
+msgid "Sphere Volume"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1026
+msgid "r:sphere"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1027
+msgid "Surface Area of Sphere"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1028
+msgid "r:sphere_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1029
+msgid "Square Area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1030
+msgid "r:square"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1031
+msgid "Length of side"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1032
+msgid "Square Perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1033
+msgid "r:square_perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1034
+msgid "Cube"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1035
+msgid "Cube Volume"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1036
+msgid "r:cube"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1037
+msgid "Surface Area of Cube"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1038
+msgid "r:cube_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1039
+msgid "Rectangle"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1040
+msgid "Rectangle Area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1041
+msgid "r:rect"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1042
+msgid "Width"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1043
+msgid "Rectangle Perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1044
+msgid "r:rect_perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1045
+msgid "Prism"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1046
+msgid "Volume of Rectangular Prism"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1047
+msgid "r:rectprism"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1048
+msgid "Calculates the volume of a prism with rectangular base."
+msgstr "Calcula el volum d'una prisma amb base rectangular."
+
+#: ../data/functions.xml.in.h:1049
+msgid "Surface Area of Rectangular Prism"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1050
+msgid "r:rectprism_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1051
+msgid "Calculates the surface area of a prism with rectangular base."
+msgstr "Calcula l'àrea de superfície d'una prisma amb base rectangular."
+
+#: ../data/functions.xml.in.h:1052
+msgid "Volume of Triangular Prism"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1053
+msgid "r:triangleprism"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1054
+msgid "Calculates the volume of a prism with triangular base."
+msgstr "Calcula el volum d'una prisma amb base triangular."
+
+#: ../data/functions.xml.in.h:1055
+msgid "Pyramid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1056
+msgid "Pyramid Volume"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1057
+msgid "r:pyramid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1058
+msgid ""
+"Calculates the volume of a 3-dimensional shape standing on a rectangular "
+"base and terminating in a point at the top."
+msgstr ""
+"Calcula el volum d'una figura de 3 dimensions que es reposa sobre una base "
+"rectangular i termina en un punt al cim."
+
+#: ../data/functions.xml.in.h:1059
+msgid "Length of base"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1060
+msgid "Width of base"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1061
+msgid "Volume of Regular Tetrahedron"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1062
+msgid "r:tetrahedron"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1063
+msgid "Surface Area of Regular Tetrahedron"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1064
+msgid "r:tetrahedron_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1065
+msgid "Height of Regular Tetrahedron"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1066
+msgid "r:tetrahedron_height"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1067
+msgid "Volume of Square Pyramid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1068
+msgid "r:sqpyramid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1069
+msgid "Surface Area of Square Pyramid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1070
+msgid "r:sqpyramid_sa"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1071
+msgid "Height of Square Pyramid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1072
+msgid "r:sqpyramid_height"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1073
+msgid "Parallelogram"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1074
+msgid "Parallelogram Area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1075
+msgid "r:parallelogram"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1076
+msgid ""
+"Calculates the area of a four-sided figure whose opposite sides are both "
+"parallel and equal in length."
+msgstr ""
+"Calcula l'àrea d'una figura de quatre costats, els costats oposats del qual "
+"són ambdós paral·lels i iguals de llargada."
+
+#: ../data/functions.xml.in.h:1077
+msgid "Parallelogram Perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1078
+msgid "r:parallelogram_perimeter"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1079
+msgid ""
+"Calculates the perimeter of a four-sided figure whose opposite sides are "
+"both parallel and equal in length."
+msgstr ""
+"Calcula el perímetre d'una figura de quatre costats, els costats oposats de "
+"la qual són ambdós paral·lels i iguals de llargada."
+
+#: ../data/functions.xml.in.h:1080
+msgid "Trapezoid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1081
+msgid "Trapezoid Area"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1082
+msgid "r:trapezoid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1083
+msgid "Calculates the area of a four-sided figure with two parallel sides."
+msgstr ""
+"Calcula l'àrea d'una figura de quatre costats amb dos costats paral·lels."
+
+#: ../data/functions.xml.in.h:1084
+msgid "Economics"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1085
+msgid "Microeconomics"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1086
+msgid "Elasticity"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1087
+msgid "r:elasticity"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1088
+msgid ""
+"Calculates the demand elasticity. Also works for supply elasticity, income "
+"elasticity, cross-price elasticity, etc. Just replace demand with supply, or "
+"price with income...&#10;&#10;eg. elasticity(100-x^2, 3) calculates the "
+"demand elasticity when the price is 3 for the function \"Q = 100 - x^2\" "
+"where x is the default price variable."
+msgstr ""
+"Calcula l'elasticitat de demanda. També funciona per a l'elasticitat "
+"d'ofert, elasticitat d'ingrés, elasticitat creuada de demanda, etc. Només "
+"reemplaceu la demanda amb l'ofert, o el preu amb l'ingrés...&#10;&#10;per "
+"exemple elasticity(100-x^2, 3) calcula l'elasticitat de demanda quan el preu "
+"és 3 per a la funció \"Q = 100 - x^2\" on x és la variable de preu per "
+"defecte."
+
+#: ../data/functions.xml.in.h:1089
+msgid "Demand function"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1090
+msgid "Price"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1091
+msgid "Price variable"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1092
+msgid "Sum-of-Years Digits Depreciation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1093
+msgid "r:syd"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1094
+msgid ""
+"Calculates the sum-of-years digits depreciation for an asset based on its "
+"cost, salvage value, anticipated life, and a particular period. This method "
+"accelerates the rate of the depreciation, so that more depreciation expense "
+"occurs in earlier periods than in later ones. The depreciable cost is the "
+"actual cost minus the salvage value. The useful life is the number of "
+"periods (typically years) over which the asset is depreciated."
+msgstr ""
+"Calcula la depreciació de suma de les xifres dels anys d'un actiu basada en "
+"el seu cost, valor residual, vida anticipada i un període particular. Aquest "
+"mètode accelera la taxa de la depreciació, de manera que més despesa de "
+"depreciació ocorr en en els primers períodes que en els últims. El cost "
+"depreciable és el cost actual menys el valor residual. La vida útil és el "
+"nombre de períodes (típicament anys) durant els quals l'actiu es deprecia."
+
+#: ../data/functions.xml.in.h:1095
+msgid "Cost"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1096
+msgid "Salvage value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1097
+msgid "Life"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1098
+msgid "Period"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1099
+msgid "Straight Line Depreciation"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1100
+msgid "r:sln"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1101
+msgid ""
+"Determines the straight line depreciation of an asset for a single period."
+"&#10;&#10;Cost is the amount you paid for the asset. Salvage is the value of "
+"the asset at the end of the period. Life is the number of periods over which "
+"the asset is depreciated. SLN divides the cost evenly over the life of an "
+"asset."
+msgstr ""
+"Determina la depreciació de línia recta d'un actiu durant un sol període."
+"&#10;&#10;El cost és la quantitat que aneu pagar pel actiu. El valor "
+"residual (salvage) és el valor del actiu al final del període. La vida és el "
+"nombre de períodes durant els quals es deprecia l'actiu. SLN divideix el "
+"cost uniformement al llarg de la vida d'un actiu."
+
+#: ../data/functions.xml.in.h:1102
+msgid "Present Value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1103
+msgid "r:pv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1104
+msgid ""
+"Returns the present value of an investment.&#10;&#10;If type = 1 then the "
+"payment is made at the beginning of the period. If type = 0 (or omitted) it "
+"is made at the end of each period."
+msgstr ""
+"Retorna el valor actual d'una inversió.&#10;&#10;Si el tipus és 1 el "
+"pagament es fa al inici el període. Si el tipus es 0 (o omès) es fa al final "
+"de cada període."
+
+#: ../data/functions.xml.in.h:1105
+msgid "Interest rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1106
+msgid "Number of periods"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1107
+msgid "Payment made each period"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1108
+msgid "Future value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1109
+msgid "Type"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1110
+msgid "Nominal Interest Rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1111
+msgid "r:nominal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1112
+msgid ""
+"Calculates the nominal interest rate from a given effective interest rate "
+"compounded at given intervals."
+msgstr ""
+"Calcula la taxa d'interès nominal d'una taxa d'interès efectiva donada que "
+"es compon a intervals donats."
+
+#: ../data/functions.xml.in.h:1113
+msgid "Effective interest rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1114
+msgid "Periods"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1115
+msgid "Zero Coupon"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1116
+msgid "r:zero_coupon"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1117
+msgid "Calculates the value of a zero-coupon (pure discount) bond."
+msgstr "Calcula el valor d'un bo cupó-zero (descompte pur)."
+
+#: ../data/functions.xml.in.h:1118
+msgid "Face value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1119
+msgid "Treasury Bill Yield"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1120
+msgid "r:tbillyield"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1121
+msgid "Returns the yield for a treasury bill."
+msgstr "Retorna el rendiment d'un bitllet de tresoreria."
+
+#: ../data/functions.xml.in.h:1122
+msgid "Settlement date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1123
+msgid "Maturity date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1124
+msgid "Price per $100 face value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1125
+msgid "Treasury Bill Price"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1126
+msgid "r:tbillprice"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1127
+msgid "Returns the price per $100 value for a treasury bill."
+msgstr "Retorna el preu per valor de 100€ d'un bitllet de tresoreria."
+
+#: ../data/functions.xml.in.h:1128
+msgid "Discount rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1129
+msgid "Treasury Bill Equivalent"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1130
+msgid "r:tbilleq"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1131
+msgid "Returns the bond equivalent for a treasury bill."
+msgstr "Retorna el bo equivalent a un bitllet de tresoreria."
+
+#: ../data/functions.xml.in.h:1132
+msgid "Interest paid on a given period of an investment (ISPMT)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1133
+msgid "r:ispmt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1134
+msgid "Calculates the interest paid on a given period of an investment."
+msgstr "Calcula l'interès pagat en un període donat d'una inversió."
+
+#: ../data/functions.xml.in.h:1135
+msgid "Periodic interest rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1136
+msgid "Amortizement period"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1137
+msgid "Present value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1138
+msgid "Payment for a loan"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1139
+msgid "r:pmt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1140
+msgid ""
+"Returns the amount of payment (negative) each period for a loan based on a "
+"constant interest rate and constant payments (each payment is equal amount)."
+"&#10;&#10;If type = 1 then the payment is made at the beginning of the "
+"period. If type = 0 (or omitted) it is made at the end of each period.&#10;"
+"&#10;Note that the interest rate here refers to the rate for each period and "
+"if you calculate with an annual rate, each period will be interpreted as a "
+"whole year. To get monthly payments divide the annual interest rate by 12 "
+"and enter the total number of months (12 times number of years) in the "
+"periods field."
+msgstr ""
+"Retorna l'import de pagament (negatiu) per cada període d'un préstec basat "
+"en una taxa d'interès constant i pagaments constants (cada pagament és d'una "
+"quantitat igual).&#10;&#10;Si el tipus és 1 el pagament es fa al principi "
+"del període, si el tipus és 0 (o omès) es fa al final de cada període.&#10;"
+"&#10;Tingueu en compte que la taxa d'interès aquí es refereix a la taxa de "
+"cada període i si calculeu amb una taxa anual, cada període s'interpreta com "
+"a any enter. Per a obtenir els pagaments mensuals, dividiu la taxa d'interès "
+"anual per 12 i introduïu el nombre total de mesos (12 per el nombre d'anys) "
+"en el camp de períodes."
+
+#: ../data/functions.xml.in.h:1141
+msgid "Rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1142
+msgid "Periods of an investment"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1143
+msgid "r:nper"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1144
+msgid ""
+"Calculates number of periods of an investment based on periodic constant "
+"payments and a constant interest rate.&#10;&#10;Type defines the due date. 1 "
+"for payment at the beginning of a period and 0 (default) for payment at the "
+"end of a period."
+msgstr ""
+"Calcula el nombre de períodes d'una inversió basat en pagaments constants "
+"periòdics i una taxa d'interès constant.&#10;&#10;El tipus defineix la data "
+"de venciment. 1 per pagament al principi d'un període i 0 (el predeterminat) "
+"per pagament al final d'un període."
+
+#: ../data/functions.xml.in.h:1145
+msgid "Periods for investment to attain desired value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1146
+msgid "r:g_duration"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1147
+msgid ""
+"Returns the number of periods needed for an investment to attain a desired "
+"value."
+msgstr ""
+"Retorna el nombre de períodes necessaris fins que una inversió arribi a un "
+"valor desitjat."
+
+#: ../data/functions.xml.in.h:1148
+msgid "Payment of an annuity going towards principal (PPMT)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1149
+msgid "r:ppmt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1150
+msgid ""
+"Calculates the amount of a payment of an annuity going towards principal."
+"&#10;&#10;Type defines the due date. 1 for payment at the beginning of a "
+"period and 0 (default) for payment at the end of a period."
+msgstr ""
+"Calcula la quantitat d'un pagament d'una anualitat que va al principal.&#10;"
+"&#10;El tipus defineix la data de venciment. 1 per pagament al principi d'un "
+"període i 0 (el predeterminat) per pagament al final d'un període."
+
+#: ../data/functions.xml.in.h:1151
+msgid "Desired future value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1152
+msgid "Effective Interest Rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1153
+msgid "r:effect"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1154
+msgid "Calculates the effective interest for a given nominal rate."
+msgstr "Calcula l'interès efectiu per a una taxa nominal donada."
+
+#: ../data/functions.xml.in.h:1155
+msgid "Nominal interest rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1156
+msgid "Future Value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1157
+msgid "r:fv"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1158
+msgid ""
+"Computes the future value of an investment. This is based on periodic, "
+"constant payments and a constant interest rate.&#10;&#10;If type = 1 then "
+"the payment is made at the beginning of the period. If type = 0 (or omitted) "
+"it is made at the end of each period."
+msgstr ""
+"Computa el valor futur d'una inversió. Això es basa en pagaments constants "
+"periòdics i una taxa d'interès constant.&#10;&#10;Si el tipus és 1 el "
+"pagament es fa al inici del període, si el tipus és 0 (o omès) es fa al "
+"final de cada període."
+
+#: ../data/functions.xml.in.h:1159
+msgid "Return on continuously compounded interest"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1160
+msgid "r:continuous"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1161
+msgid ""
+"Calculates the return on continuously compounded interest, given the "
+"principal, nominal rate and time in years."
+msgstr ""
+"Calcula el rendiment d'interès continuadament capitalitzat, donats el "
+"principal, la taxa nominal i el temps en anys."
+
+#: ../data/functions.xml.in.h:1162
+msgid "Principal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1163
+msgid "Compound"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1164
+msgid "r:compound"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1165
+msgid ""
+"Returns the value of an investment, given the principal, nominal interest "
+"rate, compounding frequency and time."
+msgstr ""
+"Retorna el valor d'una inversió, donats el principal, la taxa d'interès "
+"nominal, la freqüència de capitalització i el temps."
+
+#: ../data/functions.xml.in.h:1166
+msgid "Periods per year"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1167
+msgid "Payment of an annuity going towards interest (IPMT)"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1168
+msgid "r:ipmt"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1169
+msgid ""
+"Calculates the amount of a payment of an annuity going towards interest.&#10;"
+"&#10;Type defines the due date. 1 for payment at the beginning of a period "
+"and 0 (default) for payment at the end of a period."
+msgstr ""
+"Calcula la quantitat d'un pagament d'una anualitat que va al interès.&#10;"
+"&#10;El tipus defineix el data de venciment. 1 per pagament al principi d'un "
+"període i 0 (el predeterminat) per pagament al final d'un període."
+
+#: ../data/functions.xml.in.h:1170
+msgid "Interest rate for a fully invested security"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1171
+msgid "r:intrate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1172
+msgid ""
+"Returns the interest rate for a fully invested security.&#10;&#10;Basis is "
+"the type of day counting you want to use: 0: US 30/360 (default), 1: real "
+"days, 2: real days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Retorna la taxa d'interès d'un valor mobiliari completament invertit.&#10;"
+"&#10;La basi és el tipus de compte de dies que voleu usar: 0: US 30/360 (el "
+"predeterminat), 1: dies reals, 2: dies reals/360, 3: dies reals/365 o 4: "
+"Europeu 30/360."
+
+#: ../data/functions.xml.in.h:1173
+msgid "Investment"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1174
+msgid "Redemption"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1175
+msgid "Dollar Fraction"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1176
+msgid "r:dollarfr"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1177
+msgid ""
+"Converts a decimal dollar price into a dollar price expressed as a fraction."
+msgstr ""
+"Converteix un preu d'euros decimal en un preu d'euros expressat com a "
+"fracció."
+
+#: ../data/functions.xml.in.h:1178
+msgid "Decimal dollar"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1179
+msgid "Denominator of fraction"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1180
+msgid "Dollar Decimal"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1181
+msgid "r:dollarde"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1182
+msgid ""
+"Converts a dollar price expressed as a fraction into a dollar price "
+"expressed as a decimal number."
+msgstr ""
+"Converteix un preu d'euros expressat com a fracció en un preu d'euros "
+"expressat com a nombre decimal."
+
+#: ../data/functions.xml.in.h:1183
+msgid "Fractional dollar"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1184
+msgid "Amount received at maturity for a security bond"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1185
+msgid "r:received"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1186
+msgid ""
+"Returns the amount received at the maturity date for an invested security."
+"&#10;&#10;Basis is the type of day counting you want to use: 0: US 30/360 "
+"(default), 1: real days, 2: real days/360, 3: real days/365 or 4: European "
+"30/360. The settlement date must be before maturity date."
+msgstr ""
+"Retorna l'import rebut a la data de maduresa d'un valor mobiliari invertit."
+"&#10;&#10;La basi és el tipus de compte de dies que voleu usar: 0: US 30/360 "
+"(el predeterminat), 1: dies reals, 2: dies reals/360, 3: dies reals/365 o 4: "
+"Europeu 30/360. La data de conveni (settlement) ha de ser abans de la data "
+"de maduresa."
+
+#: ../data/functions.xml.in.h:1187
+msgid "Discount rate for a security"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1188
+msgid "r:disc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1189
+msgid ""
+"Returns the discount rate for a security.&#10;&#10;Basis is the type of day "
+"counting you want to use: 0: US 30/360 (default), 1: real days, 2: real "
+"days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Retorna la taxa de descompte d'un valor mobiliari.&#10;&#10;La basi és el "
+"tipus de compte de dies que voleu usar: 0: US 30/360 (el predeterminat), 1: "
+"dies reals, 2: dies reals/360, 3: dies reals/365 o 4: Europeu 30/360."
+
+#: ../data/functions.xml.in.h:1190
+msgid "Accrued interest of security paying at maturity"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1191
+msgid "r:accrintm"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1192
+msgid ""
+"Returns the accrued interest for a security which pays interest at maturity "
+"date.&#10;&#10;Basis is the type of day counting you want to use: 0: US "
+"30/360 (default), 1: real days, 2: real days/360, 3: real days/365 or 4: "
+"European 30/360."
+msgstr ""
+"Retorna l'interès acumulat d'un valor mobiliari que paga interès a la seva "
+"data de maduresa.&#10;&#10;La basi és el tipus de compte de dies que voleu "
+"usar: 0: US 30/360 (el predeterminat), 1: dies reals, 2: dies reals/360, 3: "
+"dies reals/365 o 4: Europeu 30/360."
+
+#: ../data/functions.xml.in.h:1193
+msgid "Issue date"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1194
+msgid "Annual rate of security"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1195
+msgid "Par value"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1196
+msgid "Accrued interest of security with periodic interest payments"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1197
+msgid "r:accrint"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1198
+msgid ""
+"Returns accrued interest for a security which pays periodic interest.&#10;"
+"&#10;Allowed frequencies are 1 - annual, 2 - semi-annual or 4 - quarterly. "
+"Basis is the type of day counting you want to use: 0: US 30/360 (default), "
+"1: real days, 2: real days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Retorna l'interès acumulat d'un valor mobiliari que paga interès periòdic."
+"&#10;&#10;Les freqüències permeses són 1 - anual, 2 - semestral o 4 - "
+"trimestral. La basi és el tipus de compte de dies que voleu usar: 0: US "
+"30/360 (el predeterminat), 1: dies reals, 2: dies reals/360, 3: dies "
+"reals/365 o 4: Europeu 30/360."
+
+#: ../data/functions.xml.in.h:1199
+msgid "First interest"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1200
+msgid "Frequency"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1201
+msgid "Number of coupons to be paid"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1202
+msgid "r:coupnum"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1203
+msgid ""
+"Returns the number of coupons to be paid between the settlement and the "
+"maturity.&#10;&#10;Basis is the type of day counting you want to use: 0: US "
+"30/360 (default), 1: real days, 2: real days/360, 3: real days/365 or 4: "
+"European 30/360."
+msgstr ""
+"Retorna el nombre de cupons a pagar entre el conveni (settlement) i la seva "
+"maduresa.&#10;&#10;La basi és el tipus de compte de dies que voleu usar: 0: "
+"US 30/360 (el predeterminat), 1: dies reals, 2: dies reals/360, 3: dies "
+"reals/365 o 4: Europeu 30/360."
+
+#: ../data/functions.xml.in.h:1204
+msgid "Price per $100 face value of a discounted security"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1205
+msgid "r:pricedisc"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1206
+msgid ""
+"Calculates and returns the price per $100 face value of a discounted "
+"security. The security does not pay interest at maturity.&#10;&#10;Basis is "
+"the type of day counting you want to use: 0: US 30/360 (default), 1: real "
+"days, 2: real days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Calcula i retorna el preu per valor nominal de 100€ d'un valor mobiliari amb "
+"descompte. El valor mobiliari no paga interès a la seva maduresa.&#10;&#10;"
+"La basi és el tipus de compte de dies que voleu usar: 0: US 30/360 (el "
+"predeterminat), 1: dies reals, 2: dies reals/360, 3: dies reals/365 o 4: "
+"Europeu 30/360."
+
+#: ../data/functions.xml.in.h:1207
+msgid "Discount"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1208
+msgid "Price per $100 face value of a security"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1209
+msgid "r:pricemat"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1210
+msgid ""
+"Calculates and returns the price per $100 face value of a security. The "
+"security pays interest at maturity.&#10;&#10;Basis is the type of day "
+"counting you want to use: 0: US 30/360 (default), 1: real days, 2: real "
+"days/360, 3: real days/365 or 4: European 30/360."
+msgstr ""
+"Calcula i retorna el preu per valor nominal de 100€ d'un valor mobiliari. El "
+"valor mobiliari paga interès a la seva maduresa.&#10;&#10;La basi és el "
+"tipus de compte de dies que voleu usar: 0: US 30/360 (el predeterminat), 1: "
+"dies reals, 2: dies reals/360, 3: dies reals/365 o 4: Europeu 30/360."
+
+#: ../data/functions.xml.in.h:1211
+msgid "Annual yield"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1212
+msgid "Level-Coupon Bond"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1213
+msgid "r:level_coupon"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1214
+msgid "Calculates the value of a level-coupon bond."
+msgstr "Calcula el nivell d'un bo de cupons iguals."
+
+#: ../data/functions.xml.in.h:1215
+msgid "Coupon rate"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1216
+msgid "Coupons per year"
+msgstr ""
+
+#: ../data/functions.xml.in.h:1217
+msgid "Market interest rate"
+msgstr ""
+
+#: ../data/planets.xml.in.h:1
+msgid "Earth"
+msgstr ""
+
+#: ../data/planets.xml.in.h:2
+msgid "Mars"
+msgstr ""
+
+#. Planet
+#: ../data/planets.xml.in.h:4
+msgid "!planets!Mercury"
+msgstr ""
+
+#: ../data/planets.xml.in.h:5
+msgid "Venus"
+msgstr ""
+
+#: ../data/planets.xml.in.h:6
+msgid "Jupiter"
+msgstr ""
+
+#: ../data/planets.xml.in.h:7
+msgid "Saturn"
+msgstr ""
+
+#: ../data/planets.xml.in.h:8
+msgid "Neptune"
+msgstr ""
+
+#: ../data/planets.xml.in.h:9
+msgid "Pluto"
+msgstr ""
+
+#: ../data/planets.xml.in.h:10
+msgid "Uranus"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:1
+msgid "ar:y,r:yocto"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:2
+msgid "ar:z,r:zepto"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:3
+msgid "ar:a,r:atto"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:4
+msgid "ar:f,r:femto"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:5
+msgid "ar:p,r:pico"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:6
+msgid "ar:n,r:nano"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:7
+msgid "aur:&#x3BC;,ar:u,r:micro"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:8
+msgid "ar:m,r:milli"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:9
+msgid "ar:c,r:centi"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:10
+msgid "ar:d,r:deci"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:11
+msgid "ar:da,r:deca"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:12
+msgid "ar:h,r:hecto"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:13
+msgid "ar:k,r:kilo"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:14
+msgid "ar:M,r:mega"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:15
+msgid "ar:G,r:giga"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:16
+msgid "ar:T,r:tera"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:17
+msgid "ar:P,r:peta"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:18
+msgid "ar:E,r:exa"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:19
+msgid "ar:Z,r:zetta"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:20
+msgid "ar:Y,r:yotta"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:21
+msgid "ar:Ki,r:kibi"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:22
+msgid "ar:Mi,r:mebi"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:23
+msgid "ar:Gi,r:gibi"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:24
+msgid "ar:Ti,r:tebi"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:25
+msgid "ar:Pi,r:pebi"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:26
+msgid "ar:Ei,r:exbi"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:27
+msgid "ar:Zi,r:zebi"
+msgstr ""
+
+#: ../data/prefixes.xml.in.h:28
+msgid "ar:Yi,r:yobi"
+msgstr ""
+
+#. Unit category
+#: ../data/units.xml.in.h:2
+msgid "!units!Length"
+msgstr ""
+
+#: ../data/units.xml.in.h:3
+msgid "Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:4
+msgid "ar:m,meter,p:meters,metre,p:metres"
+msgstr ""
+
+#: ../data/units.xml.in.h:5
+msgid "Kilometer"
+msgstr ""
+
+#: ../data/units.xml.in.h:6
+msgid "Decimeter"
+msgstr ""
+
+#: ../data/units.xml.in.h:7
+msgid "Centimeter"
+msgstr ""
+
+#: ../data/units.xml.in.h:8
+msgid "Millimeter"
+msgstr ""
+
+#: ../data/units.xml.in.h:9
+msgid "Nautical Mile"
+msgstr ""
+
+#: ../data/units.xml.in.h:10
+msgid "r:nautical_mile,p:nautical_miles"
+msgstr ""
+
+#: ../data/units.xml.in.h:11
+msgid "&#xC5;ngstr&#xF6;m"
+msgstr ""
+
+#: ../data/units.xml.in.h:12
+msgid "aru:&#xC5;,aou:&#x212B;,u:&#xE5;ngstr&#xF6;m,angstrom"
+msgstr ""
+
+#: ../data/units.xml.in.h:13
+msgid "U.S. Survey Inch"
+msgstr ""
+
+#: ../data/units.xml.in.h:14
+msgid "ar:US_in,US_inch,p:US_inches"
+msgstr ""
+
+#: ../data/units.xml.in.h:15
+msgid "Inch"
+msgstr ""
+
+#: ../data/units.xml.in.h:16
+msgid "ar:in,inch,p:inches"
+msgstr ""
+
+#: ../data/units.xml.in.h:17
+msgid "Hand"
+msgstr ""
+
+#: ../data/units.xml.in.h:18
+msgid "r:hand,p:hands"
+msgstr ""
+
+#: ../data/units.xml.in.h:19
+msgid "Foot"
+msgstr ""
+
+#: ../data/units.xml.in.h:20
+msgid "ar:ft,foot,p:feet"
+msgstr ""
+
+#: ../data/units.xml.in.h:21
+msgid "U.S. Survey Foot"
+msgstr ""
+
+#: ../data/units.xml.in.h:22
+msgid "ar:US_ft,US_foot,p:US_feet"
+msgstr ""
+
+#: ../data/units.xml.in.h:23
+msgid "Link"
+msgstr ""
+
+#: ../data/units.xml.in.h:24
+msgid "ar:li,link,p:links"
+msgstr ""
+
+#: ../data/units.xml.in.h:25
+msgid "Yard"
+msgstr ""
+
+#: ../data/units.xml.in.h:26
+msgid "ar:yd,yard,p:yards"
+msgstr ""
+
+#: ../data/units.xml.in.h:27
+msgid "Rod (pole/perch)"
+msgstr ""
+
+#: ../data/units.xml.in.h:28
+msgid "ar:rd,rod,p:rods"
+msgstr ""
+
+#: ../data/units.xml.in.h:29
+msgid "Fathom"
+msgstr ""
+
+#: ../data/units.xml.in.h:30
+msgid "r:fathom,p:fathoms"
+msgstr ""
+
+#: ../data/units.xml.in.h:31
+msgid "Chain"
+msgstr ""
+
+#: ../data/units.xml.in.h:32
+msgid "ar:ch,chain,p:chains"
+msgstr ""
+
+#: ../data/units.xml.in.h:33
+msgid "Furlong"
+msgstr ""
+
+#: ../data/units.xml.in.h:34
+msgid "ar:fur,furlong,p:furlongs"
+msgstr ""
+
+#: ../data/units.xml.in.h:35
+msgid "Mile"
+msgstr ""
+
+#: ../data/units.xml.in.h:36
+msgid "ar:mi,mile,p:miles"
+msgstr ""
+
+#: ../data/units.xml.in.h:37
+msgid "U.S. Survey Mile"
+msgstr ""
+
+#: ../data/units.xml.in.h:38
+msgid "ar:US_mi,US_mile,p:US_miles"
+msgstr ""
+
+#: ../data/units.xml.in.h:39
+msgid "Mil (1/1000 in)"
+msgstr ""
+
+#: ../data/units.xml.in.h:40
+msgid "r:mil,p:mils"
+msgstr ""
+
+#: ../data/units.xml.in.h:41
+msgid "Astronomical Unit"
+msgstr ""
+
+#: ../data/units.xml.in.h:42
+msgid "ar:AU,astronomical_unit,p:astronomical_units"
+msgstr ""
+
+#: ../data/units.xml.in.h:43
+msgid "Light Year"
+msgstr ""
+
+#: ../data/units.xml.in.h:44
+msgid "ar:ly,lightyear,p:lightyears"
+msgstr ""
+
+#: ../data/units.xml.in.h:45
+msgid "Parsec"
+msgstr ""
+
+#: ../data/units.xml.in.h:46
+msgid "ar:pc,parsec,p:parsecs"
+msgstr ""
+
+#: ../data/units.xml.in.h:47
+msgid "Pied du roi (French Royal Foot)"
+msgstr ""
+
+#: ../data/units.xml.in.h:48
+msgid "r:pied_du_roi"
+msgstr ""
+
+#: ../data/units.xml.in.h:49
+msgid "Pouce (French Royal Inch)"
+msgstr ""
+
+#: ../data/units.xml.in.h:50
+msgid "r:pouce"
+msgstr ""
+
+#: ../data/units.xml.in.h:51
+msgid "Ligne"
+msgstr ""
+
+#: ../data/units.xml.in.h:52
+msgid "r:ligne"
+msgstr ""
+
+#: ../data/units.xml.in.h:53
+msgid "Toise"
+msgstr ""
+
+#: ../data/units.xml.in.h:54
+msgid "r:toise"
+msgstr ""
+
+#: ../data/units.xml.in.h:55
+msgid "Planck Length"
+msgstr ""
+
+#: ../data/units.xml.in.h:56
+msgid "Bohr (Atomic Unit of Length)"
+msgstr ""
+
+#: ../data/units.xml.in.h:57
+msgid "Electronvolt Distance"
+msgstr ""
+
+#: ../data/units.xml.in.h:58
+msgid "Natural Unit of Length"
+msgstr ""
+
+#. Unit category
+#: ../data/units.xml.in.h:60
+msgid "!units!Angle"
+msgstr ""
+
+#: ../data/units.xml.in.h:61
+msgid "Plane Angle"
+msgstr ""
+
+#: ../data/units.xml.in.h:62
+msgid "Radian"
+msgstr ""
+
+#: ../data/units.xml.in.h:63
+msgid "ar:rad,radian,p:radians"
+msgstr ""
+
+#: ../data/units.xml.in.h:65
+msgid "ar:deg,au:&#xB0;,degree,p:degrees"
+msgstr ""
+
+#: ../data/units.xml.in.h:66
+msgid "Gradian (Gon)"
+msgstr ""
+
+#: ../data/units.xml.in.h:67
+msgid "ar:gra,gradian,p:gradians,gon,p:gons"
+msgstr ""
+
+#: ../data/units.xml.in.h:68
+msgid "Arcminute"
+msgstr ""
+
+#: ../data/units.xml.in.h:69
+msgid "ar:arcmin,arcminute,p:arcminutes"
+msgstr ""
+
+#: ../data/units.xml.in.h:70
+msgid "Arcsecond"
+msgstr ""
+
+#: ../data/units.xml.in.h:71
+msgid "ar:arcsec,arcsecond,p:arcseconds"
+msgstr ""
+
+#: ../data/units.xml.in.h:72
+msgid "Turn"
+msgstr ""
+
+#: ../data/units.xml.in.h:73
+msgid "r:turn,p:turns"
+msgstr ""
+
+#: ../data/units.xml.in.h:74
+msgid "Solid Angle"
+msgstr ""
+
+#: ../data/units.xml.in.h:75
+msgid "Steradian"
+msgstr ""
+
+#: ../data/units.xml.in.h:76
+msgid "ar:sr,steradian,p:steradians"
+msgstr ""
+
+#: ../data/units.xml.in.h:77
+msgid "Angular Acceleration"
+msgstr ""
+
+#: ../data/units.xml.in.h:78
+msgid "Radians per Second Squared"
+msgstr ""
+
+#: ../data/units.xml.in.h:79
+msgid "Angular Velocity"
+msgstr ""
+
+#: ../data/units.xml.in.h:80
+msgid "Radians per Second"
+msgstr ""
+
+#. Unit category
+#: ../data/units.xml.in.h:82
+msgid "!units!Mass"
+msgstr ""
+
+#: ../data/units.xml.in.h:83
+msgid "Gram"
+msgstr ""
+
+#: ../data/units.xml.in.h:84
+msgid "ar:g,gram,p:grams"
+msgstr ""
+
+#: ../data/units.xml.in.h:85
+msgid "Kilogram"
+msgstr ""
+
+#: ../data/units.xml.in.h:86
+msgid "Hectogram"
+msgstr ""
+
+#: ../data/units.xml.in.h:87
+msgid "Metric Ton (Tonne)"
+msgstr ""
+
+#: ../data/units.xml.in.h:88
+msgid "ar:t,tonne,p:tonnes,ton,p:tons"
+msgstr ""
+
+#: ../data/units.xml.in.h:89
+msgid "Grain"
+msgstr ""
+
+#: ../data/units.xml.in.h:90
+msgid "ar:gr,grain,p:grains"
+msgstr ""
+
+#: ../data/units.xml.in.h:91
+msgid "Pennyweight"
+msgstr ""
+
+#: ../data/units.xml.in.h:92
+msgid "ar:pwt,pennyweight,p:pennyweights"
+msgstr ""
+
+#: ../data/units.xml.in.h:93
+msgid "Ounce (troy)"
+msgstr ""
+
+#: ../data/units.xml.in.h:94
+msgid "ar:oz_t,troy_ounce,p:troy_ounces"
+msgstr ""
+
+#: ../data/units.xml.in.h:95
+msgid "Pound (troy)"
+msgstr ""
+
+#: ../data/units.xml.in.h:96
+msgid "ar:lb_t,troy_pound,p:troy_pounds"
+msgstr ""
+
+#: ../data/units.xml.in.h:97
+msgid "Dram"
+msgstr ""
+
+#: ../data/units.xml.in.h:98
+msgid "ar:dr,dram,p:drams"
+msgstr ""
+
+#: ../data/units.xml.in.h:99
+msgid "Ounce"
+msgstr ""
+
+#: ../data/units.xml.in.h:100
+msgid "ar:oz,ounce,p:ounces"
+msgstr ""
+
+#: ../data/units.xml.in.h:101
+msgid "Pound"
+msgstr ""
+
+#: ../data/units.xml.in.h:102
+msgid "ar:lb,aou:&#x2114;,pound,p:pounds"
+msgstr ""
+
+#: ../data/units.xml.in.h:103
+msgid "Short Hundredweight (Cental)"
+msgstr ""
+
+#: ../data/units.xml.in.h:104
+msgid "ar:cwt,hundredweight,cental,p:hundredweights,centals"
+msgstr ""
+
+#: ../data/units.xml.in.h:105
+msgid "Long Hundredweight"
+msgstr ""
+
+#: ../data/units.xml.in.h:106
+msgid "ar:l_cwt,long_hundredweight,p:long_hundredweights"
+msgstr ""
+
+#: ../data/units.xml.in.h:107
+msgid "Short Ton"
+msgstr ""
+
+#: ../data/units.xml.in.h:108
+msgid "ar:s_ton,short_ton,p:short_tons"
+msgstr ""
+
+#: ../data/units.xml.in.h:109
+msgid "Long Ton"
+msgstr ""
+
+#: ../data/units.xml.in.h:110
+msgid "ar:l_ton,long_ton,p:long_tons"
+msgstr ""
+
+#: ../data/units.xml.in.h:111
+msgid "Stone"
+msgstr ""
+
+#: ../data/units.xml.in.h:112
+msgid "r:stone,p:stones"
+msgstr ""
+
+#: ../data/units.xml.in.h:113
+msgid "Carat"
+msgstr ""
+
+#: ../data/units.xml.in.h:114
+msgid "r:carat,p:carats"
+msgstr ""
+
+#: ../data/units.xml.in.h:115
+msgid "Pfund"
+msgstr ""
+
+#: ../data/units.xml.in.h:116
+msgid "r:pfund"
+msgstr ""
+
+#: ../data/units.xml.in.h:117
+msgid "Zentner"
+msgstr ""
+
+#: ../data/units.xml.in.h:118
+msgid "r:zentner"
+msgstr ""
+
+#: ../data/units.xml.in.h:119
+msgid "Planck Mass"
+msgstr ""
+
+#: ../data/units.xml.in.h:120
+msgid "Atomic/Natural Unit of Mass"
+msgstr ""
+
+#: ../data/units.xml.in.h:121
+msgid "Electronvolt Mass"
+msgstr ""
+
+#: ../data/units.xml.in.h:122
+msgid "Atomic Mass Unit"
+msgstr ""
+
+#: ../data/units.xml.in.h:123
+msgid "ar:u,a:AMU,atomic_mass_unit,p:atomic_mass_units"
+msgstr ""
+
+#: ../data/units.xml.in.h:124
+msgid "Dalton"
+msgstr ""
+
+#: ../data/units.xml.in.h:125
+msgid "ar:Da,dalton,p:daltons"
+msgstr ""
+
+#: ../data/units.xml.in.h:126
+msgid "Kilodalton"
+msgstr ""
+
+#: ../data/units.xml.in.h:128
+msgid "Kilogram per Cubic Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:129
+msgid "Gram per Cubic Decimeter"
+msgstr ""
+
+#: ../data/units.xml.in.h:130
+msgid "Gram per Cubic Centimeter"
+msgstr ""
+
+#: ../data/units.xml.in.h:132
+msgid "Gram per Mole"
+msgstr ""
+
+#: ../data/units.xml.in.h:133
+msgid "Mass Fraction"
+msgstr ""
+
+#: ../data/units.xml.in.h:134
+msgid "Kilogram per Kilogram"
+msgstr ""
+
+#: ../data/units.xml.in.h:137
+msgid "ar:s,second,p:seconds"
+msgstr ""
+
+#: ../data/units.xml.in.h:139
+msgid "ar:min,minute,p:minutes"
+msgstr ""
+
+#: ../data/units.xml.in.h:141
+msgid "ar:h,hour,p:hours"
+msgstr ""
+
+#: ../data/units.xml.in.h:143
+msgid "ar:d,day,p:days"
+msgstr ""
+
+#: ../data/units.xml.in.h:144
+msgid "Week"
+msgstr ""
+
+#: ../data/units.xml.in.h:145
+msgid "r:week,p:weeks"
+msgstr ""
+
+#: ../data/units.xml.in.h:146
+msgid "Fortnight"
+msgstr ""
+
+#: ../data/units.xml.in.h:147
+msgid "r:fortnight,p:fortnights"
+msgstr ""
+
+#: ../data/units.xml.in.h:148
+msgid "Julian Year"
+msgstr ""
+
+#: ../data/units.xml.in.h:149
+msgid "r:year,p:years,a:yr,annus"
+msgstr ""
+
+#: ../data/units.xml.in.h:151
+msgid "r:month,p:months"
+msgstr ""
+
+#: ../data/units.xml.in.h:152
+msgid "Planck Time"
+msgstr ""
+
+#: ../data/units.xml.in.h:153
+msgid "Atomic Unit of Time"
+msgstr ""
+
+#: ../data/units.xml.in.h:154
+msgid "Natural Unit of Time"
+msgstr ""
+
+#: ../data/units.xml.in.h:155
+msgid "Electronvolt Time"
+msgstr ""
+
+#. Unit category
+#: ../data/units.xml.in.h:157
+msgid "!units!Frequency"
+msgstr ""
+
+#: ../data/units.xml.in.h:158
+msgid "Hertz"
+msgstr ""
+
+#: ../data/units.xml.in.h:159
+msgid "ar:Hz,hertz"
+msgstr ""
+
+#: ../data/units.xml.in.h:160
+msgid "Electricity"
+msgstr ""
+
+#: ../data/units.xml.in.h:161
+msgid "Electric Current"
+msgstr ""
+
+#: ../data/units.xml.in.h:162
+msgid "Ampere"
+msgstr ""
+
+#: ../data/units.xml.in.h:163
+msgid "ar:A,ampere,p:amperes"
+msgstr ""
+
+#: ../data/units.xml.in.h:164
+msgid "Abampere"
+msgstr ""
+
+#: ../data/units.xml.in.h:165
+msgid "r:abampere,a:abA,a:aA,p:abamperes,a:Bi,biot"
+msgstr ""
+
+#: ../data/units.xml.in.h:166
+msgid "Current Density"
+msgstr ""
+
+#: ../data/units.xml.in.h:167
+msgid "Ampere per Meter Squared"
+msgstr ""
+
+#: ../data/units.xml.in.h:168
+msgid "Electric Charge"
+msgstr ""
+
+#: ../data/units.xml.in.h:169
+msgid "Coulomb"
+msgstr ""
+
+#: ../data/units.xml.in.h:170
+msgid "ar:C,coulomb,p:coulombs"
+msgstr ""
+
+#: ../data/units.xml.in.h:171
+msgid "Abcoulomb"
+msgstr ""
+
+#: ../data/units.xml.in.h:172
+msgid "r:abcoulomb,p:abcoulombs,a:abC,a:aC"
+msgstr ""
+
+#: ../data/units.xml.in.h:173
+msgid "Statcoulomb (Franklin)"
+msgstr ""
+
+#: ../data/units.xml.in.h:174
+msgid "r:statcoulomb,p:statcoulombs,a:statC,franklin,a:Fr,p:franklins"
+msgstr ""
+
+#: ../data/units.xml.in.h:175
+msgid "Planck Charge"
+msgstr ""
+
+#: ../data/units.xml.in.h:176
+msgid "Atomic Unit of Charge"
+msgstr ""
+
+#: ../data/units.xml.in.h:177
+msgid "Electric Charge Density"
+msgstr ""
+
+#: ../data/units.xml.in.h:178
+msgid "Coulomb per Cubic Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:179
+msgid "Electric Flux Density"
+msgstr ""
+
+#: ../data/units.xml.in.h:180
+msgid "Coulomb per Meter Squared"
+msgstr ""
+
+#: ../data/units.xml.in.h:181
+msgid "Electric Potential"
+msgstr ""
+
+#: ../data/units.xml.in.h:182
+msgid "Volt"
+msgstr ""
+
+#: ../data/units.xml.in.h:183
+msgid "ar:V,volt,p:volts"
+msgstr ""
+
+#: ../data/units.xml.in.h:184
+msgid "Statvolt"
+msgstr ""
+
+#: ../data/units.xml.in.h:185
+msgid "r:statvolt,p:statvolts,a:statV"
+msgstr ""
+
+#: ../data/units.xml.in.h:186
+msgid "Abvolt"
+msgstr ""
+
+#: ../data/units.xml.in.h:187
+msgid "r:abvolt,p:abvolts,a:abV"
+msgstr ""
+
+#: ../data/units.xml.in.h:188
+msgid "Atomic Unit of Electric Potential"
+msgstr ""
+
+#: ../data/units.xml.in.h:189
+msgid "Capacitance"
+msgstr ""
+
+#: ../data/units.xml.in.h:190
+msgid "Farad"
+msgstr ""
+
+#: ../data/units.xml.in.h:191
+msgid "ar:F,farad,p:farads"
+msgstr ""
+
+#: ../data/units.xml.in.h:192
+msgid "Electric Resistance"
+msgstr ""
+
+#: ../data/units.xml.in.h:193
+msgid "Ohm"
+msgstr ""
+
+#: ../data/units.xml.in.h:194
+msgid "au:&#x3A9;,r:ohm,p:ohms,auio:&#x2126;"
+msgstr ""
+
+#: ../data/units.xml.in.h:195
+msgid "Abohm"
+msgstr ""
+
+#: ../data/units.xml.in.h:196
+msgid "r:abohm,p:abohms,au:ab&#x3A9;"
+msgstr ""
+
+#: ../data/units.xml.in.h:197
+msgid "Statohm"
+msgstr ""
+
+#: ../data/units.xml.in.h:198
+msgid "r:statohm,p:statohms,au:stat&#x3A9;"
+msgstr ""
+
+#: ../data/units.xml.in.h:199
+msgid "Electric Conductance"
+msgstr ""
+
+#: ../data/units.xml.in.h:200
+msgid "Siemens"
+msgstr ""
+
+#: ../data/units.xml.in.h:201
+msgid "ar:S,siemens,auio:&#x2127;"
+msgstr ""
+
+#: ../data/units.xml.in.h:202
+msgid "Electric Field Strength"
+msgstr ""
+
+#: ../data/units.xml.in.h:203
+msgid "Volt per Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:204
+msgid "Atomic Unit of Electric Field"
+msgstr ""
+
+#: ../data/units.xml.in.h:205
+msgid "Permittivity"
+msgstr ""
+
+#: ../data/units.xml.in.h:206
+msgid "Farad per Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:207
+msgid "Inductance"
+msgstr ""
+
+#: ../data/units.xml.in.h:208
+msgid "Henry"
+msgstr ""
+
+#: ../data/units.xml.in.h:209
+msgid "ar:H,henry,p:henrys"
+msgstr ""
+
+#: ../data/units.xml.in.h:210
+msgid "Abhenry"
+msgstr ""
+
+#: ../data/units.xml.in.h:211
+msgid "r:abhenry,p:abhenrys,a:abH"
+msgstr ""
+
+#: ../data/units.xml.in.h:212
+msgid "Permeability"
+msgstr ""
+
+#: ../data/units.xml.in.h:213
+msgid "Henry per Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:214
+msgid "Temperature"
+msgstr ""
+
+#: ../data/units.xml.in.h:215
+msgid "Kelvin"
+msgstr ""
+
+#: ../data/units.xml.in.h:216
+msgid "ar:K,aou:&#x212A;,kelvin,p:kelvins"
+msgstr ""
+
+#: ../data/units.xml.in.h:217
+msgid "Degree Celsius"
+msgstr ""
+
+#: ../data/units.xml.in.h:218
+msgid ""
+"ar:oC,au:&#xB0;C,au:&#x2103;,r:celsius,p:celsius,centigrade,p:centigrades"
+msgstr ""
+
+#: ../data/units.xml.in.h:219
+msgid "Degree Rankine"
+msgstr ""
+
+#: ../data/units.xml.in.h:220
+msgid "ar:oR,a:oRa,au:&#xB0;R,au:&#xB0;Ra,r:rankine"
+msgstr ""
+
+#: ../data/units.xml.in.h:221
+msgid "Degree Fahrenheit"
+msgstr ""
+
+#: ../data/units.xml.in.h:222
+msgid "ar:oF,au:&#xB0;F,au:&#x2109;,r:fahrenheit"
+msgstr ""
+
+#: ../data/units.xml.in.h:223
+msgid "Planck Temperature"
+msgstr ""
+
+#: ../data/units.xml.in.h:224
+msgid "Electronvolt Temperature"
+msgstr ""
+
+#: ../data/units.xml.in.h:225
+msgid "Substance"
+msgstr ""
+
+#: ../data/units.xml.in.h:226
+msgid "Mole"
+msgstr ""
+
+#: ../data/units.xml.in.h:227
+msgid "ar:mol,mole,p:moles"
+msgstr ""
+
+#: ../data/units.xml.in.h:228
+msgid "Einstein"
+msgstr ""
+
+#: ../data/units.xml.in.h:229
+msgid "r:einstein,p:einsteins"
+msgstr ""
+
+#: ../data/units.xml.in.h:230
+msgid "Substance Concentration"
+msgstr ""
+
+#: ../data/units.xml.in.h:231
+msgid "Mole per Cubic Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:232
+msgid "Catalytic Activity"
+msgstr ""
+
+#: ../data/units.xml.in.h:233
+msgid "Katal"
+msgstr ""
+
+#: ../data/units.xml.in.h:234
+msgid "ar:kat,katal,p:katals"
+msgstr ""
+
+#: ../data/units.xml.in.h:235
+msgid "Catalytic Concentration"
+msgstr ""
+
+#: ../data/units.xml.in.h:236
+msgid "Katal per Cubic Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:237
+msgid "Light"
+msgstr ""
+
+#: ../data/units.xml.in.h:238
+msgid "Luminous Intensity"
+msgstr ""
+
+#: ../data/units.xml.in.h:239
+msgid "Candela"
+msgstr ""
+
+#: ../data/units.xml.in.h:240
+msgid "ar:cd,candela,p:candelas"
+msgstr ""
+
+#: ../data/units.xml.in.h:241
+msgid "Luminance"
+msgstr ""
+
+#: ../data/units.xml.in.h:242
+msgid "Candela per Meter Squared"
+msgstr ""
+
+#: ../data/units.xml.in.h:243
+msgid "Stilb"
+msgstr ""
+
+#: ../data/units.xml.in.h:244
+msgid "ar:sb,stilb,p:stilbs"
+msgstr ""
+
+#: ../data/units.xml.in.h:245
+msgid "Luminous Flux"
+msgstr ""
+
+#: ../data/units.xml.in.h:246
+msgid "Lumen"
+msgstr ""
+
+#: ../data/units.xml.in.h:247
+msgid "ar:lm,lumen,p:lumens"
+msgstr ""
+
+#: ../data/units.xml.in.h:248
+msgid "Illuminance"
+msgstr ""
+
+#: ../data/units.xml.in.h:249
+msgid "Lux"
+msgstr ""
+
+#: ../data/units.xml.in.h:250
+msgid "ar:lx,lux"
+msgstr ""
+
+#: ../data/units.xml.in.h:251
+msgid "Foot-Candle"
+msgstr ""
+
+#: ../data/units.xml.in.h:252
+msgid "ar:fc,footcandle,p:footcandles"
+msgstr ""
+
+#: ../data/units.xml.in.h:253
+msgid "Phot"
+msgstr ""
+
+#: ../data/units.xml.in.h:254
+msgid "ar:ph,phot,p:phots"
+msgstr ""
+
+#: ../data/units.xml.in.h:255
+msgid "Radiant Intensity"
+msgstr ""
+
+#: ../data/units.xml.in.h:256
+msgid "Watt per Steradian"
+msgstr ""
+
+#: ../data/units.xml.in.h:257
+msgid "Irradiance"
+msgstr ""
+
+#: ../data/units.xml.in.h:258
+msgid "Watt per Meter Squared"
+msgstr ""
+
+#: ../data/units.xml.in.h:259
+msgid "Einstein per Meter Squared per Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:260
+msgid "Microeinstein per Meter Squared per Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:261
+msgid "Radiance"
+msgstr ""
+
+#: ../data/units.xml.in.h:262
+msgid "Watt per Square Meter Steradian"
+msgstr ""
+
+#: ../data/units.xml.in.h:263
+msgid "Area"
+msgstr ""
+
+#: ../data/units.xml.in.h:264
+msgid "Square Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:265
+msgid "Square Kilometer"
+msgstr ""
+
+#: ../data/units.xml.in.h:266
+msgid "Are"
+msgstr ""
+
+#: ../data/units.xml.in.h:267
+msgid "ar:a,are,p:ares"
+msgstr ""
+
+#: ../data/units.xml.in.h:268
+msgid "Circular Mil"
+msgstr ""
+
+#: ../data/units.xml.in.h:269
+msgid "r:cmil,p:cmils"
+msgstr ""
+
+#: ../data/units.xml.in.h:270
+msgid "Thousand of Circular Mil"
+msgstr ""
+
+#: ../data/units.xml.in.h:271
+msgid "Hectare"
+msgstr ""
+
+#: ../data/units.xml.in.h:272
+msgid "ar:ha,hectare,p:hectares"
+msgstr ""
+
+#: ../data/units.xml.in.h:273
+msgid "Decare"
+msgstr ""
+
+#: ../data/units.xml.in.h:274
+msgid "a:da,r:decare,p:decares"
+msgstr ""
+
+#: ../data/units.xml.in.h:275
+msgid "Barn"
+msgstr ""
+
+#: ../data/units.xml.in.h:276
+msgid "ar:b,barn,p:barns"
+msgstr ""
+
+#: ../data/units.xml.in.h:277
+msgid "Rood"
+msgstr ""
+
+#: ../data/units.xml.in.h:278
+msgid "r:rood,p:roods"
+msgstr ""
+
+#: ../data/units.xml.in.h:279
+msgid "Acre"
+msgstr ""
+
+#: ../data/units.xml.in.h:280
+msgid "r:acre,p:acres"
+msgstr ""
+
+#: ../data/units.xml.in.h:281
+msgid "Section"
+msgstr ""
+
+#: ../data/units.xml.in.h:282
+msgid "r:section,p:sections"
+msgstr ""
+
+#: ../data/units.xml.in.h:283
+msgid "Township"
+msgstr ""
+
+#: ../data/units.xml.in.h:284
+msgid "r:township,p:townships"
+msgstr ""
+
+#: ../data/units.xml.in.h:285
+msgid "Square Foot"
+msgstr ""
+
+#: ../data/units.xml.in.h:286
+msgid "Square Inch"
+msgstr ""
+
+#: ../data/units.xml.in.h:287
+msgid "Square Mile"
+msgstr ""
+
+#: ../data/units.xml.in.h:288
+msgid "Volume"
+msgstr ""
+
+#: ../data/units.xml.in.h:289
+msgid "Cubic Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:290
+msgid "Liter"
+msgstr ""
+
+#: ../data/units.xml.in.h:291
+msgid "ar:L,a:l,aou:&#x2113;,liter,p:liters,litre,p:litres"
+msgstr ""
+
+#: ../data/units.xml.in.h:292
+msgid "Milliliter"
+msgstr ""
+
+#: ../data/units.xml.in.h:293
+msgid "Centiliter"
+msgstr ""
+
+#: ../data/units.xml.in.h:294
+msgid "Deciliter"
+msgstr ""
+
+#: ../data/units.xml.in.h:295
+msgid "Cubic Inch"
+msgstr ""
+
+#: ../data/units.xml.in.h:296
+msgid "Fuel Economy"
+msgstr ""
+
+#: ../data/units.xml.in.h:297
+msgid "Liter per Kilometer"
+msgstr ""
+
+#: ../data/units.xml.in.h:298
+msgid "Kilometer per Liter"
+msgstr ""
+
+#: ../data/units.xml.in.h:299
+msgid "Miles per Gallon"
+msgstr ""
+
+#: ../data/units.xml.in.h:300
+msgid "a-cr:mpg"
+msgstr ""
+
+#: ../data/units.xml.in.h:301
+msgid "Cooking"
+msgstr ""
+
+#: ../data/units.xml.in.h:302
+msgid "Teaspoon"
+msgstr ""
+
+#: ../data/units.xml.in.h:303
+msgid "r:teaspoon,p:teaspoons"
+msgstr ""
+
+#: ../data/units.xml.in.h:304
+msgid "Dessertspoon"
+msgstr ""
+
+#: ../data/units.xml.in.h:305
+msgid "r:dessertspoon,p:dessertspoons"
+msgstr ""
+
+#: ../data/units.xml.in.h:306
+msgid "Tablespoon"
+msgstr ""
+
+#: ../data/units.xml.in.h:307
+msgid "r:tablespoon,p:tablespoons"
+msgstr ""
+
+#: ../data/units.xml.in.h:308
+msgid "Cup (U.S.)"
+msgstr ""
+
+#: ../data/units.xml.in.h:309
+msgid "r-c:cup,p-c:cups"
+msgstr ""
+
+#: ../data/units.xml.in.h:310
+msgid "Imperial Capacity"
+msgstr ""
+
+#: ../data/units.xml.in.h:311
+msgid "Imperial Fluid Ounce"
+msgstr ""
+
+#: ../data/units.xml.in.h:312
+msgid "ar:UK_fl_oz,imperial_fluid_ounce,p:imperial_fluid_ounces"
+msgstr ""
+
+#: ../data/units.xml.in.h:313
+msgid "Imperial Gill"
+msgstr ""
+
+#: ../data/units.xml.in.h:314
+msgid "ar:UK_gi,imperial_gill,p:imperial_gills"
+msgstr ""
+
+#: ../data/units.xml.in.h:315
+msgid "Imperial Pint"
+msgstr ""
+
+#: ../data/units.xml.in.h:316
+msgid "ar:UK_pt,imperial_pint,p:imperial_pints"
+msgstr ""
+
+#: ../data/units.xml.in.h:317
+msgid "Imperial Quart"
+msgstr ""
+
+#: ../data/units.xml.in.h:318
+msgid "ar:UK_qt,imperial_quart,p:imperial_quarts"
+msgstr ""
+
+#: ../data/units.xml.in.h:319
+msgid "Imperial Gallon"
+msgstr ""
+
+#: ../data/units.xml.in.h:320
+msgid "ar:UK_gal,imperial_gallon,p:imperial_gallons"
+msgstr ""
+
+#: ../data/units.xml.in.h:321
+msgid "Imperial Minim"
+msgstr ""
+
+#: ../data/units.xml.in.h:322
+msgid "r:imperial_minim,p:imperial_minims"
+msgstr ""
+
+#: ../data/units.xml.in.h:323
+msgid "Imperial Fluid Scuple"
+msgstr ""
+
+#: ../data/units.xml.in.h:324
+msgid "r:imperial_fluid_scuple,p:imperial_fluid_scuples"
+msgstr ""
+
+#: ../data/units.xml.in.h:325
+msgid "Imperial Fluid Drachm"
+msgstr ""
+
+#: ../data/units.xml.in.h:326
+msgid "ar:UK_fl_dr,imperial_fluid_drachm,p:imperial_fluid_drachms"
+msgstr ""
+
+#: ../data/units.xml.in.h:327
+msgid "Imperial Bushel"
+msgstr ""
+
+#: ../data/units.xml.in.h:328
+msgid "ar:UK_bu,imperial_bushel,p:imperial_bushels"
+msgstr ""
+
+#: ../data/units.xml.in.h:329
+msgid "U.S. Capacity"
+msgstr ""
+
+#: ../data/units.xml.in.h:330
+msgid "U.S. Fluid Ounce"
+msgstr ""
+
+#: ../data/units.xml.in.h:331
+msgid "ar:fl_oz,fluid_ounce,p:fluid_ounces"
+msgstr ""
+
+#: ../data/units.xml.in.h:332
+msgid "U.S. Gill"
+msgstr ""
+
+#: ../data/units.xml.in.h:333
+msgid "ar:gi,gill,p:gills"
+msgstr ""
+
+#: ../data/units.xml.in.h:334
+msgid "U.S. Liquid Pints"
+msgstr ""
+
+#: ../data/units.xml.in.h:335
+msgid "ar:liq_pt,liquid_pint,p:liquid_pints"
+msgstr ""
+
+#: ../data/units.xml.in.h:336
+msgid "U.S. Liquid Quarts"
+msgstr ""
+
+#: ../data/units.xml.in.h:337
+msgid "ar:liq_qt,liquid_quart,p:liquid_quarts"
+msgstr ""
+
+#: ../data/units.xml.in.h:338
+msgid "U.S. Minim"
+msgstr ""
+
+#: ../data/units.xml.in.h:339
+msgid "r:minim,p:minims"
+msgstr ""
+
+#: ../data/units.xml.in.h:340
+msgid "U.S. Fluid Drachm"
+msgstr ""
+
+#: ../data/units.xml.in.h:341
+msgid "ar:fl_dr,fluid_drachm,p:fluid_drachms"
+msgstr ""
+
+#: ../data/units.xml.in.h:342
+msgid "U.S. Dry Pint"
+msgstr ""
+
+#: ../data/units.xml.in.h:343
+msgid "ar:dry_pt,dry_pint,p:dry_pints"
+msgstr ""
+
+#: ../data/units.xml.in.h:344
+msgid "U.S. Dry Quart"
+msgstr ""
+
+#: ../data/units.xml.in.h:345
+msgid "ar:dry_qt,dry_quart,p:dry_quarts"
+msgstr ""
+
+#: ../data/units.xml.in.h:346
+msgid "U.S. Peck"
+msgstr ""
+
+#: ../data/units.xml.in.h:347
+msgid "ar:pk,peck,p:pecks"
+msgstr ""
+
+#: ../data/units.xml.in.h:348
+msgid "U.S. Bushel"
+msgstr ""
+
+#: ../data/units.xml.in.h:349
+msgid "ar:bu,bushel,p:bushels"
+msgstr ""
+
+#: ../data/units.xml.in.h:350
+msgid "U.S. Gallon"
+msgstr ""
+
+#: ../data/units.xml.in.h:351
+msgid "ar:gal,gallon,p:gallons"
+msgstr ""
+
+#: ../data/units.xml.in.h:352
+msgid "U.S. Barrel (oil)"
+msgstr ""
+
+#: ../data/units.xml.in.h:353
+msgid "ar:bbl,barrel,p:barrels"
+msgstr ""
+
+#: ../data/units.xml.in.h:354
+msgid "Specific Volume"
+msgstr ""
+
+#: ../data/units.xml.in.h:355
+msgid "Cubic Meter per Kilogram"
+msgstr ""
+
+#: ../data/units.xml.in.h:356
+msgid "Speed"
+msgstr ""
+
+#: ../data/units.xml.in.h:357
+msgid "Meter per Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:358
+msgid "Kilometer per Hour"
+msgstr ""
+
+#: ../data/units.xml.in.h:359
+msgid "a-c-r:kph,a-c-r:kmph"
+msgstr ""
+
+#: ../data/units.xml.in.h:360
+msgid "Nautical Mile per Hour"
+msgstr ""
+
+#: ../data/units.xml.in.h:361
+msgid "Knot"
+msgstr ""
+
+#: ../data/units.xml.in.h:362
+msgid "r:knot,p:knots"
+msgstr ""
+
+#: ../data/units.xml.in.h:363
+msgid "Miles per Hour"
+msgstr ""
+
+#: ../data/units.xml.in.h:364
+msgid "a-cr:mph"
+msgstr ""
+
+#: ../data/units.xml.in.h:365
+msgid "Speed of Light (Natural Unit of Velocity)"
+msgstr ""
+
+#: ../data/units.xml.in.h:366
+msgid "Atomic Unit of Velocity"
+msgstr ""
+
+#: ../data/units.xml.in.h:367
+msgid "Acceleration"
+msgstr ""
+
+#: ../data/units.xml.in.h:368
+msgid "Meter per Second Squared"
+msgstr ""
+
+#: ../data/units.xml.in.h:369
+msgid "Galileo"
+msgstr ""
+
+#: ../data/units.xml.in.h:370
+msgid "ar:Gal,galileo,p:galileos"
+msgstr ""
+
+#: ../data/units.xml.in.h:371
+msgid "Gee"
+msgstr ""
+
+#: ../data/units.xml.in.h:372
+msgid "r:gee,p:gees"
+msgstr ""
+
+#: ../data/units.xml.in.h:373
+msgid "Magnetism"
+msgstr ""
+
+#: ../data/units.xml.in.h:374
+msgid "Wave Number"
+msgstr ""
+
+#: ../data/units.xml.in.h:375
+msgid "Reciprocal Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:376
+msgid "Magnetic Field Strength"
+msgstr ""
+
+#: ../data/units.xml.in.h:377
+msgid "Ampere per Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:378
+msgid "Oersted"
+msgstr ""
+
+#: ../data/units.xml.in.h:379
+msgid "ar:Oe,oersted,p:oersteds"
+msgstr ""
+
+#: ../data/units.xml.in.h:380
+msgid "Magnetic Flux"
+msgstr ""
+
+#: ../data/units.xml.in.h:381
+msgid "Weber"
+msgstr ""
+
+#: ../data/units.xml.in.h:382
+msgid "ar:Wb,weber,p:webers"
+msgstr ""
+
+#: ../data/units.xml.in.h:383
+msgid "Maxwell"
+msgstr ""
+
+#: ../data/units.xml.in.h:384
+msgid "ar:Mx,maxwell,p:maxwells"
+msgstr ""
+
+#: ../data/units.xml.in.h:385
+msgid "Magnetic Flux Density"
+msgstr ""
+
+#: ../data/units.xml.in.h:386
+msgid "Tesla"
+msgstr ""
+
+#: ../data/units.xml.in.h:387
+msgid "ar:T,tesla,p:teslas"
+msgstr ""
+
+#: ../data/units.xml.in.h:388
+msgid "Gauss"
+msgstr ""
+
+#: ../data/units.xml.in.h:389
+msgid "r:gauss"
+msgstr ""
+
+#: ../data/units.xml.in.h:390
+msgid "Atomic Unit of Magnetic Flux Density"
+msgstr ""
+
+#: ../data/units.xml.in.h:391
+msgid "Magnetic Dipole Moment"
+msgstr ""
+
+#: ../data/units.xml.in.h:392
+msgid "Ampere Square Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:393
+msgid "Atomic Unit of Magnetic Dipole Moment"
+msgstr ""
+
+#: ../data/units.xml.in.h:394
+msgid "Force"
+msgstr ""
+
+#: ../data/units.xml.in.h:395
+msgid "Newton"
+msgstr ""
+
+#: ../data/units.xml.in.h:396
+msgid "ar:N,newton,p:newtons"
+msgstr ""
+
+#: ../data/units.xml.in.h:397
+msgid "Dyne"
+msgstr ""
+
+#: ../data/units.xml.in.h:398
+msgid "ar:dyn,dyne,p:dynes"
+msgstr ""
+
+#: ../data/units.xml.in.h:399
+msgid "Pound-force"
+msgstr ""
+
+#: ../data/units.xml.in.h:400
+msgid "ar:lbf,pound_force"
+msgstr ""
+
+#: ../data/units.xml.in.h:401
+msgid "Poundal"
+msgstr ""
+
+#: ../data/units.xml.in.h:402
+msgid "r:poundal,p:poundals,a:pdl"
+msgstr ""
+
+#: ../data/units.xml.in.h:403
+msgid "Pond (Gram-Force)"
+msgstr ""
+
+#: ../data/units.xml.in.h:404
+msgid "r:pond,p:ponds,a:gf"
+msgstr ""
+
+#: ../data/units.xml.in.h:405
+msgid "Kilopond (Kilogram-Force)"
+msgstr ""
+
+#: ../data/units.xml.in.h:406
+msgid "Atomic Unit of Force"
+msgstr ""
+
+#: ../data/units.xml.in.h:407
+msgid "Moment of Force"
+msgstr ""
+
+#: ../data/units.xml.in.h:408
+msgid "Newton Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:409
+msgid "Momentum"
+msgstr ""
+
+#: ../data/units.xml.in.h:410
+msgid "Kilogram Meter per Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:411
+msgid "Electronvolt Momentum"
+msgstr ""
+
+#: ../data/units.xml.in.h:412
+msgid "Natural Unit of Momentum"
+msgstr ""
+
+#: ../data/units.xml.in.h:413
+msgid "Atomic Unit of Momentum"
+msgstr ""
+
+#: ../data/units.xml.in.h:414
+msgid "Pressure"
+msgstr ""
+
+#: ../data/units.xml.in.h:415
+msgid "Pascal"
+msgstr ""
+
+#: ../data/units.xml.in.h:416
+msgid "ar:Pa,pascal,p:pascals"
+msgstr ""
+
+#: ../data/units.xml.in.h:417
+msgid "Kilogram-force per Square Centimetre"
+msgstr ""
+
+#: ../data/units.xml.in.h:418
+msgid "Pound-force per Square Inch (psi)"
+msgstr ""
+
+#: ../data/units.xml.in.h:419
+msgid "a-cr:psi"
+msgstr ""
+
+#: ../data/units.xml.in.h:420
+msgid "Bar"
+msgstr ""
+
+#: ../data/units.xml.in.h:421
+msgid "r:bar,p:bars"
+msgstr ""
+
+#: ../data/units.xml.in.h:422
+msgid "Atmosphere"
+msgstr ""
+
+#: ../data/units.xml.in.h:423
+msgid "ar:atm,atmosphere,p:atmospheres"
+msgstr ""
+
+#: ../data/units.xml.in.h:424
+msgid "Torr"
+msgstr ""
+
+#: ../data/units.xml.in.h:425
+msgid "ar:Torr,torr,p:torrs"
+msgstr ""
+
+#: ../data/units.xml.in.h:426
+msgid "Millimeter of Mercury"
+msgstr ""
+
+#: ../data/units.xml.in.h:427
+msgid "ar:mmHg"
+msgstr ""
+
+#: ../data/units.xml.in.h:428
+msgid "Inch of Mercury"
+msgstr ""
+
+#: ../data/units.xml.in.h:429
+msgid "ar:inHg"
+msgstr ""
+
+#: ../data/units.xml.in.h:430
+msgid "Millitorr"
+msgstr ""
+
+#: ../data/units.xml.in.h:431
+msgid "Barye"
+msgstr ""
+
+#: ../data/units.xml.in.h:432
+msgid "ar:Ba,barye"
+msgstr ""
+
+#: ../data/units.xml.in.h:433
+msgid "Dynamic Viscosity"
+msgstr ""
+
+#: ../data/units.xml.in.h:434
+msgid "Pascal Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:435
+msgid "Poise"
+msgstr ""
+
+#: ../data/units.xml.in.h:436
+msgid "ar:P,poise,p:poises"
+msgstr ""
+
+#: ../data/units.xml.in.h:437
+msgid "Centipoise"
+msgstr ""
+
+#: ../data/units.xml.in.h:438
+msgid "Kinematic Viscosity"
+msgstr ""
+
+#: ../data/units.xml.in.h:439
+msgid "Square Meter per Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:440
+msgid "Stokes"
+msgstr ""
+
+#: ../data/units.xml.in.h:441
+msgid "ar:St,stokes"
+msgstr ""
+
+#: ../data/units.xml.in.h:442
+msgid "Centistokes"
+msgstr ""
+
+#: ../data/units.xml.in.h:443
+msgid "Surface Tension"
+msgstr ""
+
+#: ../data/units.xml.in.h:444
+msgid "Newton per Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:445
+msgid "Energy"
+msgstr ""
+
+#: ../data/units.xml.in.h:446
+msgid "Joule"
+msgstr ""
+
+#: ../data/units.xml.in.h:447
+msgid "ar:J,joule,p:joules"
+msgstr ""
+
+#: ../data/units.xml.in.h:448
+msgid "Watt Hour"
+msgstr ""
+
+#: ../data/units.xml.in.h:449
+msgid "Kilowatt Hour"
+msgstr ""
+
+#: ../data/units.xml.in.h:450
+msgid "Calorie (international table)"
+msgstr ""
+
+#: ../data/units.xml.in.h:451
+msgid "ais:cal_IT,ar:cal,c:calorie,cp:calories"
+msgstr ""
+
+#: ../data/units.xml.in.h:452
+msgid "Calorie (capital C)"
+msgstr ""
+
+#: ../data/units.xml.in.h:453
+msgid "cr:Calorie,cp:Calories"
+msgstr ""
+
+#: ../data/units.xml.in.h:454
+msgid "Calorie (thermochemical)"
+msgstr ""
+
+#: ../data/units.xml.in.h:455
+msgid "ars:cal_th"
+msgstr ""
+
+#: ../data/units.xml.in.h:456
+msgid "Gram of TNT"
+msgstr ""
+
+#: ../data/units.xml.in.h:457
+msgid "a-cr:gTNT,gramTNT"
+msgstr ""
+
+#: ../data/units.xml.in.h:458
+msgid "Ton of TNT"
+msgstr ""
+
+#: ../data/units.xml.in.h:459
+msgid "a-cr:tTNT,tonTNT"
+msgstr ""
+
+#: ../data/units.xml.in.h:460
+msgid "Calorie (15 degrees Celsius)"
+msgstr ""
+
+#: ../data/units.xml.in.h:461
+msgid "ars:cal_fifteen"
+msgstr ""
+
+#: ../data/units.xml.in.h:462
+msgid "Calorie (mean)"
+msgstr ""
+
+#: ../data/units.xml.in.h:463
+msgid "ars:cal_mean"
+msgstr ""
+
+#: ../data/units.xml.in.h:464
+msgid "British Thermal Unit (IT)"
+msgstr ""
+
+#: ../data/units.xml.in.h:465
+msgid "ar:Btu"
+msgstr ""
+
+#: ../data/units.xml.in.h:466
+msgid "Electronvolt"
+msgstr ""
+
+#: ../data/units.xml.in.h:467
+msgid "ar:eV,electronvolt,p:electronvolts"
+msgstr ""
+
+#: ../data/units.xml.in.h:468
+msgid "Erg"
+msgstr ""
+
+#: ../data/units.xml.in.h:469
+msgid "r:erg,p:ergs"
+msgstr ""
+
+#: ../data/units.xml.in.h:470
+msgid "Foe"
+msgstr ""
+
+#: ../data/units.xml.in.h:471
+msgid "r:foe,p:foes"
+msgstr ""
+
+#: ../data/units.xml.in.h:472
+msgid "Foot-Pound Force"
+msgstr ""
+
+#: ../data/units.xml.in.h:473
+msgid "Hartree (Atomic Unit of Energy)"
+msgstr ""
+
+#: ../data/units.xml.in.h:474
+msgid "Rydberg (unit)"
+msgstr ""
+
+#: ../data/units.xml.in.h:475
+msgid "Natural Unit of Energy"
+msgstr ""
+
+#: ../data/units.xml.in.h:476
+msgid "Specific Energy"
+msgstr ""
+
+#: ../data/units.xml.in.h:477
+msgid "Joule per Kilogram"
+msgstr ""
+
+#: ../data/units.xml.in.h:478
+msgid "Power"
+msgstr ""
+
+#: ../data/units.xml.in.h:479
+msgid "Watt"
+msgstr ""
+
+#: ../data/units.xml.in.h:480
+msgid "ar:W,watt,p:watts"
+msgstr ""
+
+#: ../data/units.xml.in.h:481
+msgid "Horse Power"
+msgstr ""
+
+#: ../data/units.xml.in.h:482
+msgid "ar:hp,horsepower,p:horsepowers"
+msgstr ""
+
+#: ../data/units.xml.in.h:483
+msgid "Pferdest&#xE4;rke"
+msgstr ""
+
+#: ../data/units.xml.in.h:484
+msgid "ar:PS,u:pferdest&#xE4;rke"
+msgstr ""
+
+#: ../data/units.xml.in.h:485
+msgid "Decibel Milliwatt"
+msgstr ""
+
+#: ../data/units.xml.in.h:486
+msgid "ar:dBm"
+msgstr ""
+
+#: ../data/units.xml.in.h:487
+msgid "Decibel Watt"
+msgstr ""
+
+#: ../data/units.xml.in.h:488
+msgid "ar:dBW"
+msgstr ""
+
+#: ../data/units.xml.in.h:489
+msgid "Erg per Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:490
+msgid "Entropy"
+msgstr ""
+
+#: ../data/units.xml.in.h:491
+msgid "Joule per Kelvin"
+msgstr ""
+
+#: ../data/units.xml.in.h:492
+msgid "Boltzmann (unit)"
+msgstr ""
+
+#: ../data/units.xml.in.h:493
+msgid "Specific Entropy"
+msgstr ""
+
+#: ../data/units.xml.in.h:494
+msgid "Joule per Kilogram Kelvin"
+msgstr ""
+
+#: ../data/units.xml.in.h:495
+msgid "Thermal Conductivity"
+msgstr ""
+
+#: ../data/units.xml.in.h:496
+msgid "Watt per Meter Kelvin"
+msgstr ""
+
+#: ../data/units.xml.in.h:497
+msgid "Energy Density"
+msgstr ""
+
+#: ../data/units.xml.in.h:498
+msgid "Joule per Cubic Meter"
+msgstr ""
+
+#: ../data/units.xml.in.h:499
+msgid "Molar Energy"
+msgstr ""
+
+#: ../data/units.xml.in.h:500
+msgid "Joule per Mole"
+msgstr ""
+
+#: ../data/units.xml.in.h:501
+msgid "Molar Entropy"
+msgstr ""
+
+#: ../data/units.xml.in.h:502
+msgid "Joule per Mole Kelvin"
+msgstr ""
+
+#: ../data/units.xml.in.h:503
+msgid "Action"
+msgstr ""
+
+#: ../data/units.xml.in.h:504
+msgid "Joule Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:505
+msgid "Reduced Planck (Atomic/Natural Unit of Action)"
+msgstr ""
+
+#: ../data/units.xml.in.h:506
+msgid "Radioactivity"
+msgstr ""
+
+#: ../data/units.xml.in.h:507
+msgid "Becquerel"
+msgstr ""
+
+#: ../data/units.xml.in.h:508
+msgid "ar:Bq,becquerel,p:becquerels"
+msgstr ""
+
+#: ../data/units.xml.in.h:509
+msgid "Curie"
+msgstr ""
+
+#: ../data/units.xml.in.h:510
+msgid "ar:Ci,curie,p:curies"
+msgstr ""
+
+#: ../data/units.xml.in.h:511
+msgid "Rutherford"
+msgstr ""
+
+#: ../data/units.xml.in.h:512
+msgid "ar:Rd,rutherford,p:rutherfords"
+msgstr ""
+
+#: ../data/units.xml.in.h:513
+msgid "Absorbed Dose"
+msgstr ""
+
+#: ../data/units.xml.in.h:514
+msgid "Gray"
+msgstr ""
+
+#: ../data/units.xml.in.h:515
+msgid "ar:Gy,gray,p:grays"
+msgstr ""
+
+#: ../data/units.xml.in.h:516
+msgid "Rad"
+msgstr ""
+
+#: ../data/units.xml.in.h:517
+msgid "r:rad_radioactivity"
+msgstr ""
+
+#: ../data/units.xml.in.h:518
+msgid "Dose Equivalent"
+msgstr ""
+
+#: ../data/units.xml.in.h:519
+msgid "Sievert"
+msgstr ""
+
+#: ../data/units.xml.in.h:520
+msgid "ar:Sv,sievert,p:sieverts"
+msgstr ""
+
+#: ../data/units.xml.in.h:521
+msgid "Roentgen Equivalent Man (Rem)"
+msgstr ""
+
+#: ../data/units.xml.in.h:522
+msgid "ros:rem_radioactivity,a:rem"
+msgstr ""
+
+#: ../data/units.xml.in.h:523
+msgid "Millirem"
+msgstr ""
+
+#: ../data/units.xml.in.h:524
+msgid "Erg per Gram"
+msgstr ""
+
+#: ../data/units.xml.in.h:525
+msgid "Exposure"
+msgstr ""
+
+#: ../data/units.xml.in.h:526
+msgid "Coulomb per Kilogram"
+msgstr ""
+
+#: ../data/units.xml.in.h:527
+msgid "Roentgen"
+msgstr ""
+
+#: ../data/units.xml.in.h:528
+msgid "ar:R,roentgen,r&#x00f6;ntgen,p:roentgens,p:r&#x00f6;ntgens"
+msgstr ""
+
+#: ../data/units.xml.in.h:529
+msgid "Absorbed Dose Rate"
+msgstr ""
+
+#: ../data/units.xml.in.h:530
+msgid "Gray per Second"
+msgstr ""
+
+#: ../data/units.xml.in.h:531
+msgid "Millirem per hour"
+msgstr ""
+
+#: ../data/units.xml.in.h:532
+msgid "Ratio"
+msgstr ""
+
+#: ../data/units.xml.in.h:533
+msgid "Neper"
+msgstr ""
+
+#: ../data/units.xml.in.h:534
+msgid "ar:Np,neper,p:nepers"
+msgstr ""
+
+#: ../data/units.xml.in.h:535
+msgid "Bel"
+msgstr ""
+
+#: ../data/units.xml.in.h:536
+msgid "r:bel,p:bels"
+msgstr ""
+
+#: ../data/units.xml.in.h:537
+msgid "Decibel"
+msgstr ""
+
+#: ../data/units.xml.in.h:538
+msgid "ar:dB,decibel,p:decibels"
+msgstr ""
+
+#: ../data/units.xml.in.h:539
+msgid "Information"
+msgstr ""
+
+#: ../data/units.xml.in.h:540
+msgid "Bit"
+msgstr ""
+
+#: ../data/units.xml.in.h:541
+msgid "r:bit,p:bits"
+msgstr ""
+
+#: ../data/units.xml.in.h:542
+msgid "Byte (8-bit)"
+msgstr ""
+
+#: ../data/units.xml.in.h:543
+msgid "r:byte,a:B,p:bytes,octet,p:octets"
+msgstr ""
+
+#: ../data/units.xml.in.h:544
+msgid "Nibble"
+msgstr ""
+
+#: ../data/units.xml.in.h:545
+msgid "r:nibble,p:nibbles,nybble,p:nybbles,semioctet,p:semioctets"
+msgstr ""
+
+#: ../data/units.xml.in.h:546
+msgid "Tribble"
+msgstr ""
+
+#: ../data/units.xml.in.h:547
+msgid "r:tribble,p:tribbles"
+msgstr ""
+
+#: ../data/units.xml.in.h:548
+msgid "Word (16-bit)"
+msgstr ""
+
+#: ../data/units.xml.in.h:549
+msgid "r:word,p:words"
+msgstr ""
+
+#: ../data/units.xml.in.h:550
+msgid "Kilobyte"
+msgstr ""
+
+#: ../data/units.xml.in.h:551
+msgid "Kibibyte"
+msgstr ""
+
+#: ../data/units.xml.in.h:552
+msgid "Mebibyte"
+msgstr ""
+
+#: ../data/units.xml.in.h:553
+msgid "Gibibyte"
+msgstr ""
+
+#: ../data/units.xml.in.h:554
+msgid "Megabyte"
+msgstr ""
+
+#: ../data/units.xml.in.h:555
+msgid "Gigabyte"
+msgstr ""
+
+#: ../data/units.xml.in.h:556
+msgid "Terabyte"
+msgstr ""
+
+#: ../data/units.xml.in.h:557
+msgid "Kilobit"
+msgstr ""
+
+#: ../data/units.xml.in.h:558
+msgid "Kibibit"
+msgstr ""
+
+#: ../data/units.xml.in.h:559
+msgid "Mebibit"
+msgstr ""
+
+#: ../data/units.xml.in.h:560
+msgid "Gibibit"
+msgstr ""
+
+#: ../data/units.xml.in.h:561
+msgid "Megabit"
+msgstr ""
+
+#: ../data/units.xml.in.h:562
+msgid "Gigabit"
+msgstr ""
+
+#: ../data/units.xml.in.h:563
+msgid "Terabit"
+msgstr ""
+
+#: ../data/units.xml.in.h:564
+msgid "Typography"
+msgstr ""
+
+#: ../data/units.xml.in.h:565
+msgid "PostScript Point"
+msgstr ""
+
+#: ../data/units.xml.in.h:566
+msgid "ar:pt,a:pts,point,p:points"
+msgstr ""
+
+#: ../data/units.xml.in.h:567
+msgid "PostScript Pica"
+msgstr ""
+
+#: ../data/units.xml.in.h:568
+msgid "r:pica,p:picas"
+msgstr ""
+
+#: ../data/units.xml.in.h:569
+msgid "ATA Pica"
+msgstr ""
+
+#: ../data/units.xml.in.h:570
+msgid "r:ata_pica,p:ata_picas"
+msgstr ""
+
+#: ../data/units.xml.in.h:571
+msgid "ATA Point"
+msgstr ""
+
+#: ../data/units.xml.in.h:572
+msgid "r:ata_point,a:ata_pt,p:ata_points"
+msgstr ""
+
+#: ../data/units.xml.in.h:573
+msgid "New Didot Point"
+msgstr ""
+
+#: ../data/units.xml.in.h:574
+msgid "r:new_didot"
+msgstr ""
+
+#: ../data/units.xml.in.h:575
+msgid "Didot Point"
+msgstr ""
+
+#: ../data/units.xml.in.h:576
+msgid "r:didot,a:dd"
+msgstr ""
+
+#: ../data/units.xml.in.h:577
+msgid "Cicero"
+msgstr ""
+
+#: ../data/units.xml.in.h:578
+msgid "r:cicero"
+msgstr ""
+
+#: ../data/variables.xml.in.h:1
+msgid "Small Numbers"
+msgstr ""
+
+#: ../data/variables.xml.in.h:2
+msgid "Per Mille"
+msgstr ""
+
+#: ../data/variables.xml.in.h:3
+msgid "r:permille,au:&#x2030;"
+msgstr ""
+
+#: ../data/variables.xml.in.h:4
+msgid "Per Myriad"
+msgstr ""
+
+#: ../data/variables.xml.in.h:5
+msgid "r:permyriad,au:&#x2031;"
+msgstr ""
+
+#: ../data/variables.xml.in.h:6
+msgid "Percent"
+msgstr ""
+
+#: ../data/variables.xml.in.h:8
+#, no-c-format
+msgid "a:%,r:percent"
+msgstr ""
+
+#: ../data/variables.xml.in.h:9
+msgid "Large Numbers"
+msgstr ""
+
+#: ../data/variables.xml.in.h:10
+msgid "Googolplex"
+msgstr ""
+
+#: ../data/variables.xml.in.h:11
+msgid "r:googolplex"
+msgstr ""
+
+#: ../data/variables.xml.in.h:12
+msgid "Googol"
+msgstr ""
+
+#: ../data/variables.xml.in.h:13
+msgid "r:googol"
+msgstr ""
+
+#: ../data/variables.xml.in.h:14
+msgid "Centillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:15
+msgid "-r:centillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:16
+msgid "Vigintillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:17
+msgid "-r:vigintillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:18
+msgid "Novemdecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:19
+msgid "-r:novemdecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:20
+msgid "Octodecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:21
+msgid "-r:octodecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:22
+msgid "Septendecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:23
+msgid "-r:septendecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:24
+msgid "Sexdecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:25
+msgid "-r:sexdecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:26
+msgid "Quindecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:27
+msgid "-r:quindecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:28
+msgid "Quattuordecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:29
+msgid "-r:quattuordecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:30
+msgid "Tredecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:31
+msgid "-r:tredecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:32
+msgid "Duodecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:33
+msgid "-r:duodecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:34
+msgid "Undecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:35
+msgid "-r:undecillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:36
+msgid "Decillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:37
+msgid "-r:decillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:38
+msgid "Nonillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:39
+msgid "-r:nonillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:40
+msgid "Octillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:41
+msgid "-r:octillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:42
+msgid "Septillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:43
+msgid "-r:septillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:44
+msgid "Sextillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:45
+msgid "-r:sextillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:46
+msgid "Quintillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:47
+msgid "-r:quintillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:48
+msgid "Quadrillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:49
+msgid "-r:quadrillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:50
+msgid "Trillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:51
+msgid "-r:trillion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:52
+msgid "Billion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:53
+msgid "-r:billion"
+msgstr ""
+
+#: ../data/variables.xml.in.h:54
+msgid "Million"
+msgstr ""
+
+#: ../data/variables.xml.in.h:55
+msgid "-r:million"
+msgstr ""
+
+#: ../data/variables.xml.in.h:56
+msgid "Thousand"
+msgstr ""
+
+#: ../data/variables.xml.in.h:57
+msgid "-r:thousand"
+msgstr ""
+
+#: ../data/variables.xml.in.h:58
+msgid "Hundred"
+msgstr ""
+
+#: ../data/variables.xml.in.h:59
+msgid "-r:hundred"
+msgstr ""
+
+#: ../data/variables.xml.in.h:60
+msgid "Physical Constants"
+msgstr ""
+
+#: ../data/variables.xml.in.h:61
+msgid "Universal Constants"
+msgstr ""
+
+#: ../data/variables.xml.in.h:62
+msgid "Characteristic Impedance of Vacuum"
+msgstr ""
+
+#: ../data/variables.xml.in.h:63
+msgid "Electric Constant (Permittivity of Free Space)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:64
+msgid "Magnetic Constant (Permeability of Free Space)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:65
+msgid "Planck Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:66
+msgid "Reduced Planck Constant (Dirac constant)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:67
+msgid "Newtonian Constant of Gravitation"
+msgstr ""
+
+#: ../data/variables.xml.in.h:68
+msgid "Speed of Light in Vacuum"
+msgstr ""
+
+#: ../data/variables.xml.in.h:69
+msgid "Standard Acceleration due to Gravity"
+msgstr ""
+
+#: ../data/variables.xml.in.h:70
+msgid "Electromagnetic Constants"
+msgstr ""
+
+#: ../data/variables.xml.in.h:71
+msgid "Bohr Magneton"
+msgstr ""
+
+#: ../data/variables.xml.in.h:72
+msgid "Conductance Quantum"
+msgstr ""
+
+#: ../data/variables.xml.in.h:73
+msgid "Coulomb's Constant (Electric Force Constant)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:74
+msgid "Elementary Charge"
+msgstr ""
+
+#: ../data/variables.xml.in.h:75
+msgid "Inverse of Conductance Quantum"
+msgstr ""
+
+#: ../data/variables.xml.in.h:76
+msgid "Josephson Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:77
+msgid "Josephson Constant (conventional value)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:78
+msgid "Magnetic Flux Quantum"
+msgstr ""
+
+#: ../data/variables.xml.in.h:79
+msgid "Nuclear Magneton"
+msgstr ""
+
+#: ../data/variables.xml.in.h:80
+msgid "von Klitzing Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:81
+msgid "von Klitzing Constant (conventional value)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:82
+msgid "Particle Mass in u"
+msgstr ""
+
+#: ../data/variables.xml.in.h:83
+msgid "Deuteron Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:84
+msgid "Electron Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:85
+msgid "Helion Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:86
+msgid "Neutron Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:87
+msgid "Proton Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:88
+msgid "Tau Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:89
+msgid "Muon Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:90
+msgid "Triton Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:91
+msgid "Alpha Particle Mass (in u)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:92
+msgid "Particle Mass in MeV*c^(-2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:93
+msgid "Electron Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:94
+msgid "Neutron Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:95
+msgid "Proton Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:96
+msgid "Tau Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:97
+msgid "Muon Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:98
+msgid "Alpha Particle Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:99
+msgid "Up Quark Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:100
+msgid "Down Quark Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:101
+msgid "Charm Quark Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:102
+msgid "Strange Quark Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:103
+msgid "Top Quark Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:104
+msgid "Bottom Quark Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:105
+msgid "Higgs Boson Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:106
+msgid "W Boson Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:107
+msgid "Z Boson Mass (in MeV/c^2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:108
+msgid "Particle Mass in kg"
+msgstr ""
+
+#: ../data/variables.xml.in.h:109
+msgid "Deuteron Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:110
+msgid "Electron Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:111
+msgid "Helion Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:112
+msgid "Neutron Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:113
+msgid "Proton Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:114
+msgid "Tau Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:115
+msgid "Muon Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:116
+msgid "Triton Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:117
+msgid "Alpha Particle Mass"
+msgstr ""
+
+#: ../data/variables.xml.in.h:118
+msgid "Atomic and Nuclear Constants"
+msgstr ""
+
+#: ../data/variables.xml.in.h:119
+msgid "Bohr Radius"
+msgstr ""
+
+#: ../data/variables.xml.in.h:120
+msgid "Classical Electron Radius"
+msgstr ""
+
+#: ../data/variables.xml.in.h:121
+msgid "Fermi Coupling Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:122
+msgid "Fine-Structure Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:123
+msgid "Hartree Energy (constant)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:124
+msgid "Quantum of Circulation"
+msgstr ""
+
+#: ../data/variables.xml.in.h:125
+msgid "Quantum of Circulation times 2"
+msgstr ""
+
+#: ../data/variables.xml.in.h:126
+msgid "Rydberg Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:127
+msgid "Thomson cross section"
+msgstr ""
+
+#: ../data/variables.xml.in.h:128
+msgid "Weak Mixing Angle (Weinberg Angle)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:129
+msgid "W to Z Mass Ratio"
+msgstr ""
+
+#: ../data/variables.xml.in.h:130
+msgid "Physico-Chemical Constants"
+msgstr ""
+
+#: ../data/variables.xml.in.h:131
+msgid "Lattice Spacing of Ideal Silicon (220)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:132
+msgid "Atomic Mass Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:133
+msgid "Avogadro Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:134
+msgid "Boltzmann Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:135
+msgid "Molar Mass Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:136
+msgid "Compton Wavelength"
+msgstr ""
+
+#: ../data/variables.xml.in.h:137
+msgid "Reduced Compton Wavelength"
+msgstr ""
+
+#: ../data/variables.xml.in.h:138
+msgid "Electronvolt (constant)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:139
+msgid "Faraday Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:140
+msgid "First Radiation Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:141
+msgid "First Radiation Constant for Spectral Radiance"
+msgstr ""
+
+#: ../data/variables.xml.in.h:142
+msgid "Gas Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:143
+msgid "Lattice Parameter of Silicon"
+msgstr ""
+
+#: ../data/variables.xml.in.h:144
+msgid "Loschmidt Constant (273.15 K, 100 kPa)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:145
+msgid "Loschmidt Constant (273.15 K, 101.325 kPa)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:146
+msgid "Molar Planck Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:147
+msgid "Molar Volume of Ideal Gas (273.15 K, 100 kPa)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:148
+msgid "Molar Volume of Ideal Gas (273.15 K, 101.325 kPa)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:149
+msgid "Sackur-Tetrode constant (1 K, 100 kPa)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:150
+msgid "Sackur-Tetrode constant (1 K, 101.325 kPa)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:151
+msgid "Second Radiation Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:152
+msgid "Stefan-Boltzmann Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:153
+msgid "Wien frequency displacement law constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:154
+msgid "Wien wavelength displacement law constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:155
+msgid "Conversion factors for energy equivalents"
+msgstr ""
+
+#: ../data/variables.xml.in.h:156
+msgid "Hertz - Inverse Meter Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:157
+msgid "Hertz - Joule Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:158
+msgid "Hertz - Kelvin Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:159
+msgid "Hertz - Kilogram Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:160
+msgid "Inverse Meter - Hertz Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:161
+msgid "Inverse Meter - Joule Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:162
+msgid "Inverse Meter - Kelvin Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:163
+msgid "Inverse Meter - Kilogram Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:164
+msgid "Joule - Hertz Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:165
+msgid "Joule - Inverse Meter Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:166
+msgid "Joule - Kelvin Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:167
+msgid "Joule - Kilogram Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:168
+msgid "Kelvin - Hertz Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:169
+msgid "Kelvin - Inverse Meter Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:170
+msgid "Kelvin - Joule Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:171
+msgid "Kelvin - Kilogram Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:172
+msgid "Kilogram - Hertz Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:173
+msgid "Kilogram - Inverse Meter Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:174
+msgid "Kilogram - Joule Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:175
+msgid "Kilogram - Kelvin Relationship"
+msgstr ""
+
+#: ../data/variables.xml.in.h:176
+msgid "Basic Constants"
+msgstr ""
+
+#: ../data/variables.xml.in.h:177
+msgid "Golden Ratio"
+msgstr ""
+
+#: ../data/variables.xml.in.h:178
+msgid "Omega Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:179
+msgid "Pythagoras' Constant (sqrt 2)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:180
+msgid "Apery's Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:181
+msgid "Tau (2pi)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:182
+msgid "Base of Natural Logarithms (e)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:183
+msgid "Archimedes' Constant (pi)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:184
+msgid "Euler's Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:185
+msgid "Catalan's Constant"
+msgstr ""
+
+#: ../data/variables.xml.in.h:186
+msgid "Special Numbers"
+msgstr ""
+
+#: ../data/variables.xml.in.h:187
+msgid "Imaginary i (sqrt -1)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:188
+msgid "Positive Infinity"
+msgstr ""
+
+#: ../data/variables.xml.in.h:189
+msgid "a:&#x221E;,r:plus_infinity,r:infinity"
+msgstr ""
+
+#: ../data/variables.xml.in.h:190
+msgid "Negative Infinity"
+msgstr ""
+
+#: ../data/variables.xml.in.h:191
+msgid "r:minus_infinity"
+msgstr ""
+
+#: ../data/variables.xml.in.h:192
+msgid "Undefined"
+msgstr ""
+
+#: ../data/variables.xml.in.h:193
+msgid "r:undefined"
+msgstr ""
+
+#: ../data/variables.xml.in.h:194
+msgid "False"
+msgstr ""
+
+#: ../data/variables.xml.in.h:195
+msgid "r:false,r:no"
+msgstr ""
+
+#: ../data/variables.xml.in.h:196
+msgid "True"
+msgstr ""
+
+#: ../data/variables.xml.in.h:197
+msgid "r:true,r:yes"
+msgstr ""
+
+#: ../data/variables.xml.in.h:200
+msgid "r:precision"
+msgstr ""
+
+#: ../data/variables.xml.in.h:201
+msgid "System Uptime"
+msgstr ""
+
+#: ../data/variables.xml.in.h:202
+msgid "r:uptime"
+msgstr ""
+
+#: ../data/variables.xml.in.h:203
+msgid "Unknowns"
+msgstr ""
+
+#: ../data/variables.xml.in.h:204
+msgid "n (integer)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:206
+msgid "Today"
+msgstr ""
+
+#: ../data/variables.xml.in.h:207
+msgid "r:today"
+msgstr ""
+
+#: ../data/variables.xml.in.h:208
+msgid "Tomorrow"
+msgstr ""
+
+#: ../data/variables.xml.in.h:209
+msgid "r:tomorrow"
+msgstr ""
+
+#: ../data/variables.xml.in.h:210
+msgid "Yesterday"
+msgstr ""
+
+#: ../data/variables.xml.in.h:211
+msgid "r:yesterday"
+msgstr ""
+
+#: ../data/variables.xml.in.h:212
+msgid "Now (date and time)"
+msgstr ""
+
+#: ../data/variables.xml.in.h:213
+msgid "r:now"
+msgstr ""

--- a/po-defs/fixed/Makefile.am
+++ b/po-defs/fixed/Makefile.am
@@ -2,6 +2,6 @@
 # po-defs/fixed/Makefile.am for qalculate
 #
 
-noinst_DATA = es.po fr.po nl.po ru.po sv.po zh_CN.po
+noinst_DATA = ca.po es.po fr.po nl.po ru.po sv.po zh_CN.po
 
 @QALCULATE_PODEFS_RULE@

--- a/po/ca.po
+++ b/po/ca.po
@@ -1,0 +1,4104 @@
+# Catalan translations for libqalculate package.
+# Copyright (C) 2021 THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the libqalculate package.
+# Alex Henrie <alexhenrie24@gmail.com>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: libqalculate\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-25 02:11-0600\n"
+"PO-Revision-Date: 2021-05-25 09:48-0600\n"
+"Last-Translator: Alex Henrie <alexhenrie24@gmail.com>\n"
+"Language-Team: Catalan <ca@dodds.net>\n"
+"Language: ca\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.4.3\n"
+
+#: ../src/defs2doc.cc:333 ../src/qalc.cc:3849 ../libqalculate/Function.cc:222
+#: ../libqalculate/Function.cc:1370
+msgid "argument"
+msgstr ""
+
+#: ../src/defs2doc.cc:356 ../src/qalc.cc:3872
+#, c-format
+msgid ""
+"Retrieves data from the %s data set for a given object and property. If "
+"\"info\" is typed as property, all properties of the object will be listed."
+msgstr ""
+"Obté dades del conjunt de dades %s per a un objecte i propietat donats. Si "
+"\"info\" és de tipus propietat, es llistaran totes les propietats de "
+"l'objecte."
+
+#: ../src/defs2doc.cc:363 ../src/qalc.cc:3881
+msgid "Example:"
+msgstr "Exemple:"
+
+#: ../src/defs2doc.cc:371 ../src/qalc.cc:3890
+msgid "Arguments"
+msgstr ""
+
+#. optional argument, in description
+#: ../src/defs2doc.cc:388 ../src/qalc.cc:3912
+msgid "optional"
+msgstr ""
+
+#. argument default, in description
+#: ../src/defs2doc.cc:391 ../src/qalc.cc:3916
+msgid "default: "
+msgstr ""
+
+#: ../src/defs2doc.cc:404 ../src/qalc.cc:3927
+msgid "Requirement"
+msgstr ""
+
+#: ../src/defs2doc.cc:413 ../src/qalc.cc:3940
+msgid "Properties"
+msgstr ""
+
+#: ../src/defs2doc.cc:429 ../src/qalc.cc:3955
+msgid "key"
+msgstr ""
+
+#: ../src/defs2doc.cc:461 ../src/qalc.cc:4074
+msgid "a previous result"
+msgstr ""
+
+#: ../src/defs2doc.cc:463
+msgid "result of memory operations (MC, MS, M+, M−)"
+msgstr ""
+
+#: ../src/defs2doc.cc:466
+msgid "current precision"
+msgstr ""
+
+#: ../src/defs2doc.cc:468
+msgid "current date"
+msgstr ""
+
+#: ../src/defs2doc.cc:470
+msgid "tomorrow's date"
+msgstr ""
+
+#: ../src/defs2doc.cc:472
+msgid "yesterday's date"
+msgstr ""
+
+#: ../src/defs2doc.cc:474
+msgid "current date and time"
+msgstr ""
+
+#: ../src/defs2doc.cc:476
+msgid "current computer uptime"
+msgstr ""
+
+#: ../src/defs2doc.cc:480 ../src/defs2doc.cc:579 ../src/qalc.cc:1722
+msgid "relative uncertainty"
+msgstr ""
+
+#: ../src/defs2doc.cc:495 ../src/qalc.cc:1744 ../src/qalc.cc:4081
+#: ../libqalculate/Function.cc:2142
+msgid "matrix"
+msgstr ""
+
+#: ../src/defs2doc.cc:497 ../src/qalc.cc:1746 ../src/qalc.cc:4083
+#: ../libqalculate/Function.cc:2078
+msgid "vector"
+msgstr ""
+
+#: ../src/defs2doc.cc:505 ../src/qalc.cc:289 ../src/qalc.cc:743
+#: ../src/qalc.cc:1764 ../src/qalc.cc:3401 ../src/qalc.cc:4094
+#: ../src/qalc.cc:4241 ../src/qalc.cc:4479
+msgid "positive"
+msgstr ""
+
+#: ../src/defs2doc.cc:506 ../src/qalc.cc:295 ../src/qalc.cc:744
+#: ../src/qalc.cc:1765 ../src/qalc.cc:3402 ../src/qalc.cc:4095
+#: ../src/qalc.cc:4245 ../src/qalc.cc:4483
+msgid "non-positive"
+msgstr ""
+
+#: ../src/defs2doc.cc:507 ../src/qalc.cc:293 ../src/qalc.cc:745
+#: ../src/qalc.cc:1766 ../src/qalc.cc:3403 ../src/qalc.cc:4096
+#: ../src/qalc.cc:4243 ../src/qalc.cc:4481
+msgid "negative"
+msgstr ""
+
+#: ../src/defs2doc.cc:508 ../src/qalc.cc:291 ../src/qalc.cc:746
+#: ../src/qalc.cc:1767 ../src/qalc.cc:3404 ../src/qalc.cc:4097
+#: ../src/qalc.cc:4247 ../src/qalc.cc:4485
+msgid "non-negative"
+msgstr ""
+
+#: ../src/defs2doc.cc:509 ../src/qalc.cc:287 ../src/qalc.cc:747
+#: ../src/qalc.cc:1768 ../src/qalc.cc:3405 ../src/qalc.cc:4098
+#: ../src/qalc.cc:4239 ../src/qalc.cc:4477
+msgid "non-zero"
+msgstr ""
+
+#: ../src/defs2doc.cc:514 ../src/qalc.cc:283 ../src/qalc.cc:753
+#: ../src/qalc.cc:1774 ../src/qalc.cc:3411 ../src/qalc.cc:4104
+#: ../src/qalc.cc:4255 ../src/qalc.cc:4493 ../libqalculate/Function.cc:1934
+msgid "integer"
+msgstr ""
+
+#: ../src/defs2doc.cc:515 ../src/qalc.cc:281 ../src/qalc.cc:755
+#: ../src/qalc.cc:1776 ../src/qalc.cc:3413 ../src/qalc.cc:4106
+#: ../src/qalc.cc:4253 ../src/qalc.cc:4491
+msgid "rational"
+msgstr ""
+
+#: ../src/defs2doc.cc:516 ../src/qalc.cc:277 ../src/qalc.cc:756
+#: ../src/qalc.cc:1777 ../src/qalc.cc:3414 ../src/qalc.cc:4107
+#: ../src/qalc.cc:4251 ../src/qalc.cc:4489
+msgid "real"
+msgstr ""
+
+#: ../src/defs2doc.cc:517 ../src/qalc.cc:757 ../src/qalc.cc:1778
+#: ../src/qalc.cc:3415 ../src/qalc.cc:4108
+msgid "complex"
+msgstr ""
+
+#: ../src/defs2doc.cc:518 ../src/qalc.cc:279 ../src/qalc.cc:758
+#: ../src/qalc.cc:1779 ../src/qalc.cc:3416 ../src/qalc.cc:4109
+#: ../src/qalc.cc:4249 ../src/qalc.cc:4487 ../libqalculate/Function.cc:1773
+msgid "number"
+msgstr ""
+
+#: ../src/defs2doc.cc:519 ../src/qalc.cc:759 ../src/qalc.cc:1780
+#: ../src/qalc.cc:3417 ../src/qalc.cc:4110
+msgid "non-matrix"
+msgstr ""
+
+#: ../src/defs2doc.cc:522 ../src/qalc.cc:271 ../src/qalc.cc:762
+#: ../src/qalc.cc:1783 ../src/qalc.cc:3420 ../src/qalc.cc:4113
+#: ../src/qalc.cc:4237 ../src/qalc.cc:4475
+msgid "unknown"
+msgstr ""
+
+#: ../src/defs2doc.cc:524 ../src/qalc.cc:1785 ../src/qalc.cc:4115
+msgid "default assumptions"
+msgstr ""
+
+#: ../src/defs2doc.cc:530
+msgid "variable precision"
+msgstr ""
+
+#. qalc command
+#: ../src/defs2doc.cc:534 ../src/defs2doc.cc:586 ../src/qalc.cc:1005
+#: ../src/qalc.cc:1738 ../src/qalc.cc:1755 ../src/qalc.cc:2980
+#: ../src/qalc.cc:3445 ../src/qalc.cc:3722 ../src/qalc.cc:4024
+#: ../src/qalc.cc:4034 ../src/qalc.cc:4141 ../src/qalc.cc:4268
+#: ../src/qalc.cc:4607 ../src/qalc.cc:4698
+msgid "approximate"
+msgstr ""
+
+#: ../src/defs2doc.cc:623 ../src/qalc.cc:2232
+msgid "ans"
+msgstr ""
+
+#: ../src/defs2doc.cc:624 ../src/defs2doc.cc:627 ../src/defs2doc.cc:628
+#: ../src/defs2doc.cc:629 ../src/defs2doc.cc:630
+#: ../libqalculate/Calculator-definitions.cc:2326
+#: ../libqalculate/Calculator-definitions.cc:2342
+msgid "Temporary"
+msgstr ""
+
+#: ../src/defs2doc.cc:624 ../src/qalc.cc:2233
+msgid "Last Answer"
+msgstr ""
+
+#: ../src/defs2doc.cc:625 ../src/qalc.cc:2234
+msgid "answer"
+msgstr ""
+
+#: ../src/defs2doc.cc:627 ../src/qalc.cc:2236
+msgid "Answer 2"
+msgstr ""
+
+#: ../src/defs2doc.cc:628 ../src/qalc.cc:2237
+msgid "Answer 3"
+msgstr ""
+
+#: ../src/defs2doc.cc:629 ../src/qalc.cc:2238
+msgid "Answer 4"
+msgstr ""
+
+#: ../src/defs2doc.cc:630 ../src/qalc.cc:2239
+msgid "Answer 5"
+msgstr ""
+
+#: ../src/defs2doc.cc:631 ../src/qalc.cc:2249
+msgid "Memory"
+msgstr ""
+
+#: ../src/defs2doc.cc:643
+#, c-format
+msgid "Failed to load global definitions!\n"
+msgstr "S'ha fallat en carregar les definicions globals!\n"
+
+#: ../src/defs2doc.cc:694 ../src/defs2doc.cc:761 ../src/defs2doc.cc:762
+#: ../src/defs2doc.cc:763 ../src/defs2doc.cc:845 ../src/defs2doc.cc:846
+#: ../src/defs2doc.cc:847
+msgid "Uncategorized"
+msgstr ""
+
+#: ../src/qalc.cc:189 ../src/qalc.cc:257 ../src/qalc.cc:4214
+#: ../libqalculate/util.cc:175
+msgid "yes"
+msgstr ""
+
+#: ../src/qalc.cc:190 ../src/qalc.cc:259 ../src/qalc.cc:4214
+#: ../libqalculate/util.cc:176
+msgid "no"
+msgstr ""
+
+#: ../src/qalc.cc:191 ../libqalculate/util.cc:183
+msgid "true"
+msgstr ""
+
+#: ../src/qalc.cc:192 ../libqalculate/util.cc:184
+msgid "false"
+msgstr ""
+
+#: ../src/qalc.cc:193 ../src/qalc.cc:869 ../src/qalc.cc:891 ../src/qalc.cc:1217
+#: ../src/qalc.cc:1258 ../src/qalc.cc:1403 ../src/qalc.cc:3550
+#: ../src/qalc.cc:3568 ../src/qalc.cc:3627 ../src/qalc.cc:4213
+#: ../src/qalc.cc:4335 ../src/qalc.cc:4344 ../src/qalc.cc:4395
+#: ../libqalculate/util.cc:191
+msgid "on"
+msgstr ""
+
+#: ../src/qalc.cc:194 ../src/qalc.cc:867 ../src/qalc.cc:890 ../src/qalc.cc:1125
+#: ../src/qalc.cc:1189 ../src/qalc.cc:1201 ../src/qalc.cc:1214
+#: ../src/qalc.cc:1256 ../src/qalc.cc:1399 ../src/qalc.cc:3476
+#: ../src/qalc.cc:3549 ../src/qalc.cc:3554 ../src/qalc.cc:3566
+#: ../src/qalc.cc:3596 ../src/qalc.cc:3603 ../src/qalc.cc:3610
+#: ../src/qalc.cc:3626 ../src/qalc.cc:3662 ../src/qalc.cc:4213
+#: ../src/qalc.cc:4290 ../src/qalc.cc:4333 ../src/qalc.cc:4339
+#: ../src/qalc.cc:4344 ../src/qalc.cc:4352 ../src/qalc.cc:4359
+#: ../src/qalc.cc:4369 ../src/qalc.cc:4393 ../src/qalc.cc:4428
+#: ../libqalculate/util.cc:192
+msgid "off"
+msgstr ""
+
+#: ../src/qalc.cc:264
+msgid "Please answer yes or no"
+msgstr "Si us plau, responeu amb yes o no"
+
+#: ../src/qalc.cc:285 ../src/qalc.cc:754 ../src/qalc.cc:1775
+#: ../src/qalc.cc:3412 ../src/qalc.cc:4105 ../src/qalc.cc:4257
+#: ../src/qalc.cc:4495 ../libqalculate/Function.cc:2232
+msgid "boolean"
+msgstr ""
+
+#: ../src/qalc.cc:298
+msgid "Unrecognized assumption."
+msgstr "La suposició no s'ha reconegut."
+
+#. logical operator
+#: ../src/qalc.cc:463 ../src/qalc.cc:497
+#: ../libqalculate/Calculator-calculate.cc:1003
+#: ../libqalculate/Calculator.cc:253 ../libqalculate/Calculator.cc:482
+#: ../libqalculate/DataSet.cc:1113 ../libqalculate/DataSet.cc:1175
+#: ../libqalculate/MathStructure-print.cc:3484 ../libqalculate/Function.cc:2302
+#: ../libqalculate/Function.cc:2318
+msgid "or"
+msgstr ""
+
+#: ../src/qalc.cc:585 ../libqalculate/Calculator-definitions.cc:3995
+#, c-format
+msgid "It has been %s day since the exchange rates last were updated."
+msgid_plural "It has been %s days since the exchange rates last were updated."
+msgstr[0] "Fa %s dia que es van actualitzar les tarifes d'intercanvi."
+msgstr[1] "Fa %s dies que es van actualitzar les tarifes d'intercanvi."
+
+#: ../src/qalc.cc:590
+msgid "Do you wish to update the exchange rates now?"
+msgstr "Voleu actualitzar les tarifes d'intercanvi ara?"
+
+#: ../src/qalc.cc:604 ../src/qalc.cc:605
+msgid ""
+"\n"
+"Press Enter to continue."
+msgstr ""
+"\n"
+"Premeu Retorn per a continuar."
+
+#: ../src/qalc.cc:620 ../src/qalc.cc:621 ../src/qalc.cc:622 ../src/qalc.cc:623
+#: ../src/qalc.cc:624 ../src/qalc.cc:625 ../src/qalc.cc:774 ../src/qalc.cc:785
+#: ../src/qalc.cc:810 ../src/qalc.cc:858 ../src/qalc.cc:875 ../src/qalc.cc:897
+#: ../src/qalc.cc:908 ../src/qalc.cc:913 ../src/qalc.cc:934 ../src/qalc.cc:954
+#: ../src/qalc.cc:980 ../src/qalc.cc:994 ../src/qalc.cc:1010
+#: ../src/qalc.cc:1032 ../src/qalc.cc:1059 ../src/qalc.cc:1075
+#: ../src/qalc.cc:1084 ../src/qalc.cc:1095 ../src/qalc.cc:1107
+#: ../src/qalc.cc:1116 ../src/qalc.cc:1136 ../src/qalc.cc:1142
+#: ../src/qalc.cc:1166 ../src/qalc.cc:1225 ../src/qalc.cc:1247
+#: ../src/qalc.cc:1263 ../src/qalc.cc:2775 ../src/qalc.cc:2924
+msgid "Illegal value."
+msgstr "El valor és il·legal."
+
+#. qalc command
+#: ../src/qalc.cc:655 ../src/qalc.cc:1044 ../src/qalc.cc:2752
+#: ../src/qalc.cc:3295 ../src/qalc.cc:3301 ../src/qalc.cc:3505
+#: ../src/qalc.cc:3680 ../src/qalc.cc:3724 ../src/qalc.cc:4302
+#: ../src/qalc.cc:4440 ../src/qalc.cc:4599 ../src/qalc.cc:4705
+#: ../src/qalc.cc:5677 ../src/qalc.cc:5681
+#: ../libqalculate/Calculator-calculate.cc:1538
+#: ../libqalculate/Calculator-calculate.cc:1542
+msgid "base"
+msgstr ""
+
+#: ../src/qalc.cc:655 ../src/qalc.cc:657 ../src/qalc.cc:3636
+#: ../src/qalc.cc:4406
+msgid "input base"
+msgstr ""
+
+#: ../src/qalc.cc:655 ../src/qalc.cc:658
+msgid "output base"
+msgstr ""
+
+#: ../src/qalc.cc:659 ../src/qalc.cc:3031 ../src/qalc.cc:3507
+#: ../src/qalc.cc:3638 ../src/qalc.cc:4314 ../src/qalc.cc:4414
+#: ../src/qalc.cc:5581 ../libqalculate/Calculator-calculate.cc:1446
+msgid "roman"
+msgstr ""
+
+#: ../src/qalc.cc:660 ../src/qalc.cc:3036 ../src/qalc.cc:3508
+#: ../src/qalc.cc:3639 ../src/qalc.cc:5583
+#: ../libqalculate/Calculator-calculate.cc:1448
+msgid "bijective"
+msgstr ""
+
+#: ../src/qalc.cc:666 ../src/qalc.cc:3101 ../src/qalc.cc:3521
+#: ../src/qalc.cc:4312 ../src/qalc.cc:5609
+#: ../libqalculate/Calculator-calculate.cc:1474
+msgid "time"
+msgstr ""
+
+#: ../src/qalc.cc:667 ../src/qalc.cc:3006 ../src/qalc.cc:5571
+#: ../libqalculate/Calculator-calculate.cc:1436
+msgid "hexadecimal"
+msgstr ""
+
+#: ../src/qalc.cc:674 ../src/qalc.cc:3026 ../src/qalc.cc:5579
+#: ../libqalculate/Calculator-calculate.cc:1444
+msgid "duodecimal"
+msgstr ""
+
+#: ../src/qalc.cc:675 ../src/qalc.cc:3011 ../src/qalc.cc:5573
+#: ../libqalculate/Calculator-calculate.cc:1438
+msgid "binary"
+msgstr ""
+
+#: ../src/qalc.cc:676 ../src/qalc.cc:3021 ../src/qalc.cc:5577
+#: ../libqalculate/Calculator-calculate.cc:1442
+msgid "octal"
+msgstr ""
+
+#: ../src/qalc.cc:677 ../src/qalc.cc:3016 ../src/qalc.cc:5575
+#: ../libqalculate/Calculator-calculate.cc:1440
+msgid "decimal"
+msgstr ""
+
+#: ../src/qalc.cc:678 ../src/qalc.cc:679 ../src/qalc.cc:680 ../src/qalc.cc:3041
+#: ../src/qalc.cc:3046 ../src/qalc.cc:3051 ../src/qalc.cc:3509
+#: ../src/qalc.cc:3510 ../src/qalc.cc:3511 ../src/qalc.cc:5585
+#: ../src/qalc.cc:5587 ../src/qalc.cc:5589
+#: ../libqalculate/Calculator-calculate.cc:1450
+#: ../libqalculate/Calculator-calculate.cc:1452
+#: ../libqalculate/Calculator-calculate.cc:1454
+msgid "sexagesimal"
+msgstr ""
+
+#: ../src/qalc.cc:681 ../src/qalc.cc:682 ../src/qalc.cc:3066
+#: ../src/qalc.cc:3071 ../src/qalc.cc:3512 ../src/qalc.cc:3513
+#: ../src/qalc.cc:5595 ../src/qalc.cc:5597
+#: ../libqalculate/Calculator-calculate.cc:1460
+#: ../libqalculate/Calculator-calculate.cc:1462
+msgid "latitude"
+msgstr ""
+
+#: ../src/qalc.cc:683 ../src/qalc.cc:684 ../src/qalc.cc:3056
+#: ../src/qalc.cc:3061 ../src/qalc.cc:3514 ../src/qalc.cc:3515
+#: ../src/qalc.cc:5591 ../src/qalc.cc:5593
+#: ../libqalculate/Calculator-calculate.cc:1456
+#: ../libqalculate/Calculator-calculate.cc:1458
+msgid "longitude"
+msgstr ""
+
+#: ../src/qalc.cc:694 ../src/qalc.cc:849 ../src/qalc.cc:3532
+#: ../src/qalc.cc:4326
+msgid "base display"
+msgstr ""
+
+#: ../src/qalc.cc:724
+msgid "Illegal base."
+msgstr ""
+
+#: ../src/qalc.cc:732 ../src/qalc.cc:763 ../src/qalc.cc:3421
+#: ../src/qalc.cc:4234
+msgid "assumptions"
+msgstr ""
+
+#: ../src/qalc.cc:766 ../src/qalc.cc:3671 ../src/qalc.cc:4432
+msgid "all prefixes"
+msgstr ""
+
+#: ../src/qalc.cc:767 ../src/qalc.cc:3474 ../src/qalc.cc:4290
+msgid "color"
+msgstr ""
+
+#. light color
+#: ../src/qalc.cc:770 ../src/qalc.cc:3477 ../src/qalc.cc:4290
+msgid "light"
+msgstr ""
+
+#: ../src/qalc.cc:771 ../src/qalc.cc:3478 ../src/qalc.cc:4290
+#: ../src/qalc.cc:5390 ../src/qalc.cc:5465 ../src/qalc.cc:5471
+msgid "default"
+msgstr ""
+
+#: ../src/qalc.cc:779 ../src/qalc.cc:3463 ../src/qalc.cc:4279
+msgid "complex numbers"
+msgstr ""
+
+#: ../src/qalc.cc:780 ../src/qalc.cc:3488 ../src/qalc.cc:4292
+msgid "excessive parentheses"
+msgstr ""
+
+#: ../src/qalc.cc:781 ../src/qalc.cc:3464 ../src/qalc.cc:3783
+#: ../src/qalc.cc:3789 ../src/qalc.cc:4280
+msgid "functions"
+msgstr ""
+
+#: ../src/qalc.cc:782 ../src/qalc.cc:3465 ../src/qalc.cc:4281
+msgid "infinite numbers"
+msgstr ""
+
+#: ../src/qalc.cc:783 ../src/qalc.cc:3689 ../src/qalc.cc:4453
+msgid "show negative exponents"
+msgstr ""
+
+#: ../src/qalc.cc:784 ../src/qalc.cc:3489 ../src/qalc.cc:4293
+msgid "minus last"
+msgstr ""
+
+#: ../src/qalc.cc:786 ../src/qalc.cc:3396 ../src/qalc.cc:4231
+msgid "assume nonzero denominators"
+msgstr ""
+
+#: ../src/qalc.cc:787 ../src/qalc.cc:3397 ../src/qalc.cc:4232
+msgid "warn nonzero denominators"
+msgstr ""
+
+#: ../src/qalc.cc:788 ../src/qalc.cc:3688 ../src/qalc.cc:3786
+#: ../src/qalc.cc:3792 ../src/qalc.cc:4452
+msgid "prefixes"
+msgstr ""
+
+#: ../src/qalc.cc:789 ../src/qalc.cc:3684 ../src/qalc.cc:4448
+msgid "binary prefixes"
+msgstr ""
+
+#: ../src/qalc.cc:796 ../src/qalc.cc:3686 ../src/qalc.cc:4450
+msgid "denominator prefixes"
+msgstr ""
+
+#: ../src/qalc.cc:797 ../src/qalc.cc:3687 ../src/qalc.cc:4451
+msgid "place units separately"
+msgstr ""
+
+#: ../src/qalc.cc:798 ../src/qalc.cc:3462 ../src/qalc.cc:4278
+msgid "calculate variables"
+msgstr ""
+
+#: ../src/qalc.cc:799 ../src/qalc.cc:3461 ../src/qalc.cc:4277
+msgid "calculate functions"
+msgstr ""
+
+#: ../src/qalc.cc:800 ../src/qalc.cc:3690 ../src/qalc.cc:4454
+msgid "sync units"
+msgstr ""
+
+#: ../src/qalc.cc:801 ../src/qalc.cc:3691 ../src/qalc.cc:4455
+msgid "temperature calculation"
+msgstr ""
+
+#: ../src/qalc.cc:803 ../src/qalc.cc:3693 ../src/qalc.cc:4455
+#: ../src/qalc.cc:5404 ../src/qalc.cc:5426
+msgid "relative"
+msgstr ""
+
+#: ../src/qalc.cc:804 ../src/qalc.cc:3695 ../src/qalc.cc:4455
+#: ../src/qalc.cc:5390 ../src/qalc.cc:5427
+msgid "hybrid"
+msgstr ""
+
+#: ../src/qalc.cc:805 ../src/qalc.cc:3694 ../src/qalc.cc:4455
+#: ../src/qalc.cc:5397 ../src/qalc.cc:5428
+msgid "absolute"
+msgstr ""
+
+#: ../src/qalc.cc:816 ../src/qalc.cc:3607 ../src/qalc.cc:4365
+msgid "round to even"
+msgstr ""
+
+#: ../src/qalc.cc:817
+msgid "rpn syntax"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:829 ../src/qalc.cc:949 ../src/qalc.cc:2755
+#: ../src/qalc.cc:3657 ../src/qalc.cc:3709 ../src/qalc.cc:3747
+#: ../src/qalc.cc:4427 ../src/qalc.cc:4467 ../src/qalc.cc:4549
+#: ../src/qalc.cc:4680 ../src/qalc.cc:4705
+msgid "rpn"
+msgstr ""
+
+#: ../src/qalc.cc:830 ../src/qalc.cc:3498 ../src/qalc.cc:4295
+msgid "short multiplication"
+msgstr ""
+
+#: ../src/qalc.cc:831 ../src/qalc.cc:3590 ../src/qalc.cc:4348
+msgid "lowercase e"
+msgstr ""
+
+#: ../src/qalc.cc:832 ../src/qalc.cc:3591 ../src/qalc.cc:4349
+msgid "lowercase numbers"
+msgstr ""
+
+#: ../src/qalc.cc:833 ../src/qalc.cc:3574 ../src/qalc.cc:3635
+#: ../src/qalc.cc:4346 ../src/qalc.cc:4405
+msgid "imaginary j"
+msgstr ""
+
+#: ../src/qalc.cc:851 ../src/qalc.cc:868 ../src/qalc.cc:929 ../src/qalc.cc:1040
+#: ../src/qalc.cc:1068 ../src/qalc.cc:3391 ../src/qalc.cc:3430
+#: ../src/qalc.cc:3451 ../src/qalc.cc:3534 ../src/qalc.cc:3676
+#: ../src/qalc.cc:4264 ../src/qalc.cc:4326 ../src/qalc.cc:4436
+msgid "none"
+msgstr ""
+
+#: ../src/qalc.cc:852 ../src/qalc.cc:3535 ../src/qalc.cc:4326
+msgid "normal"
+msgstr ""
+
+#: ../src/qalc.cc:853 ../src/qalc.cc:3536 ../src/qalc.cc:4326
+msgid "alternative"
+msgstr ""
+
+#: ../src/qalc.cc:863 ../src/qalc.cc:3619 ../src/qalc.cc:4383
+msgid "two's complement"
+msgstr ""
+
+#: ../src/qalc.cc:864 ../src/qalc.cc:3573 ../src/qalc.cc:4345
+msgid "hexadecimal two's"
+msgstr ""
+
+#: ../src/qalc.cc:865 ../src/qalc.cc:3552 ../src/qalc.cc:4339
+msgid "digit grouping"
+msgstr ""
+
+#: ../src/qalc.cc:869 ../src/qalc.cc:3555 ../src/qalc.cc:4339
+msgid "standard"
+msgstr ""
+
+#: ../src/qalc.cc:870 ../src/qalc.cc:892 ../src/qalc.cc:3548
+#: ../src/qalc.cc:3556 ../src/qalc.cc:3625 ../src/qalc.cc:4331
+#: ../src/qalc.cc:4339 ../src/qalc.cc:4391
+msgid "locale"
+msgstr ""
+
+#: ../src/qalc.cc:880 ../src/qalc.cc:3500 ../src/qalc.cc:4297
+msgid "spell out logical"
+msgstr ""
+
+#: ../src/qalc.cc:881 ../src/qalc.cc:3633 ../src/qalc.cc:4403
+msgid "ignore dot"
+msgstr ""
+
+#: ../src/qalc.cc:884 ../src/qalc.cc:3630 ../src/qalc.cc:4400
+msgid "ignore comma"
+msgstr ""
+
+#: ../src/qalc.cc:888 ../src/qalc.cc:3547 ../src/qalc.cc:3624
+#: ../src/qalc.cc:4328 ../src/qalc.cc:4388
+msgid "decimal comma"
+msgstr ""
+
+#: ../src/qalc.cc:907 ../src/qalc.cc:3650 ../src/qalc.cc:4426
+msgid "limit implicit multiplication"
+msgstr ""
+
+#: ../src/qalc.cc:909 ../src/qalc.cc:3499 ../src/qalc.cc:4296
+msgid "spacious"
+msgstr ""
+
+#: ../src/qalc.cc:910 ../src/qalc.cc:3501 ../src/qalc.cc:4298
+msgid "unicode"
+msgstr ""
+
+#: ../src/qalc.cc:918 ../src/qalc.cc:3466 ../src/qalc.cc:3785
+#: ../src/qalc.cc:3791 ../src/qalc.cc:4282
+msgid "units"
+msgstr ""
+
+#: ../src/qalc.cc:919 ../src/qalc.cc:3467 ../src/qalc.cc:4283
+msgid "unknowns"
+msgstr ""
+
+#: ../src/qalc.cc:920 ../src/qalc.cc:3468 ../src/qalc.cc:3784
+#: ../src/qalc.cc:3790 ../src/qalc.cc:4284
+msgid "variables"
+msgstr ""
+
+#: ../src/qalc.cc:921 ../src/qalc.cc:3473 ../src/qalc.cc:4289
+msgid "abbreviations"
+msgstr ""
+
+#: ../src/qalc.cc:922 ../src/qalc.cc:3618 ../src/qalc.cc:4382
+msgid "show ending zeroes"
+msgstr ""
+
+#: ../src/qalc.cc:923 ../src/qalc.cc:3606 ../src/qalc.cc:4364
+msgid "repeating decimals"
+msgstr ""
+
+#: ../src/qalc.cc:924 ../src/qalc.cc:3425 ../src/qalc.cc:4264
+msgid "angle unit"
+msgstr ""
+
+#: ../src/qalc.cc:926 ../src/qalc.cc:3427 ../src/qalc.cc:3428
+msgid "rad"
+msgstr ""
+
+#: ../src/qalc.cc:926 ../src/qalc.cc:4264
+msgid "radians"
+msgstr ""
+
+#: ../src/qalc.cc:927
+msgid "deg"
+msgstr ""
+
+#: ../src/qalc.cc:927 ../src/qalc.cc:4264
+msgid "degrees"
+msgstr ""
+
+#: ../src/qalc.cc:928 ../src/qalc.cc:3429
+msgid "gra"
+msgstr ""
+
+#: ../src/qalc.cc:928 ../src/qalc.cc:4264
+msgid "gradians"
+msgstr ""
+
+#: ../src/qalc.cc:941 ../src/qalc.cc:3623 ../src/qalc.cc:4387
+msgid "caret as xor"
+msgstr ""
+
+#: ../src/qalc.cc:942 ../src/qalc.cc:3651 ../src/qalc.cc:4427
+#: ../src/qalc.cc:4667
+msgid "parsing mode"
+msgstr ""
+
+#: ../src/qalc.cc:944 ../src/qalc.cc:1149 ../src/qalc.cc:3577
+#: ../src/qalc.cc:3653 ../src/qalc.cc:4347 ../src/qalc.cc:4427
+#: ../src/qalc.cc:4675
+msgid "adaptive"
+msgstr ""
+
+#: ../src/qalc.cc:945 ../src/qalc.cc:3654 ../src/qalc.cc:4427
+#: ../src/qalc.cc:4672
+msgid "implicit first"
+msgstr ""
+
+#: ../src/qalc.cc:946 ../src/qalc.cc:3655 ../src/qalc.cc:4427
+#: ../src/qalc.cc:4669
+msgid "conventional"
+msgstr ""
+
+#. chain calculation mode (parsing mode)
+#: ../src/qalc.cc:948 ../src/qalc.cc:3656 ../src/qalc.cc:4427
+#: ../src/qalc.cc:4683
+msgid "chain"
+msgstr ""
+
+#: ../src/qalc.cc:959 ../src/qalc.cc:1988 ../src/qalc.cc:3698
+#: ../src/qalc.cc:4456
+msgid "update exchange rates"
+msgstr ""
+
+#: ../src/qalc.cc:960 ../src/qalc.cc:3701 ../src/qalc.cc:4458
+msgid "never"
+msgstr ""
+
+#: ../src/qalc.cc:962 ../src/qalc.cc:3700 ../src/qalc.cc:4457
+msgid "ask"
+msgstr ""
+
+#: ../src/qalc.cc:970 ../src/qalc.cc:3490 ../src/qalc.cc:4294
+msgid "multiplication sign"
+msgstr ""
+
+#: ../src/qalc.cc:985 ../src/qalc.cc:3481 ../src/qalc.cc:4291
+msgid "division sign"
+msgstr ""
+
+#: ../src/qalc.cc:999 ../src/qalc.cc:1366 ../src/qalc.cc:3433
+#: ../src/qalc.cc:4268
+msgid "approximation"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:1001 ../src/qalc.cc:1081 ../src/qalc.cc:1216
+#: ../src/qalc.cc:1373 ../src/qalc.cc:2974 ../src/qalc.cc:3435
+#: ../src/qalc.cc:3567 ../src/qalc.cc:3726 ../src/qalc.cc:4268
+#: ../src/qalc.cc:4344 ../src/qalc.cc:4603 ../src/qalc.cc:4698
+msgid "exact"
+msgstr ""
+
+#: ../src/qalc.cc:1002 ../src/qalc.cc:1126 ../src/qalc.cc:1215
+#: ../src/qalc.cc:1377 ../src/qalc.cc:1407 ../src/qalc.cc:3438
+#: ../src/qalc.cc:3561 ../src/qalc.cc:3611 ../src/qalc.cc:4268
+#: ../src/qalc.cc:4344 ../src/qalc.cc:4371
+msgid "auto"
+msgstr ""
+
+#: ../src/qalc.cc:1003 ../src/qalc.cc:1220 ../src/qalc.cc:3440
+#: ../src/qalc.cc:3563 ../src/qalc.cc:4268 ../src/qalc.cc:4344
+msgid "dual"
+msgstr ""
+
+#: ../src/qalc.cc:1004 ../src/qalc.cc:1370 ../src/qalc.cc:3442
+#: ../src/qalc.cc:4268
+msgid "try exact"
+msgstr ""
+
+#: ../src/qalc.cc:1024 ../src/qalc.cc:3449 ../src/qalc.cc:4270
+msgid "interval calculation"
+msgstr ""
+
+#: ../src/qalc.cc:1024
+msgid "uncertainty propagation"
+msgstr ""
+
+#: ../src/qalc.cc:1026 ../src/qalc.cc:3452 ../src/qalc.cc:4270
+msgid "variance formula"
+msgstr ""
+
+#: ../src/qalc.cc:1026
+msgid "variance"
+msgstr ""
+
+#: ../src/qalc.cc:1027 ../src/qalc.cc:1173 ../src/qalc.cc:3448
+#: ../src/qalc.cc:3453 ../src/qalc.cc:4269 ../src/qalc.cc:4270
+msgid "interval arithmetic"
+msgstr ""
+
+#: ../src/qalc.cc:1037 ../src/qalc.cc:3672 ../src/qalc.cc:4433
+msgid "autoconversion"
+msgstr ""
+
+#: ../src/qalc.cc:1041 ../src/qalc.cc:3289
+msgid "best"
+msgstr ""
+
+#: ../src/qalc.cc:1042 ../src/qalc.cc:3681 ../src/qalc.cc:4442
+msgid "optimalsi"
+msgstr ""
+
+#: ../src/qalc.cc:1043 ../src/qalc.cc:3289 ../src/qalc.cc:3679
+#: ../src/qalc.cc:4438 ../src/qalc.cc:5673
+#: ../libqalculate/Calculator-calculate.cc:1534
+msgid "optimal"
+msgstr ""
+
+#: ../src/qalc.cc:1045 ../src/qalc.cc:1218 ../src/qalc.cc:1395
+#: ../src/qalc.cc:3569 ../src/qalc.cc:3675 ../src/qalc.cc:4344
+#: ../src/qalc.cc:4444 ../src/qalc.cc:5710
+#: ../libqalculate/Calculator-calculate.cc:1563
+msgid "mixed"
+msgstr ""
+
+#: ../src/qalc.cc:1065 ../src/qalc.cc:3685 ../src/qalc.cc:4449
+msgid "currency conversion"
+msgstr ""
+
+#: ../src/qalc.cc:1066 ../src/qalc.cc:3389 ../src/qalc.cc:4230
+msgid "algebra mode"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:1069 ../src/qalc.cc:3377 ../src/qalc.cc:4205
+#: ../src/qalc.cc:4698
+msgid "simplify"
+msgstr ""
+
+#: ../src/qalc.cc:1069 ../src/qalc.cc:3377 ../src/qalc.cc:3393
+#: ../src/qalc.cc:3727 ../src/qalc.cc:4205 ../src/qalc.cc:4230
+#: ../src/qalc.cc:4698 ../src/qalc.cc:5742
+#: ../libqalculate/Calculator-calculate.cc:1602
+msgid "expand"
+msgstr ""
+
+#: ../src/qalc.cc:1070 ../src/qalc.cc:3392 ../src/qalc.cc:4230
+#: ../src/qalc.cc:5739 ../libqalculate/Calculator-calculate.cc:1598
+msgid "factorize"
+msgstr ""
+
+#: ../src/qalc.cc:1092 ../src/qalc.cc:3708 ../src/qalc.cc:4466
+msgid "ignore locale"
+msgstr ""
+
+#: ../src/qalc.cc:1104 ../src/qalc.cc:3711 ../src/qalc.cc:3741
+#: ../src/qalc.cc:4469
+msgid "save mode"
+msgstr ""
+
+#: ../src/qalc.cc:1113 ../src/qalc.cc:3710 ../src/qalc.cc:3740
+#: ../src/qalc.cc:4468
+msgid "save definitions"
+msgstr ""
+
+#: ../src/qalc.cc:1122 ../src/qalc.cc:3608 ../src/qalc.cc:4366
+msgid "scientific notation"
+msgstr ""
+
+#: ../src/qalc.cc:1127 ../src/qalc.cc:3612 ../src/qalc.cc:4375
+msgid "pure"
+msgstr ""
+
+#: ../src/qalc.cc:1128 ../src/qalc.cc:3613 ../src/qalc.cc:4377
+msgid "scientific"
+msgstr ""
+
+#: ../src/qalc.cc:1129 ../src/qalc.cc:3614 ../src/qalc.cc:4373
+msgid "engineering"
+msgstr ""
+
+#: ../src/qalc.cc:1138 ../src/qalc.cc:3457 ../src/qalc.cc:4271
+msgid "precision"
+msgstr ""
+
+#: ../src/qalc.cc:1147 ../src/qalc.cc:3575 ../src/qalc.cc:4347
+msgid "interval display"
+msgstr ""
+
+#: ../src/qalc.cc:1150 ../src/qalc.cc:3580 ../src/qalc.cc:4347
+msgid "significant"
+msgstr ""
+
+#: ../src/qalc.cc:1151 ../src/qalc.cc:3581 ../src/qalc.cc:4347
+msgid "interval"
+msgstr ""
+
+#: ../src/qalc.cc:1152 ../src/qalc.cc:3582 ../src/qalc.cc:4347
+msgid "plusminus"
+msgstr ""
+
+#: ../src/qalc.cc:1153 ../src/qalc.cc:3583 ../src/qalc.cc:4347
+msgid "midpoint"
+msgstr ""
+
+#: ../src/qalc.cc:1154 ../src/qalc.cc:3585 ../src/qalc.cc:4347
+msgid "upper"
+msgstr ""
+
+#: ../src/qalc.cc:1155 ../src/qalc.cc:3584 ../src/qalc.cc:4347
+msgid "lower"
+msgstr ""
+
+#: ../src/qalc.cc:1180 ../src/qalc.cc:3469 ../src/qalc.cc:4285
+msgid "variable units"
+msgstr ""
+
+#: ../src/qalc.cc:1187 ../src/qalc.cc:3592 ../src/qalc.cc:4350
+msgid "max decimals"
+msgstr ""
+
+#: ../src/qalc.cc:1199 ../src/qalc.cc:3599 ../src/qalc.cc:4357
+msgid "min decimals"
+msgstr ""
+
+#: ../src/qalc.cc:1212 ../src/qalc.cc:3559 ../src/qalc.cc:4344
+msgid "fractions"
+msgstr ""
+
+#: ../src/qalc.cc:1218
+msgid "combined"
+msgstr ""
+
+#: ../src/qalc.cc:1219 ../src/qalc.cc:3568 ../src/qalc.cc:4344
+msgid "long"
+msgstr ""
+
+#: ../src/qalc.cc:1236 ../src/qalc.cc:3539 ../src/qalc.cc:4327
+msgid "complex form"
+msgstr ""
+
+#: ../src/qalc.cc:1238 ../src/qalc.cc:3161 ../src/qalc.cc:3541
+#: ../src/qalc.cc:4327 ../src/qalc.cc:5658
+#: ../libqalculate/Calculator-calculate.cc:1512
+msgid "rectangular"
+msgstr ""
+
+#: ../src/qalc.cc:1238 ../src/qalc.cc:3161 ../src/qalc.cc:5658
+#: ../libqalculate/Calculator-calculate.cc:1512
+msgid "cartesian"
+msgstr ""
+
+#: ../src/qalc.cc:1239 ../src/qalc.cc:3173 ../src/qalc.cc:3542
+#: ../src/qalc.cc:4327 ../src/qalc.cc:5661
+#: ../libqalculate/Calculator-calculate.cc:1514
+msgid "exponential"
+msgstr ""
+
+#: ../src/qalc.cc:1240 ../src/qalc.cc:3185 ../src/qalc.cc:3543
+#: ../src/qalc.cc:4327 ../src/qalc.cc:5664
+#: ../libqalculate/Calculator-calculate.cc:1516
+msgid "polar"
+msgstr ""
+
+#: ../src/qalc.cc:1241 ../src/qalc.cc:3197 ../src/qalc.cc:3544
+#: ../src/qalc.cc:4327 ../src/qalc.cc:5667
+#: ../libqalculate/Calculator-calculate.cc:1518
+#: ../libqalculate/Function.cc:2243
+msgid "angle"
+msgstr ""
+
+#: ../src/qalc.cc:1241 ../src/qalc.cc:3197 ../src/qalc.cc:5667
+#: ../libqalculate/Calculator-calculate.cc:1518
+msgid "phasor"
+msgstr ""
+
+#: ../src/qalc.cc:1254 ../src/qalc.cc:3660 ../src/qalc.cc:4428
+msgid "read precision"
+msgstr ""
+
+#: ../src/qalc.cc:1257 ../src/qalc.cc:3663 ../src/qalc.cc:4428
+msgid "always"
+msgstr ""
+
+#: ../src/qalc.cc:1258 ../src/qalc.cc:3664 ../src/qalc.cc:4428
+msgid "when decimals"
+msgstr ""
+
+#: ../src/qalc.cc:1290
+msgid "Unrecognized option."
+msgstr "L'opció no és reconeguda."
+
+#. The qalc command "set" as in "set precision 10". The original text string for commands is kept in addition to the translation.
+#: ../src/qalc.cc:1366 ../src/qalc.cc:1391 ../src/qalc.cc:2492
+#: ../src/qalc.cc:3742 ../src/qalc.cc:4209 ../src/qalc.cc:4705
+msgid "set"
+msgstr ""
+
+#: ../src/qalc.cc:1391 ../src/qalc.cc:3277 ../src/qalc.cc:5647
+#: ../libqalculate/Calculator-calculate.cc:1523
+msgid "fraction"
+msgstr ""
+
+#: ../src/qalc.cc:1431 ../src/qalc.cc:1709 ../src/qalc.cc:2498
+msgid "Name"
+msgstr ""
+
+#: ../src/qalc.cc:1447 ../src/qalc.cc:2570 ../src/qalc.cc:2634
+#: ../src/qalc.cc:2695
+msgid "Illegal name."
+msgstr "El nom és il·legal."
+
+#: ../src/qalc.cc:1450 ../src/qalc.cc:1452 ../src/qalc.cc:2573
+#: ../src/qalc.cc:2575 ../src/qalc.cc:2637 ../src/qalc.cc:2639
+#: ../src/qalc.cc:2698 ../src/qalc.cc:2700
+#, c-format
+msgid "Illegal name. Save as %s instead (default: no)?"
+msgstr "El nom és il·legal. Desar com a %s en compte (per defecte: no)?"
+
+#: ../src/qalc.cc:1462 ../src/qalc.cc:2585 ../src/qalc.cc:2649
+msgid ""
+"A unit or variable with the same name already exists.\n"
+"Do you want to overwrite it (default: no)?"
+msgstr ""
+"Una unitat o variable amb el mateix nom ja existeix.\n"
+"Voleu sobreescriure-ho (per defecte: no)?"
+
+#: ../src/qalc.cc:1557
+msgid "Calendar"
+msgstr ""
+
+#: ../src/qalc.cc:1557
+msgid "Day"
+msgstr ""
+
+#: ../src/qalc.cc:1557
+msgid "Month"
+msgstr ""
+
+#: ../src/qalc.cc:1557
+msgid "Year"
+msgstr ""
+
+#: ../src/qalc.cc:1558 ../libqalculate/Calculator-calculate.cc:1731
+msgid "failed"
+msgstr ""
+
+#: ../src/qalc.cc:1559 ../libqalculate/Calculator-calculate.cc:1732
+msgid "Gregorian:"
+msgstr ""
+
+#: ../src/qalc.cc:1560 ../libqalculate/Calculator-calculate.cc:1733
+msgid "Hebrew:"
+msgstr ""
+
+#: ../src/qalc.cc:1561 ../libqalculate/Calculator-calculate.cc:1734
+msgid "Islamic:"
+msgstr ""
+
+#: ../src/qalc.cc:1562 ../libqalculate/Calculator-calculate.cc:1735
+msgid "Persian:"
+msgstr ""
+
+#: ../src/qalc.cc:1563 ../libqalculate/Calculator-calculate.cc:1736
+msgid "Indian national:"
+msgstr ""
+
+#: ../src/qalc.cc:1564 ../libqalculate/Calculator-calculate.cc:1737
+msgid "Chinese:"
+msgstr ""
+
+#: ../src/qalc.cc:1569 ../libqalculate/Calculator-calculate.cc:1741
+msgid "Julian:"
+msgstr ""
+
+#: ../src/qalc.cc:1570 ../libqalculate/Calculator-calculate.cc:1742
+msgid "Revised julian:"
+msgstr ""
+
+#: ../src/qalc.cc:1571 ../libqalculate/Calculator-calculate.cc:1743
+msgid "Coptic:"
+msgstr ""
+
+#: ../src/qalc.cc:1572 ../libqalculate/Calculator-calculate.cc:1744
+msgid "Ethiopian:"
+msgstr ""
+
+#: ../src/qalc.cc:1661 ../libqalculate/BuiltinFunctions-matrixvector.cc:672
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:702
+msgid "No matching item found."
+msgstr "No s'ha trobat cap article concordant."
+
+#: ../src/qalc.cc:1692 ../src/qalc.cc:1693 ../src/qalc.cc:1827
+#: ../src/qalc.cc:1828 ../src/qalc.cc:1912 ../src/qalc.cc:1913
+msgid ""
+"For more information about a specific function, variable, unit, or prefix, "
+"please use the info command (in interactive mode)."
+msgstr ""
+"Per a més informació sobre una funció, una variable, una unitat o un prefix, "
+"si us plau, introduïu l'ordre info (en mode interactiu)."
+
+#: ../src/qalc.cc:1707
+msgid "Variables:"
+msgstr ""
+
+#: ../src/qalc.cc:1710 ../src/qalc.cc:4121 ../src/qalc.cc:4128
+#: ../src/qalc.cc:4182
+msgid "Value"
+msgstr ""
+
+#: ../src/qalc.cc:1801
+msgid "Functions:"
+msgstr ""
+
+#: ../src/qalc.cc:1815
+msgid "Units:"
+msgstr ""
+
+#: ../src/qalc.cc:1822
+msgid "No local variables, functions or units have been defined."
+msgstr "No s'ha definit cap variable, funció o unitat local."
+
+#: ../src/qalc.cc:1979
+msgid "usage: qalc [options] [expression]"
+msgstr "ús: qalc [opcions] [expressió]"
+
+#: ../src/qalc.cc:1981
+msgid "where options are:"
+msgstr "on les opcions són:"
+
+#: ../src/qalc.cc:1982 ../src/qalc.cc:2018 ../src/qalc.cc:3724
+msgid "BASE"
+msgstr "BASE"
+
+#: ../src/qalc.cc:1983
+msgid "set the number base for results and, optionally, expressions"
+msgstr ""
+"estableix la base numèrica per a resultats i, opcionalment, expressions"
+
+#: ../src/qalc.cc:1985
+msgid "use colors to highlight different elements of expressions and results"
+msgstr ""
+"usa colors per a ressaltar elements diferents d'expressions i de resultats"
+
+#: ../src/qalc.cc:1990
+msgid "FILE"
+msgstr "FITXER"
+
+#: ../src/qalc.cc:1991
+msgid "execute commands from a file first"
+msgstr "primer executa ordres d'un fitxer"
+
+#: ../src/qalc.cc:1993
+msgid "start in interactive mode"
+msgstr "comença en mode interactiu"
+
+#: ../src/qalc.cc:1994 ../src/qalc.cc:1996 ../src/qalc.cc:1998
+#: ../src/qalc.cc:2000 ../src/qalc.cc:2002
+msgid "SEARCH TERM"
+msgstr "TERMINI A CERCAR"
+
+#: ../src/qalc.cc:1995
+msgid ""
+"displays a list of all user-defined or matching variables, functions, units, "
+"and prefixes"
+msgstr ""
+"mostra una llista de tots els variables, funcions, unitats i prefixes "
+"definits pel usuari o concordants"
+
+#: ../src/qalc.cc:1997
+msgid "displays a list of all or matching functions"
+msgstr "mostra una llista de totes les funcions o les que concordin"
+
+#: ../src/qalc.cc:1999
+msgid "displays a list of all or matching prefixes"
+msgstr "mostra una llista de tots els prefixes o els que concordin"
+
+#: ../src/qalc.cc:2001
+msgid "displays a list of all or matching units"
+msgstr "mostra una llista de totes les unitats o les que concordin"
+
+#: ../src/qalc.cc:2003
+msgid "displays a list of all or matching variables"
+msgstr "mostra una llista de totes les variables o les que concordin"
+
+#: ../src/qalc.cc:2004
+msgid "MILLISECONDS"
+msgstr "MIL·LISEGONS"
+
+#: ../src/qalc.cc:2005
+msgid ""
+"terminate calculation and display of result after specified amount of time"
+msgstr ""
+"termina el càlcul i visualització del resultat desprès del temps especificat"
+
+#: ../src/qalc.cc:2007
+msgid "do not load any functions, units, or variables from file"
+msgstr "no carregis cap funció, unitat o variable del fitxer"
+
+#: ../src/qalc.cc:2009
+msgid "do not load any global currencies from file"
+msgstr "no carregis cap moneda global del fitxer"
+
+#: ../src/qalc.cc:2011
+msgid "do not load any global data sets from file"
+msgstr "no carregis cap conjunt de dades global del fitxer"
+
+#: ../src/qalc.cc:2013
+msgid "do not load any global functions from file"
+msgstr "no carregis cap funció global del fitxer"
+
+#: ../src/qalc.cc:2015
+msgid "do not load any global units from file"
+msgstr "no carregis cap unitat global del fitxer"
+
+#: ../src/qalc.cc:2017
+msgid "do not load any global variables from file"
+msgstr "no carregis cap variable global del fitxer"
+
+#: ../src/qalc.cc:2019
+msgid ""
+"start in programming mode (same as -b \"BASE BASE\" -s \"xor^\", with base "
+"conversion)"
+msgstr ""
+"comença en mode de programació (ho mateix que 'b \"BASE BASE\" -s \"xor^\", "
+"amb conversió de base)"
+
+#: ../src/qalc.cc:2020 ../src/qalc.cc:3742
+msgid "OPTION"
+msgstr "OPCIÓ"
+
+#: ../src/qalc.cc:2020 ../src/qalc.cc:3742
+msgid "VALUE"
+msgstr "VALOR"
+
+#: ../src/qalc.cc:2021
+msgid "as set command in interactive program session (e.g. -set \"base 16\")"
+msgstr ""
+"com ordre set en sessió de programa interactiva (per exemple -set \"base "
+"16\")"
+
+#: ../src/qalc.cc:2023
+msgid "reduce output to just the result of the input expression"
+msgstr "redueix la sortida a només el resultat de l'expressió introduïda"
+
+#: ../src/qalc.cc:2025
+msgid "switch unicode support on/off"
+msgstr "activa o desactiva el suport d'unicode"
+
+#: ../src/qalc.cc:2027
+msgid "show application version and exit"
+msgstr "mostra la versió de l'aplicació i surt"
+
+#: ../src/qalc.cc:2029
+msgid ""
+"The program will start in interactive mode if no expression and no file is "
+"specified (or interactive mode is explicitly selected)."
+msgstr ""
+"El programa començarà en mode interactiu si no s'ha especificat cap "
+"expressió o fitxer (o si el mode interactiu s'ha seleccionat explícitament)."
+
+#: ../src/qalc.cc:2029
+msgid "Type help in interactive mode for information about available commands."
+msgstr ""
+"Introduïu help en mode interactiu per a informació sobre les ordres "
+"disponibles."
+
+#: ../src/qalc.cc:2032 ../src/qalc.cc:3761
+msgid ""
+"For more information about mathematical expression and different options, "
+"and a complete list of functions, variables, and units, see the relevant "
+"sections in the manual of the graphical user interface (available at https://"
+"qalculate.github.io/manual/index.html)."
+msgstr ""
+"Per a més informació sobre l'expressió matemàtica i les diverses opcions, i "
+"una llista completa de funcions, variables i unitats, vegeu les seccions "
+"rellevants en el manual de la interfície gràfica d'usuari (disponible a "
+"https://qalculate.github.io/manual/index.html)."
+
+#: ../src/qalc.cc:2034 ../src/qalc.cc:3763
+msgid ""
+"For more information about mathematical expression and different options, "
+"please consult the man page, or the relevant sections in the manual of the "
+"graphical user interface (available at https://qalculate.github.io/manual/"
+"index.html), which also includes a complete list of functions, variables, "
+"and units."
+msgstr ""
+"Per a més informació sobre l'expressió matemàtica i les diverses opcions, si "
+"us plau, consulteu la pàgina del manual, o les seccions rellevants en el "
+"manual de la interfície gràfica d'usuari (disponible a https://qalculate."
+"github.io/manual/index.html), el qual també inclou una llista completa de "
+"funcions, variables i unitats."
+
+#: ../src/qalc.cc:2166
+msgid "No option and value specified for set command."
+msgstr "No s'ha especificat cap opció o valor per a la ordre set."
+
+#: ../src/qalc.cc:2177
+msgid "No file specified."
+msgstr "No s'ha especificat cap fitxer."
+
+#: ../src/qalc.cc:2268
+msgid "Failed to load global definitions!"
+msgstr "S'ha fallat en carregar les definicions globals!"
+
+#: ../src/qalc.cc:2314
+#, c-format
+msgid "Could not open \"%s\".\n"
+msgstr "No s'ha pogut obrir \"%s\".\n"
+
+#: ../src/qalc.cc:2360 ../src/qalc.cc:2425 ../src/qalc.cc:4718
+#, c-format
+msgid "Illegal character, '%c', in expression."
+msgstr "Hi ha un caràcter il·legal, '%c', en l'expressió."
+
+#. qalc command
+#: ../src/qalc.cc:2496 ../src/qalc.cc:3739 ../src/qalc.cc:4500
+#: ../src/qalc.cc:4705
+msgid "save"
+msgstr ""
+
+#: ../src/qalc.cc:2496 ../src/qalc.cc:3739 ../src/qalc.cc:4500
+#: ../src/qalc.cc:4705
+msgid "store"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2516 ../src/qalc.cc:3380 ../src/qalc.cc:3737
+#: ../src/qalc.cc:4526 ../src/qalc.cc:4698
+msgid "mode"
+msgstr ""
+
+#: ../src/qalc.cc:2518
+msgid "mode saved"
+msgstr ""
+
+#: ../src/qalc.cc:2520
+msgid "definitions"
+msgstr ""
+
+#: ../src/qalc.cc:2522
+msgid "definitions saved"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2605 ../src/qalc.cc:3744 ../src/qalc.cc:4507
+#: ../src/qalc.cc:4705 ../libqalculate/Function.cc:2204
+msgid "variable"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2666 ../src/qalc.cc:3734 ../src/qalc.cc:4513
+#: ../src/qalc.cc:4705 ../libqalculate/Function.cc:2176
+msgid "function"
+msgstr ""
+
+#: ../src/qalc.cc:2708
+msgid ""
+"A function with the same name already exists.\n"
+"Do you want to overwrite it (default: no)?"
+msgstr ""
+"Una funció amb el mateix nom ja existeix.\n"
+"Voleu sobreescriure-la (per defecte: no)?"
+
+#. qalc command
+#: ../src/qalc.cc:2733 ../src/qalc.cc:3725 ../src/qalc.cc:4520
+#: ../src/qalc.cc:4705
+msgid "delete"
+msgstr ""
+
+#: ../src/qalc.cc:2744
+msgid "No user-defined variable or function with the specified name exist."
+msgstr ""
+"Cap funció o variable definit per l'usuari existeix amb el nom especificat."
+
+#. qalc command
+#: ../src/qalc.cc:2748 ../src/qalc.cc:3723 ../src/qalc.cc:4471
+#: ../src/qalc.cc:4705
+msgid "assume"
+msgstr ""
+
+#: ../src/qalc.cc:2758
+msgid "syntax"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2766 ../src/qalc.cc:2813 ../src/qalc.cc:3748
+#: ../src/qalc.cc:4565 ../src/qalc.cc:4698
+msgid "stack"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2791 ../src/qalc.cc:3729 ../src/qalc.cc:4545
+#: ../src/qalc.cc:4698
+msgid "exrates"
+msgstr ""
+
+#: ../src/qalc.cc:2815 ../src/qalc.cc:2833 ../src/qalc.cc:2842
+#: ../src/qalc.cc:2875 ../src/qalc.cc:2904 ../src/qalc.cc:2913
+#: ../src/qalc.cc:2930 ../src/qalc.cc:2937 ../src/qalc.cc:2955
+#: ../src/qalc.cc:2962
+msgid "The RPN stack is empty."
+msgstr "La pila NPI està buida."
+
+#. qalc command
+#: ../src/qalc.cc:2831 ../src/qalc.cc:2840 ../src/qalc.cc:3754
+#: ../src/qalc.cc:4569
+msgid "swap"
+msgstr ""
+
+#: ../src/qalc.cc:2835 ../src/qalc.cc:2844 ../src/qalc.cc:2877
+#: ../src/qalc.cc:2906 ../src/qalc.cc:2915
+msgid "The RPN stack only contains one value."
+msgstr "La pila NPI conté un valor només."
+
+#: ../src/qalc.cc:2863 ../src/qalc.cc:2896 ../src/qalc.cc:2944
+#: ../src/qalc.cc:2968
+msgid "The specified RPN stack index does not exist."
+msgstr "L'índex de pila NPI especificat no existeix."
+
+#. qalc command
+#: ../src/qalc.cc:2873 ../src/qalc.cc:3751 ../src/qalc.cc:4591
+#: ../src/qalc.cc:4705
+msgid "move"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2902 ../src/qalc.cc:2911 ../src/qalc.cc:3753
+#: ../src/qalc.cc:4587
+msgid "rotate"
+msgstr ""
+
+#: ../src/qalc.cc:2919
+msgid "up"
+msgstr ""
+
+#: ../src/qalc.cc:2921
+msgid "down"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2928 ../src/qalc.cc:2935 ../src/qalc.cc:3750
+#: ../src/qalc.cc:4579
+msgid "copy"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2950 ../src/qalc.cc:3749 ../src/qalc.cc:4555
+msgid "clear stack"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2953 ../src/qalc.cc:2960 ../src/qalc.cc:3752
+#: ../src/qalc.cc:4559
+msgid "pop"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:2988 ../src/qalc.cc:2989 ../src/qalc.cc:3743
+#: ../src/qalc.cc:4611 ../src/qalc.cc:4705
+msgid "convert"
+msgstr ""
+
+#. "to"-operator
+#: ../src/qalc.cc:2988 ../src/qalc.cc:2989 ../src/qalc.cc:3743
+#: ../src/qalc.cc:4611 ../src/qalc.cc:4659 ../src/qalc.cc:4705
+#: ../libqalculate/Calculator-calculate.cc:2004
+#: ../libqalculate/Calculator-calculate.cc:2006
+#: ../libqalculate/Calculator-calculate.cc:2034
+#: ../libqalculate/Calculator-calculate.cc:2036
+#: ../libqalculate/Calculator-calculate.cc:2065
+#: ../libqalculate/Calculator-calculate.cc:2069
+#: ../libqalculate/Calculator.cc:304 ../libqalculate/Calculator.cc:533
+#: ../libqalculate/Calculator.cc:1254 ../libqalculate/Calculator.cc:1255
+msgid "to"
+msgstr ""
+
+#: ../src/qalc.cc:3148 ../src/qalc.cc:5640
+#: ../libqalculate/Calculator-calculate.cc:1505
+msgid "Time zone parsing failed."
+msgstr "Ha fallat l'anàlisi de zona horària."
+
+#: ../src/qalc.cc:3221 ../src/qalc.cc:5654
+#: ../libqalculate/Calculator-calculate.cc:1530
+msgid "bases"
+msgstr ""
+
+#: ../src/qalc.cc:3267 ../src/qalc.cc:5656
+#: ../libqalculate/Calculator-calculate.cc:1532
+msgid "calendars"
+msgstr ""
+
+#: ../src/qalc.cc:3285 ../src/qalc.cc:5650
+#: ../libqalculate/Calculator-calculate.cc:1525
+msgid "factors"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:3287 ../src/qalc.cc:3374 ../src/qalc.cc:3738
+#: ../src/qalc.cc:4201 ../src/qalc.cc:5652
+#: ../libqalculate/Calculator-calculate.cc:1528
+msgid "partial fraction"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:3371 ../src/qalc.cc:3732 ../src/qalc.cc:4197
+#: ../src/qalc.cc:4698
+msgid "factor"
+msgstr ""
+
+#: ../src/qalc.cc:3385 ../src/qalc.cc:4228
+msgid "Algebraic Mode"
+msgstr ""
+
+#: ../src/qalc.cc:3423 ../src/qalc.cc:4262
+msgid "Calculation"
+msgstr ""
+
+#: ../src/qalc.cc:3454
+msgid "simplified"
+msgstr ""
+
+#: ../src/qalc.cc:3459 ../src/qalc.cc:4275
+msgid "Enabled Objects"
+msgstr ""
+
+#: ../src/qalc.cc:3471 ../src/qalc.cc:4287
+msgid "Generic Display Options"
+msgstr ""
+
+#: ../src/qalc.cc:3503 ../src/qalc.cc:4300
+msgid "Numerical Display"
+msgstr ""
+
+#: ../src/qalc.cc:3621 ../src/qalc.cc:4385
+msgid "Parsing"
+msgstr ""
+
+#: ../src/qalc.cc:3668 ../src/qalc.cc:4430
+msgid "Units"
+msgstr ""
+
+#: ../src/qalc.cc:3706 ../src/qalc.cc:4464
+msgid "Other"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:3714 ../src/qalc.cc:4193
+msgid "help"
+msgstr ""
+
+#: ../src/qalc.cc:3717
+msgid "Enter a mathematical expression or a command and press enter."
+msgstr "Introduïu una expressió matemàtica o una ordre i premeu Retorn."
+
+#: ../src/qalc.cc:3718
+msgid "Complete functions, units and variables with the tabulator key."
+msgstr "Completeu funcions, unitats i variables amb la tecla de tabulació."
+
+#: ../src/qalc.cc:3720
+msgid "Available commands are:"
+msgstr "Les ordres disponibles són:"
+
+#: ../src/qalc.cc:3723
+msgid "ASSUMPTIONS"
+msgstr "SUPOSICIONS"
+
+#: ../src/qalc.cc:3725 ../src/qalc.cc:3733 ../src/qalc.cc:3734
+#: ../src/qalc.cc:3735 ../src/qalc.cc:3739 ../src/qalc.cc:3744
+msgid "NAME"
+msgstr "NOM"
+
+#: ../src/qalc.cc:3733 ../src/qalc.cc:3769 ../src/qalc.cc:4530
+#: ../src/qalc.cc:4705
+msgid "find"
+msgstr ""
+
+#. qalc command
+#: ../src/qalc.cc:3733 ../src/qalc.cc:3767 ../src/qalc.cc:3769
+#: ../src/qalc.cc:4530
+msgid "list"
+msgstr ""
+
+#: ../src/qalc.cc:3734 ../src/qalc.cc:3744
+msgid "EXPRESSION"
+msgstr "EXPRESSIÓ"
+
+#. qalc command
+#: ../src/qalc.cc:3735 ../src/qalc.cc:3797 ../src/qalc.cc:4539
+#: ../src/qalc.cc:4705 ../libqalculate/Calculator-definitions.cc:3000
+#: ../libqalculate/DataSet.cc:383 ../libqalculate/DataSet.cc:410
+#: ../libqalculate/DataSet.cc:1079
+msgid "info"
+msgstr ""
+
+#: ../src/qalc.cc:3736
+msgid "MC/MS/M+/M- (memory operations)"
+msgstr "MC/MS/M+/M- (operacions de memòria)"
+
+#: ../src/qalc.cc:3739
+msgid "CATEGORY"
+msgstr "CATEGORIA"
+
+#: ../src/qalc.cc:3739
+msgid "TITLE"
+msgstr "TÍTOL"
+
+#: ../src/qalc.cc:3743
+msgid "UNIT or \"TO\" COMMAND"
+msgstr "UNITAT o ORDRE \"TO\""
+
+#. qalc command
+#: ../src/qalc.cc:3745 ../src/qalc.cc:4663 ../src/qalc.cc:4690
+#: ../src/qalc.cc:4698
+msgid "quit"
+msgstr ""
+
+#: ../src/qalc.cc:3745 ../src/qalc.cc:4663 ../src/qalc.cc:4690
+#: ../src/qalc.cc:4698
+msgid "exit"
+msgstr ""
+
+#: ../src/qalc.cc:3746
+msgid "Commands for RPN mode:"
+msgstr "Ordres per al mode NPI:"
+
+#: ../src/qalc.cc:3747
+msgid "STATE"
+msgstr "ESTAT"
+
+#: ../src/qalc.cc:3750 ../src/qalc.cc:3752
+msgid "INDEX"
+msgstr "ÍNDEX"
+
+#: ../src/qalc.cc:3751 ../src/qalc.cc:3754
+msgid "INDEX 1"
+msgstr "ÍNDEX 1"
+
+#: ../src/qalc.cc:3751 ../src/qalc.cc:3754
+msgid "INDEX 2"
+msgstr "ÍNDEX 2"
+
+#: ../src/qalc.cc:3753
+msgid "DIRECTION"
+msgstr "DIRECCIÓ"
+
+#: ../src/qalc.cc:3756
+msgid "Type help COMMAND for more information (example: help save)."
+msgstr "Introduïu help ORDRE per a més informació (exemple: help save)."
+
+#: ../src/qalc.cc:3757
+msgid ""
+"Type info NAME for information about a function, variable, unit, or prefix "
+"(example: info sin)."
+msgstr ""
+"Introduïu info NOM per a informació sobre una funció, una variable, una "
+"unitat o un prefix (exemple: info sin)."
+
+#: ../src/qalc.cc:3758
+msgid ""
+"When a line begins with '/', the following text is always interpreted as a "
+"command."
+msgstr ""
+"Quan una línia comença amb '/', el text següent sempre s'interpreta com a "
+"ordre."
+
+#: ../src/qalc.cc:3782 ../src/qalc.cc:3788
+msgid "currencies"
+msgstr ""
+
+#: ../src/qalc.cc:3808
+msgid "No function, variable, unit, or prefix with specified name exist."
+msgstr "Cap funció, variable, unitat o prefix existeix amb el nom especificat."
+
+#: ../src/qalc.cc:3822
+msgid "Function"
+msgstr ""
+
+#: ../src/qalc.cc:3970
+msgid "Expression:"
+msgstr ""
+
+#: ../src/qalc.cc:3978 ../src/qalc.cc:3981 ../src/qalc.cc:4156
+msgid "Unit"
+msgstr ""
+
+#: ../src/qalc.cc:3984 ../src/qalc.cc:4062 ../src/qalc.cc:4172
+msgid "Names"
+msgstr ""
+
+#: ../src/qalc.cc:4002
+msgid "Base Unit"
+msgstr ""
+
+#: ../src/qalc.cc:4014
+msgid "Relation"
+msgstr ""
+
+#: ../src/qalc.cc:4019 ../src/qalc.cc:4124
+msgid "Relative uncertainty"
+msgstr ""
+
+#: ../src/qalc.cc:4020 ../src/qalc.cc:4125
+msgid "Uncertainty"
+msgstr ""
+
+#: ../src/qalc.cc:4030
+msgid "Inverse Relation"
+msgstr ""
+
+#: ../src/qalc.cc:4042
+msgid "Base Units"
+msgstr ""
+
+#: ../src/qalc.cc:4056 ../src/qalc.cc:4059
+msgid "Variable"
+msgstr ""
+
+#: ../src/qalc.cc:4170
+msgid "Prefix"
+msgstr ""
+
+#: ../src/qalc.cc:4199
+msgid "Factorizes the current result."
+msgstr "Factoritza el resultat actual."
+
+#: ../src/qalc.cc:4203
+msgid "Applies partial fraction decomposition to the current result."
+msgstr "Aplica la descomposició fraccionària parcial al resultat actual."
+
+#: ../src/qalc.cc:4207
+msgid "Expands the current result."
+msgstr "Expandeix el resultat actual."
+
+#: ../src/qalc.cc:4223
+msgid "Sets the value of an option."
+msgstr "Estableix el valor d'una opció."
+
+#: ../src/qalc.cc:4224
+msgid "Example: set base 16."
+msgstr "Exemple: set base 16."
+
+#: ../src/qalc.cc:4226
+msgid ""
+"Available options and accepted values are (the current value is marked with "
+"'*'):"
+msgstr ""
+"Les opcions disponibles i els valors acceptats són (el valor actual s'indica "
+"amb '*'):"
+
+#: ../src/qalc.cc:4230
+msgid "Determines if the expression is factorized or not after calculation."
+msgstr "Determina si l'expressió està factoritzada o no desprès d'un càlcul."
+
+#: ../src/qalc.cc:4231
+msgid "Determines if unknown values will be assumed non-zero (x/x=1)."
+msgstr ""
+"Determina si es presumirà que els valors desconeguts no siguin zero (x/x=1)."
+
+#: ../src/qalc.cc:4232
+msgid "Display a message after a value has been assumed non-zero."
+msgstr ""
+"Mostra un missatge desprès que s'ha presumit que un valor no sigui zero."
+
+#: ../src/qalc.cc:4235
+msgid "Default assumptions for unknown variables."
+msgstr "Suposicions per defecte per a variables desconegudes."
+
+#: ../src/qalc.cc:4264
+msgid "Default angle unit for trigonometric functions."
+msgstr "Unitat d'angle per defecte per a funcions trigonomètriques."
+
+#: ../src/qalc.cc:4268
+msgid ""
+"How approximate variables and calculations are handled. In exact mode "
+"approximate values will not be calculated."
+msgstr ""
+"Com es manegen les variables i calculacions aproximades. En el mode exacte, "
+"els valors aproximats no es calcularan."
+
+#: ../src/qalc.cc:4269
+msgid ""
+"If activated, interval arithmetic determines the final precision of "
+"calculations (avoids wrong results after loss of significance) with "
+"approximate functions and/or irrational numbers."
+msgstr ""
+"Si està activat, l'aritmètica interval determina la precisió final de les "
+"calculacions (evita resultats incorrectes desprès d'una perduda de "
+"significança) amb funcions aproximades o nombres irracionals."
+
+#: ../src/qalc.cc:4270
+msgid ""
+"Determines the method used for interval calculation / uncertainty "
+"propagation."
+msgstr ""
+"Determina el mètode que s'usa per a càlcul d'interval / propagació "
+"d'incertesa."
+
+#: ../src/qalc.cc:4272
+msgid ""
+"Specifies the default number of significant digits displayed and determines "
+"the precision used for approximate calculations."
+msgstr ""
+"Especifica el nombre predeterminat de xifres significats que es mostren i "
+"determina la precisió que s'usa per als càlculs aproximats."
+
+#: ../src/qalc.cc:4283
+msgid "Interpret undefined symbols in expressions as unknown variables."
+msgstr ""
+"Interpreta símbols no definits en expressions com a variables desconegudes."
+
+#: ../src/qalc.cc:4285
+msgid ""
+"If activated physical constants include units (e.g. c = 299 792 458 m∕s)."
+msgstr ""
+"Si està activat, els constants físics inclouen unitats (per exemple c = 299 "
+"792 458 m∕s)."
+
+#: ../src/qalc.cc:4289
+msgid "Use abbreviated names for units and variables."
+msgstr "Usa nombres abreviats per a unitats i variables."
+
+#: ../src/qalc.cc:4290
+msgid "Use colors to highlight different elements of expressions and results."
+msgstr ""
+"Usa colors per a ressaltar elements diferents de les expressions i dels "
+"resultats."
+
+#: ../src/qalc.cc:4293
+msgid "Always place negative values last."
+msgstr "Sempre posa els valors negatius al final."
+
+#: ../src/qalc.cc:4296
+msgid "Add extra space around operators."
+msgstr "Afegeix espai extra al voltant dels operadors."
+
+#: ../src/qalc.cc:4298
+msgid "Display Unicode characters."
+msgstr "Mosta caràcters d'Unicode."
+
+#: ../src/qalc.cc:4302 ../src/qalc.cc:4406
+msgid "bin"
+msgstr ""
+
+#: ../src/qalc.cc:4304 ../src/qalc.cc:4408
+msgid "oct"
+msgstr ""
+
+#: ../src/qalc.cc:4306 ../src/qalc.cc:4410
+msgid "dec"
+msgstr ""
+
+#: ../src/qalc.cc:4308 ../src/qalc.cc:4412
+msgid "hex"
+msgstr ""
+
+#: ../src/qalc.cc:4310
+msgid "sexa"
+msgstr ""
+
+#: ../src/qalc.cc:4329 ../src/qalc.cc:4389
+msgid "Determines the default decimal separator."
+msgstr "Determina el separador decimal per defecte."
+
+#: ../src/qalc.cc:4344
+msgid ""
+"Determines how rational numbers are displayed (e.g. 5/4 = 1 + 1/4 = 1.25). "
+"'long' removes limits on the size of the numerator and denominator."
+msgstr ""
+"Determina com es mostren els nombres racionals (per exemple 5/4 = 1 + 1/4 = "
+"1.25). 'long' elimina els límits en la mida del numerador i denominador."
+
+#: ../src/qalc.cc:4345
+msgid ""
+"Enables two's complement representation for display of negative hexadecimal "
+"numbers."
+msgstr ""
+"Habilita la representació de complement a dos per a presentació de nombres "
+"hexadecimals negatius."
+
+#: ../src/qalc.cc:4346 ../src/qalc.cc:4405
+msgid "Use 'j' (instead of 'i') as default symbol for the imaginary unit."
+msgstr ""
+"Usa 'j' (en lloc de 'i') com el símbol predeterminat per la unitat "
+"imaginària."
+
+#: ../src/qalc.cc:4348
+msgid "Use lowercase e for E-notation (5e2 = 5 * 10^2)."
+msgstr "Usa e minúscula per a notació E (5e2 = 5 * 10^2)."
+
+#: ../src/qalc.cc:4349
+msgid "Use lowercase letters for number bases > 10."
+msgstr "Usa lletres minúscules per a bases numèriques > 10."
+
+#: ../src/qalc.cc:4364
+msgid ""
+"If activated, 1/6 is displayed as '0.1 666...', otherwise as '0.166667'."
+msgstr ""
+"Si està activat, 1/6 es mostra com a '0.1 666...', d'altre manera '0.166667'."
+
+#: ../src/qalc.cc:4365
+msgid ""
+"Determines whether halfway numbers are rounded upwards or towards the "
+"nearest even integer."
+msgstr ""
+"Determina si els nombres a mig camí s'arrodoneixen amunt o al enter més "
+"proper."
+
+#: ../src/qalc.cc:4367
+msgid "Determines how scientific notation is used (e.g. 5 543 000 = 5.543E6)."
+msgstr ""
+"Determina com s'usa la notació científica (per exemple 5 543 000 = 5.543E6)."
+
+#: ../src/qalc.cc:4382
+msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgstr ""
+"Si està activat, es conserven els zeros al final de nombres aproximats."
+
+#: ../src/qalc.cc:4383
+msgid ""
+"Enables two's complement representation for display of negative binary "
+"numbers."
+msgstr ""
+"Habilita la representació de complement a dos per a presentació de nombres "
+"binaris negatius."
+
+#: ../src/qalc.cc:4387
+msgid "Use ^ as bitwise exclusive OR operator."
+msgstr "Usa ^ com operador OR exclusiu de bit a bit."
+
+#: ../src/qalc.cc:4400
+msgid "Allows use of ',' as thousands separator."
+msgstr "Permet l'ús de ',' com a separador de milers."
+
+#: ../src/qalc.cc:4403
+msgid "Allows use of '.' as thousands separator."
+msgstr "Permet l'ús de '.' com a separador de milers."
+
+#: ../src/qalc.cc:4427
+msgid "See 'help parsing mode'."
+msgstr "Vegeu 'help parsing mode'."
+
+#: ../src/qalc.cc:4428
+msgid ""
+"If activated, numbers are interpreted as approximate with precision equal to "
+"the number of significant digits (3.20 = 3.20+/-0.005)."
+msgstr ""
+"Si està activat, els nombres s'interpreten com aproximats amb precisió igual "
+"al nombre de xifres significants (3.20 = 3.20+/-0.005)."
+
+#: ../src/qalc.cc:4432
+msgid "Enables automatic use of hecto, deca, deci, and centi."
+msgstr "Habilita l'ús automàtica de hecto, deca, deci i centi."
+
+#: ../src/qalc.cc:4434
+msgid ""
+"Controls automatic unit conversion of the result. 'optimalsi' always "
+"converts non-SI units, while 'optimal' only converts to more optimal unit "
+"expressions, with less units and exponents."
+msgstr ""
+"Controla la conversió automàtica de les unitats del resultat. 'optimalsi' "
+"sempre converteix unitats no SI, mentre 'optimal' només converteix a "
+"expressions d'unitat més òptims, amb menys unitats i exponents."
+
+#: ../src/qalc.cc:4448
+msgid ""
+"If activated, binary prefixes are used by default for information units."
+msgstr ""
+"Si està activat, s'usen per defecte els prefixes binaris per a unitats "
+"d'informació."
+
+#: ../src/qalc.cc:4449
+msgid ""
+"Enables automatic conversion to the local currency when optimal unit "
+"conversion is enabled."
+msgstr ""
+"Habilita la conversió automàtica a la moneda local quan la conversió "
+"d'unitat òptima està activada."
+
+#: ../src/qalc.cc:4450
+msgid ""
+"Enables automatic use of prefixes in the denominator of unit expressions."
+msgstr ""
+"Habilita l'ús automàtic de prefixes en el denominador d'expressions d'unitat."
+
+#: ../src/qalc.cc:4451
+msgid ""
+"If activated, units are separated from variables at the end of the result."
+msgstr ""
+"Si està activat, les unitats se separen de les variables al final del "
+"resultat."
+
+#: ../src/qalc.cc:4452
+msgid "Enables automatic use of prefixes in the result."
+msgstr "Habilita l'ús automàtica de prefixes en el resultat."
+
+#: ../src/qalc.cc:4453
+msgid ""
+"Use negative exponents instead of division for units in result (m/s = "
+"m*s^-1)."
+msgstr ""
+"Usa exponents negatius en lloc de divisió per a les unitats en el resultat "
+"(m/s = m*s^-1)."
+
+#: ../src/qalc.cc:4455
+msgid ""
+"Determines how expressions with temperature units are calculated (hybrid "
+"acts as absolute if the expression contains different temperature units, "
+"otherwise as relative)."
+msgstr ""
+"Determina com es calculen les expressions amb unitats de temperatura (hybrid "
+"actua com a absolute si l'expressió conté unitats de temperatura diferents, "
+"d'altre manera relative)."
+
+#: ../src/qalc.cc:4459
+msgid "days"
+msgstr ""
+
+#: ../src/qalc.cc:4466
+msgid "Ignore system language and use English (requires restart)."
+msgstr "Ignora l'idioma del sistema i usa anglès (requereix reiniciar)."
+
+#: ../src/qalc.cc:4467
+msgid "Activates the Reverse Polish Notation stack."
+msgstr "Activa la pila de Notació Polonesa Inversa."
+
+#: ../src/qalc.cc:4468
+msgid "Save functions, units, and variables on exit."
+msgstr "Desa les funcions, unitats i variables en sortir."
+
+#: ../src/qalc.cc:4469
+msgid "Save settings on exit."
+msgstr "Desa les opcions en sortir."
+
+#: ../src/qalc.cc:4473
+msgid "Set default assumptions for unknown variables."
+msgstr "Desa les suposicions predeterminades per a les variables desconegudes."
+
+#: ../src/qalc.cc:4502
+msgid ""
+"Saves the current result in a variable with the specified name. You may "
+"optionally also provide a category (default \"Temporary\") and a title."
+msgstr ""
+"Desa el resultat actual en una variable amb el nom especificat. Podeu "
+"opcionalment proveir una categoria també (per defecte \"Temporary\") i un "
+"títol."
+
+#: ../src/qalc.cc:4503
+msgid ""
+"If name equals \"mode\" or \"definitions\", the current mode and "
+"definitions, respectively, will be saved."
+msgstr ""
+"Si el nom és \"mode\" o \"definitions\", es desaran el mode i les "
+"definicions actuals, respectivament."
+
+#: ../src/qalc.cc:4505
+msgid "Example: store var1."
+msgstr "Exemple: store var1."
+
+#: ../src/qalc.cc:4509
+msgid "Create a variable with the specified name and expression."
+msgstr "Crea una variable amb el nom i expressió especificats."
+
+#: ../src/qalc.cc:4511
+msgid "Example: variable var1 pi / 2."
+msgstr "Exemple: variable var1 pi / 2."
+
+#: ../src/qalc.cc:4515
+msgid "Creates a function with the specified name and expression."
+msgstr "Crea una funció amb el nom i expressió especificats."
+
+#: ../src/qalc.cc:4516
+msgid "Use '\\x', '\\y', '\\z', '\\a', etc. for arguments in the expression."
+msgstr "Usa '\\x', '\\y', '\\z', '\\a' etc. pels arguments en la expressió."
+
+#: ../src/qalc.cc:4518
+msgid "Example: function func1 5*\\x."
+msgstr "Exemple: function func1 5*\\x."
+
+#: ../src/qalc.cc:4522
+msgid "Removes the user-defined variable or function with the specified name."
+msgstr ""
+"Elimina la variable o funció amb el nom especificat definit per l'usuari."
+
+#: ../src/qalc.cc:4524
+msgid "Example: delete var1."
+msgstr "Exemple: delete var1."
+
+#: ../src/qalc.cc:4528
+msgid "Displays the current mode."
+msgstr "Mostra el mode actual."
+
+#: ../src/qalc.cc:4532
+msgid "Displays a list of variables, functions, units, and prefixes."
+msgstr "Mostra una llista de variables, funcions, unitats i prefixes."
+
+#: ../src/qalc.cc:4533
+msgid ""
+"Enter with argument 'currencies', 'functions', 'variables', 'units', or "
+"'prefixes' to show a list of all currencies, functions, variables, units, or "
+"prefixes. Enter a search term to find matching variables, functions, units, "
+"and/or prefixes. If command is called with no argument all user-definied "
+"objects are listed."
+msgstr ""
+"Inicia amb l'argument 'currencies', 'functions', 'variables', 'units' o "
+"'prefixes' per a mostrar una llista de tots els monedes, variables, unitats, "
+"o prefixes. Introduïu un termini de cerca per a trobar variables, funcions, "
+"unitats o prefixes concordants. Si l'ordre s'invoca sense argument, es "
+"llisten tots els objectes definits per l'usuari."
+
+#: ../src/qalc.cc:4535
+msgid "Example: list functions."
+msgstr "Exemple: list functions."
+
+#: ../src/qalc.cc:4536
+msgid "Example: find dinar."
+msgstr "Exemple: find dinar."
+
+#: ../src/qalc.cc:4537
+msgid "Example: find variables planck."
+msgstr "Exemple: find variables planck."
+
+#: ../src/qalc.cc:4541
+msgid "Displays information about a function, variable, unit, or prefix."
+msgstr ""
+"Mostra informació sobre una funció, un variable, una unitat o un prefix."
+
+#: ../src/qalc.cc:4543
+msgid "Example: info sin."
+msgstr "Exemple: info sin."
+
+#: ../src/qalc.cc:4547
+msgid "Downloads current exchange rates from the Internet."
+msgstr "Descarrega les tarifes d'intercanvi actual de l'Internet."
+
+#: ../src/qalc.cc:4551
+msgid "(De)activates the Reverse Polish Notation stack and syntax."
+msgstr "(Des)activa la pila i sintaxi de Notació Polonesa Inversa."
+
+#: ../src/qalc.cc:4553
+msgid ""
+"\"syntax\" activates only the RPN syntax and \"stack\" enables the RPN stack."
+msgstr ""
+"\"syntax\" activa només la sintaxi NPI i \"stack\" habilita la pila NPI."
+
+#: ../src/qalc.cc:4557
+msgid "Clears the entire RPN stack."
+msgstr "Neteja la pila NPI sencera."
+
+#: ../src/qalc.cc:4561
+msgid "Removes the top of the RPN stack or the value at the specified index."
+msgstr "Treu el cim de la pila NPI o el valor al índex especificat."
+
+#: ../src/qalc.cc:4563 ../src/qalc.cc:4575 ../src/qalc.cc:4585
+#: ../src/qalc.cc:4595
+msgid ""
+"Index 1 is the top of stack and negative index values count from the bottom "
+"of the stack."
+msgstr ""
+"L'índex 1 és el cim de la pila i els valors d'índex negatius compten des del "
+"fons de la pila."
+
+#: ../src/qalc.cc:4567
+msgid "Displays the RPN stack."
+msgstr "Mostra la pila NPI."
+
+#: ../src/qalc.cc:4571
+msgid "Swaps position of values on the RPN stack."
+msgstr "Intercanvia les posiciones de valors en la pila NPI."
+
+#: ../src/qalc.cc:4573
+msgid ""
+"If no index is specified, the values on the top of the stack (index 1 and "
+"index 2) will be swapped and if only one index is specified, the value at "
+"this index will be swapped with the top value."
+msgstr ""
+"Si no s'especifica cap índex, els valors al cim de la pila (índex 1 i índex "
+"2) s'intercanviaran i si només un índex s'especifica, el valor a aquell "
+"índex s'intercanviarà amb el cim."
+
+#: ../src/qalc.cc:4577
+msgid "Example: swap 2 4"
+msgstr "Exemple: swap 2 4"
+
+#: ../src/qalc.cc:4581
+msgid "Duplicates a value on the RPN stack to the top of the stack."
+msgstr "Duplica un valor en la pila NPI al cim de la pila."
+
+#: ../src/qalc.cc:4583
+msgid "If no index is specified, the top of the stack is duplicated."
+msgstr "Si no s'especifica cap índex, es duplica el cim de la pila."
+
+#: ../src/qalc.cc:4589
+msgid "Rotates the RPN stack up (default) or down."
+msgstr "Roda la pila NPI amunt (per defecte) o avall."
+
+#: ../src/qalc.cc:4593
+msgid "Changes the position of a value on the RPN stack."
+msgstr "Canvia la posició d'un valor en la pila NPI."
+
+#: ../src/qalc.cc:4597
+msgid "Example: move 2 4"
+msgstr "Exemple: move 2 4"
+
+#: ../src/qalc.cc:4601
+msgid "Sets the result number base (equivalent to set base)."
+msgstr "Estableix la base numèrica del resultat (equivalent a set base)."
+
+#: ../src/qalc.cc:4605
+msgid "Equivalent to set approximation exact."
+msgstr "Equivalent a set approximation exact."
+
+#: ../src/qalc.cc:4609
+msgid "Equivalent to set approximation try exact."
+msgstr "Equivalent a set approximation try exact."
+
+#: ../src/qalc.cc:4614
+msgid ""
+"Converts the current result (equivalent to using \"to\" at the end of an "
+"expression)."
+msgstr ""
+"Converteix el resultat actual (equivalent a usar \"to\" al final d'una "
+"expressió)"
+
+#: ../src/qalc.cc:4616
+msgid "Possible values:"
+msgstr "Valors possibles:"
+
+#: ../src/qalc.cc:4618
+msgid "- a unit or unit expression (e.g. meter or km/h)"
+msgstr "- una unitat o expressió de unitat (per exemple meter o km/h)"
+
+#: ../src/qalc.cc:4619
+msgid "prepend with ? to request the optimal prefix"
+msgstr "preposa ? per a sol·licitar el prefix òptim"
+
+#: ../src/qalc.cc:4620
+msgid "prepend with b? to request the optimal binary prefix"
+msgstr "preposa b? per a sol·licitar el prefix binari òptim"
+
+#: ../src/qalc.cc:4621
+msgid "prepend with + or - to force/disable use of mixed units"
+msgstr "preposa + o - per a forçar/deshabilitar l'ús d'unitats mixtes"
+
+#: ../src/qalc.cc:4622
+msgid "- a variable or physical constant (e.g. c)"
+msgstr "- una variable o un constant físic (per exemple c)"
+
+#: ../src/qalc.cc:4623
+msgid "- base (convert to base units)"
+msgstr "- base (converteix a unitats bases)"
+
+#: ../src/qalc.cc:4624
+msgid "- optimal (convert to optimal unit)"
+msgstr "- optimal (converteix a la unitat òptima)"
+
+#: ../src/qalc.cc:4625
+msgid "- mixed (convert to mixed units, e.g. hours + minutes)"
+msgstr "- mixed (converteix a unitats mixtes, per exemple hores + minuts)"
+
+#: ../src/qalc.cc:4627
+msgid "- bin / binary (show as binary number)"
+msgstr "- bin / binary (mostra com a nombre binari)"
+
+#: ../src/qalc.cc:4628
+msgid "- bin# (show as binary number with specified number of bits)"
+msgstr "- bin# (mostra com a nombre binari amb el nombre de bits especificat)"
+
+#: ../src/qalc.cc:4629
+msgid "- oct / octal (show as octal number)"
+msgstr "- oct / octal (mostra com a nombre octal)"
+
+#: ../src/qalc.cc:4630
+msgid "- duo / duodecimal (show as duodecimal number)"
+msgstr "- duo / duodecimal (mostra com a nombre duodecimal)"
+
+#: ../src/qalc.cc:4631
+msgid "- hex / hexadecimal (show as hexadecimal number)"
+msgstr "- hex / hexadecimal (mostra com a nombre hexadecimal)"
+
+#: ../src/qalc.cc:4632
+msgid "- hex# (show as hexadecimal number with specified number of bits)"
+msgstr ""
+"- hex# (mostra com a nombre hexadecimal amb el nombre especificat de bits)"
+
+#: ../src/qalc.cc:4633
+msgid "- sexa / sexa2 / sexagesimal (show as sexagesimal number)"
+msgstr "- sexa / sexa2 / sexagesimal (mostra com a nombre sexagesimal)"
+
+#: ../src/qalc.cc:4634
+msgid "- latitude / latitude2 (show as sexagesimal longitude)"
+msgstr "- latitude / latitude2 (mostra com a latitud sexagesimal)"
+
+#: ../src/qalc.cc:4635
+msgid "- longitude / longitude2 (show as sexagesimal longitude)"
+msgstr "- longitude / longitude2 (mostra com a longitud sexagesimal)"
+
+#: ../src/qalc.cc:4636
+msgid "- bijective (shown in bijective base-26)"
+msgstr "- bijective (mostra en base 26 bijectiu)"
+
+#: ../src/qalc.cc:4637
+msgid "- fp16, fp32, fp64, fp80, fp128 (show in binary floating-point format)"
+msgstr ""
+"- fp16, fp32, fp64, fp80, fp128 (mostra en format binari de punt flotant)"
+
+#: ../src/qalc.cc:4638
+msgid "- roman (show as roman numerals)"
+msgstr "- roman (mostra com a numerals romans)"
+
+#: ../src/qalc.cc:4639
+msgid "- time (show in time format)"
+msgstr "- time (mostra en format de temps)"
+
+#: ../src/qalc.cc:4640
+msgid "- unicode"
+msgstr "- unicode"
+
+#: ../src/qalc.cc:4641
+msgid "- base # (show in specified number base)"
+msgstr "- base # (mostra en la base numèrica especificada)"
+
+#: ../src/qalc.cc:4642
+msgid "- bases (show as binary, octal, decimal and hexadecimal number)"
+msgstr "- bases (mostra com a nombre binari, octal, decimal i hexadecimal)"
+
+#: ../src/qalc.cc:4644
+msgid "- rectangular / cartesian (show complex numbers in rectangular form)"
+msgstr ""
+"- rectangular / cartesian (mostra nombres complexes en forma rectangular)"
+
+#: ../src/qalc.cc:4645
+msgid "- exponential (show complex numbers in exponential form)"
+msgstr "- exponential (mostra els nombres complexes en forma exponencial)"
+
+#: ../src/qalc.cc:4646
+msgid "- polar (show complex numbers in polar form)"
+msgstr "- polar (mostra els nombres complexes en forma polar)"
+
+#: ../src/qalc.cc:4647
+msgid "- cis (show complex numbers in cis form)"
+msgstr "- cis (mostra els nombres complexes en forma cis)"
+
+#: ../src/qalc.cc:4648
+msgid "- angle / phasor (show complex numbers in angle/phasor notation)"
+msgstr "- angle / phasor (mostra els nombres complexes en notació angle/fasor)"
+
+#: ../src/qalc.cc:4650
+msgid "- fraction (show result as mixed fraction)"
+msgstr "- fraction (mostra el resultat com a fracció mixta)"
+
+#: ../src/qalc.cc:4651
+msgid "- factors (factorize result)"
+msgstr "- factors (factoritza el resultat)"
+
+#: ../src/qalc.cc:4653
+msgid "- UTC (show date and time in UTC time zone)"
+msgstr "- UTC (mostra la data i la hora en la zona horària UTC)"
+
+#: ../src/qalc.cc:4654
+msgid "- UTC+/-hh[:mm] (show date and time in specified time zone)"
+msgstr ""
+"- UTC+/-hh[:mm] (mostra la data i la hora en la zona horària especificada)"
+
+#: ../src/qalc.cc:4655
+msgid "- calendars"
+msgstr "- calendars"
+
+#: ../src/qalc.cc:4657
+msgid "Example: to ?g"
+msgstr "Exemple: to ?g"
+
+#: ../src/qalc.cc:4660
+msgid ""
+"This command can also be typed directly at the end of the mathematical "
+"expression (e.g. 5 ft + 2 in to meter)."
+msgstr ""
+"També es pot introduir aquesta ordre al final de l'expressió matemàtica (per "
+"exemple 5 ft + 2 in to meter)."
+
+#: ../src/qalc.cc:4665
+msgid "Terminates this program."
+msgstr "Termina aquest programa."
+
+#: ../src/qalc.cc:4670
+msgid ""
+"Implicit multiplication does not differ from explicit multiplication "
+"(\"12/2(1+2) = 12/2*3 = 18\", \"5x/5y = 5*x/5*y = xy\")."
+msgstr ""
+"La multiplicació implícita no difereix de multiplicació explícita "
+"(\"12/2(1+2) = 12/2*3 = 18\", \"5x/5y = 5*x/5*y = xy\")."
+
+#: ../src/qalc.cc:4673
+msgid ""
+"Implicit multiplication is parsed before explicit multiplication "
+"(\"12/2(1+2) = 12/(2*3) = 2\", \"5x/5y = (5*x)/(5*y) = x/y\")."
+msgstr ""
+"La multiplicació implícita s'analitza abans de la multiplicació explícita "
+"(\"12/2(1+2) = 12/(2*3) = 2\", \"5x/5y = (5*x)/(5*y) = x/y\")."
+
+#: ../src/qalc.cc:4676
+msgid ""
+"The default adaptive mode works as the \"implicit first\" mode, unless "
+"spaces are found (\"1/5x = 1/(5*x)\", but \"1/5 x = (1/5)*x\"). In the "
+"adaptive mode unit expressions are parsed separately (\"5 m/5 m/s = (5*m)/"
+"(5*(m/s)) = 1 s\")."
+msgstr ""
+"El mode adaptatiu predeterminat funciona com el mode \"implicit first\", a "
+"menys que es trobin espais (\"1/5x = 1/(5*x)\", però \"1/5 x = (1/5)*x\"). "
+"En el mode adaptatiu, les expressions d'unitat s'analitzen separadament (\"5 "
+"m/5 m/s = (5*m)/(5*(m/s)) = 1 s\")."
+
+#: ../src/qalc.cc:4678
+msgid ""
+"Function arguments without parentheses are an exception, where implicit "
+"multiplication in front of variables and units is parsed first regardless of "
+"mode (\"sqrt 2x = sqrt(2x)\")."
+msgstr ""
+"Els arguments de funció sense parèntesis són una excepció, on la "
+"multiplicació implícita davant de les variables i unitats s'analitza primer "
+"independentment del mode (\"sqrt 2x = sqrt(2x)\")."
+
+#: ../src/qalc.cc:4681
+msgid ""
+"Parse expressions using reverse Polish notation (\"1 2 3+* = 1*(2+3) = 5\")"
+msgstr ""
+"Analitza les expressions usant la notació polonesa inversa (\"1 2 3+* = "
+"1*(2+3) = 5\")"
+
+#: ../src/qalc.cc:4684
+msgid ""
+"Perform operations from left to right, like the immediate execution mode of "
+"a traditional calculator (\"1+2*3 = (1+2)*3 = 9\")"
+msgstr ""
+"Realitza les operacions des de l'esquerra a la dreta, com el mode d'execució "
+"immediat d'un calculador tradicional (\"1+2*3 = (1+2)*3 = 9\")"
+
+#: ../src/qalc.cc:4703
+#, c-format
+msgid "%s does not accept any arguments."
+msgstr "%s no accepta cap argument."
+
+#: ../src/qalc.cc:4709
+#, c-format
+msgid "%s requires at least one argument."
+msgstr "%s requereix al menys un argument."
+
+#: ../src/qalc.cc:4712
+msgid "Unknown command."
+msgstr "L'ordre és desconeguda."
+
+#: ../src/qalc.cc:4768
+msgid "error"
+msgstr "error"
+
+#: ../src/qalc.cc:4770
+msgid "warning"
+msgstr "advertència"
+
+#: ../src/qalc.cc:4890 ../src/qalc.cc:6157
+#: ../libqalculate/Calculator-calculate.cc:1785
+#: ../libqalculate/Calculator-calculate.cc:1805
+msgid "approx."
+msgstr "aprox."
+
+#: ../src/qalc.cc:4911 ../src/qalc.cc:5259 ../src/qalc.cc:5907
+#: ../libqalculate/Calculator-calculate.cc:1091
+#: ../libqalculate/Calculator-calculate.cc:2608
+#: ../libqalculate/MathStructure.cc:448
+#, c-format
+msgid "aborted"
+msgstr "avortat"
+
+#: ../src/qalc.cc:4923
+msgid "RPN Register Moved"
+msgstr "Registre NPI movit"
+
+#: ../src/qalc.cc:4944 ../src/qalc.cc:6111
+msgid "RPN Operation"
+msgstr "Operació NPI"
+
+#: ../src/qalc.cc:4981
+msgid "Processing (press Enter to abort)"
+msgstr "Processant (premeu Retorn per a avortar)"
+
+#: ../src/qalc.cc:5276
+msgid "Factorizing (press Enter to abort)"
+msgstr "Factoritzant (premeu Retorn per a avortar)"
+
+#: ../src/qalc.cc:5280
+msgid "Expanding partial fractions…"
+msgstr "Expandint les fraccions parcials…"
+
+#: ../src/qalc.cc:5284
+msgid "Expanding (press Enter to abort)"
+msgstr "Expandint (premeu Retorn per a avortar)"
+
+#: ../src/qalc.cc:5288 ../src/qalc.cc:5921
+msgid "Calculating (press Enter to abort)"
+msgstr "Calculant (premeu Enter per a avortar)"
+
+#: ../src/qalc.cc:5386
+msgid ""
+"The expression is ambiguous. Please select temperature calculation mode (the "
+"mode can later be changed using \"set temp\" command)."
+msgstr ""
+"L'expressió és ambigua. Si us plau, seleccioneu el mode de càlcul de "
+"temperatura (es pot canviar el mode després usant l'ordre \"set temp\")."
+
+#: ../src/qalc.cc:5411 ../src/qalc.cc:5439
+msgid "Temperature calculation mode"
+msgstr "Mode de càlcul de temperatura"
+
+#: ../src/qalc.cc:5460
+msgid "Please select interpretation of dots (\".\")."
+msgstr "Si us plau, selecciona la interpretació de punts (\".\")."
+
+#: ../src/qalc.cc:5464
+msgid "Both dot and comma as decimal separators"
+msgstr "Ambdós punt i coma com a separadors decimals"
+
+#: ../src/qalc.cc:5470
+msgid "Dot as thousands separator"
+msgstr "Punt com a separador de milers"
+
+#: ../src/qalc.cc:5476
+msgid "Only dot as decimal separator"
+msgstr "Només punt com a separador decimal"
+
+#: ../src/qalc.cc:5481 ../src/qalc.cc:5515
+msgid "Dot interpretation"
+msgstr "Interpretació del punt"
+
+#: ../src/qalc.cc:6712
+#, c-format
+msgid ""
+"Couldn't write preferences to\n"
+"%s"
+msgstr ""
+"No s'ha pogut escriure les preferència a\n"
+"%s"
+
+#: ../src/qalc.cc:6830
+msgid "Couldn't write definitions"
+msgstr "No s'ha pogut escriure les definicions"
+
+#. thread cancellation is not safe
+#: ../src/test.cc:13 ../src/test.cc:28
+#: ../libqalculate/Calculator-calculate.cc:172
+msgid ""
+"The calculation has been forcibly terminated. Please restart the application "
+"and report this as a bug."
+msgstr ""
+"S'ha terminat el càlcul a la força. Si us plau, reinicieu l'aplicació i "
+"reporteu això com a defecte."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:359
+msgid ""
+"No equality or inequality to solve. The entered expression to solve is not "
+"correct (e.g. \"x + 5 = 3\" is correct)"
+msgstr ""
+"No hi ha cap igualtat o desigualtat a resoldre. L'expressió introduïda a "
+"resoldre no és correcta (per exemple \"x + 5 = 3\" és correcte)"
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:406
+#, c-format
+msgid "The comparison is true for all %s (with current assumptions)."
+msgstr ""
+"La comparació és certa per a totes les %s (amb les suposicions actuals)."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:410
+msgid "No possible solution was found (with current assumptions)."
+msgstr "No s'ha trobat cap solució possible (amb les suposicions actuals)."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:414
+#, c-format
+msgid "Was unable to completely isolate %s."
+msgstr "No s'ha pogut aïllar %s completament."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:418
+#: ../libqalculate/BuiltinFunctions-algebra.cc:581
+#: ../libqalculate/BuiltinFunctions-algebra.cc:673
+#, c-format
+msgid "The comparison is true for all %s if %s."
+msgstr "La comparació és certa per a totes les %s si %s."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:422
+#, c-format
+msgid "Was unable to isolate %s."
+msgstr "No s'ha pogut aïllar %s."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:542
+#: ../libqalculate/BuiltinFunctions-algebra.cc:569
+#: ../libqalculate/BuiltinFunctions-algebra.cc:650
+#, c-format
+msgid ""
+"Was unable to isolate %s with the current assumptions. The assumed sign was "
+"therefore temporarily set as unknown."
+msgstr ""
+"No s'ha pogut aïllar %s amb les suposicions actuals. Per això, el signe "
+"presumit temporalment s'ha establert com a desconegut."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:545
+#: ../libqalculate/BuiltinFunctions-algebra.cc:572
+#: ../libqalculate/BuiltinFunctions-algebra.cc:653
+#, c-format
+msgid ""
+"Was unable to isolate %s with the current assumptions. The assumed type and "
+"sign was therefore temporarily set as unknown."
+msgstr ""
+"No s'ha pogut aïllar %s amb les suposicions actuals. Per això, el tipus i el "
+"signe presumits temporalment s'han establert com a desconeguts."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:577
+#: ../libqalculate/BuiltinFunctions-algebra.cc:660
+#, c-format
+msgid "The solution requires that %s."
+msgstr "La solució requereix que %s."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:667
+#, c-format
+msgid "Solution %s requires that %s."
+msgstr "La solució %s requereix que %s."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:738
+#, c-format
+msgid ""
+"Unable to isolate %s.\n"
+"\n"
+"You might need to place the equations and variables in an appropriate order "
+"so that each equation at least contains the corresponding variable (if "
+"automatic reordering failed)."
+msgstr ""
+"No s'ha pogut aïllar %s.\n"
+"\n"
+"Potser que necessiteu posar les equacions i variables en un ordre apropiat "
+"per a que cada equació contingui al menys la variable corresponent (si el "
+"reordenament automàtic ha fallat)."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:740
+#: ../libqalculate/BuiltinFunctions-algebra.cc:754
+#: ../libqalculate/BuiltinFunctions-algebra.cc:763
+#, c-format
+msgid "Unable to isolate %s."
+msgstr "No s'ha pogut aïllar %s."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:747
+#, c-format
+msgid "Inequalities are not allowed in %s()."
+msgstr "No es permeten les desigualtats en %s()."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1089
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1094
+msgid "No differential equation found."
+msgstr "No s'ha trobat cap equació diferencial."
+
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1098
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1127
+#: ../libqalculate/BuiltinFunctions-algebra.cc:1133
+msgid "Unable to solve differential equation."
+msgstr "No s'ha pogut resoldre l'equació diferencial."
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:34
+#: ../libqalculate/BuiltinFunctions-datetime.cc:68
+msgid "gregorian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:35
+msgid "milankovic"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:36
+msgid "julian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:37
+msgid "islamic"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:38
+msgid "hebrew"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:39
+msgid "egyptian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:40
+msgid "persian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:41
+msgid "coptic"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:42
+msgid "ethiopian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:43
+msgid "indian"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-datetime.cc:44
+msgid "chinese"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:57
+#, c-format
+msgid "Too many elements (%s) for the dimensions (%sx%s) of the matrix."
+msgstr "Hi ha massa elements (%s) per a les dimensions (%sx%s) de la matriu."
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:137
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:199
+#, c-format
+msgid "Row %s does not exist in matrix."
+msgstr "La fila %s no existeix en la matriu."
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:150
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:195
+#, c-format
+msgid "Column %s does not exist in matrix."
+msgstr "La columna %s no existeix en la matriu."
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:210
+#, c-format
+msgid "Argument 3, %s, is ignored for vectors."
+msgstr "L'argument 3, %s, s'ignora per als vectors."
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:214
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:235
+#, c-format
+msgid "Element %s does not exist in vector."
+msgstr "L'element %s no existeix en el vector."
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:376
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:380
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:500
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:504
+#, c-format
+msgid "%s() requires that all matrices/vectors have the same dimensions."
+msgstr ""
+"%s() requereix que totes les matrius o tots els vectors tinguin les mateixes "
+"dimensions."
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:644
+msgid ""
+"The number of requested elements in generate vector function must be a "
+"positive integer."
+msgstr ""
+"El nombre d'elements sol·licitats en la funció de generació de vectors ha de "
+"ser un enter positiu."
+
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:667
+#: ../libqalculate/BuiltinFunctions-matrixvector.cc:684
+msgid "Comparison failed."
+msgstr "La comparació ha fallat."
+
+#: ../libqalculate/BuiltinFunctions-statistics.cc:181
+#: ../libqalculate/BuiltinFunctions-statistics.cc:224
+#, c-format
+msgid "Unsolvable comparison in %s()."
+msgstr "Hi ha una comparació irresoluble en %s()."
+
+#: ../libqalculate/BuiltinFunctions-calculus.cc:710
+msgid "Unable to find limit."
+msgstr "No es pot trobar el límit."
+
+#: ../libqalculate/BuiltinFunctions-calculus.cc:805
+#: ../libqalculate/BuiltinFunctions-calculus.cc:837
+#: ../libqalculate/MathStructure-integrate.cc:7362
+#: ../libqalculate/MathStructure-integrate.cc:7382
+#: ../libqalculate/MathStructure-integrate.cc:7417
+#: ../libqalculate/MathStructure-integrate.cc:7441
+#: ../libqalculate/MathStructure-integrate.cc:7491
+#: ../libqalculate/MathStructure-integrate.cc:7530
+#: ../libqalculate/MathStructure-integrate.cc:7726
+#: ../libqalculate/MathStructure-integrate.cc:7780
+#: ../libqalculate/MathStructure-integrate.cc:7822
+msgid "Unable to integrate the expression."
+msgstr "No es pot integrar l'expressió."
+
+#: ../libqalculate/BuiltinFunctions-number.cc:818
+msgid "phoneword"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-number.cc:901
+#: ../libqalculate/BuiltinFunctions-number.cc:976 ../libqalculate/Number.cc:477
+#: ../libqalculate/Number.cc:994
+#, c-format
+msgid "Character '%s' was ignored in the number \"%s\" with base %s."
+msgstr "S'ha ignorat el caràcter '%s' en el nombre \"%s\" amb base %s."
+
+#: ../libqalculate/BuiltinFunctions-number.cc:1525
+#: ../libqalculate/Number.cc:2065 ../libqalculate/Number.cc:2190
+msgid "Floating point overflow"
+msgstr "Desbordament de punt flotant"
+
+#. test calculated floating point value and show mpfr errors (show as errors if error_level > 1, show as warnings if error_level = 1, do not generate message if error_level is zero)
+#: ../libqalculate/BuiltinFunctions-number.cc:1526
+#: ../libqalculate/Number.cc:2064 ../libqalculate/Number.cc:2189
+msgid "Floating point underflow"
+msgstr "Subdesbordament de punt flotant"
+
+#. if left value is a function without any arguments, do function replacement
+#: ../libqalculate/BuiltinFunctions-util.cc:479
+#: ../libqalculate/BuiltinFunctions-util.cc:484
+#: ../libqalculate/BuiltinFunctions-util.cc:486
+#: ../libqalculate/BuiltinFunctions-util.cc:496
+#: ../libqalculate/BuiltinFunctions-util.cc:501
+#: ../libqalculate/BuiltinFunctions-util.cc:503
+#: ../libqalculate/BuiltinFunctions-util.cc:519
+#: ../libqalculate/Calculator-calculate.cc:2212
+#: ../libqalculate/Calculator-calculate.cc:2224
+#: ../libqalculate/Calculator-calculate.cc:2226
+#: ../libqalculate/Calculator-calculate.cc:2229
+#: ../libqalculate/Calculator-calculate.cc:2300
+#, c-format
+msgid "Original value (%s) was not found."
+msgstr "No s'ha trobat el valor original (%s)."
+
+#: ../libqalculate/BuiltinFunctions-util.cc:709
+#: ../libqalculate/BuiltinFunctions-util.cc:713
+#, c-format
+msgid "Too few elements (%s) in vector (%s required)"
+msgstr "Hi ha massa pocs elements (%s) en el vector (es requereixen %s)"
+
+#: ../libqalculate/BuiltinFunctions-util.cc:759
+#, c-format
+msgid "Object %s does not exist."
+msgstr "L'objecte %s no existeix."
+
+#: ../libqalculate/BuiltinFunctions-util.cc:799
+#, c-format
+msgid "Invalid variable name (%s)."
+msgstr "El nom de variable no és vàlid (%s)."
+
+#: ../libqalculate/BuiltinFunctions-util.cc:817
+msgid ""
+"A global unit or variable was deactivated. It will be restored after the new "
+"variable has been removed."
+msgstr ""
+"S'ha desactivat una unitat o una variable global. Es restaurarà desprès que "
+"s'hagi tret la variable nova."
+
+#: ../libqalculate/BuiltinFunctions-util.cc:832
+#, c-format
+msgid "Register %s does not exist. Returning zero."
+msgstr "El registre %s no existeix. Es retorna zero."
+
+#: ../libqalculate/BuiltinFunctions-util.cc:880
+#: ../libqalculate/BuiltinFunctions-util.cc:891
+#, c-format
+msgid "Failed to run external command (%s)."
+msgstr "S'ha fallat en executar una ordre externa (%s)."
+
+#: ../libqalculate/BuiltinFunctions-util.cc:957
+#: ../libqalculate/BuiltinFunctions-util.cc:971
+msgid "Matrix"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:982
+#: ../libqalculate/BuiltinFunctions-util.cc:1032
+msgid "Vector"
+msgstr ""
+
+#: ../libqalculate/BuiltinFunctions-util.cc:997
+#: ../libqalculate/BuiltinFunctions-util.cc:1043
+#: ../libqalculate/Calculator-plot.cc:143
+msgid "Unable to generate plot data with current min, max and step size."
+msgstr ""
+"No s'ha pogut generar les dades a dibuixar amb amb el mínim, el màxim i la "
+"mida de pas actuals."
+
+#: ../libqalculate/BuiltinFunctions-util.cc:999
+#: ../libqalculate/BuiltinFunctions-util.cc:1045
+msgid "Sampling rate must be a positive integer."
+msgstr "La taxa de mostratge ha de ser un enter positiu."
+
+#: ../libqalculate/BuiltinFunctions-util.cc:1008
+#: ../libqalculate/BuiltinFunctions-util.cc:1054
+#: ../libqalculate/Calculator-plot.cc:113
+msgid "Unable to generate plot data with current min, max and sampling rate."
+msgstr ""
+"No es pot generar les dades a dibuixar amb el mínim, el màxim i la taxa de "
+"mostratge actuals."
+
+#: ../libqalculate/Calculator-calculate.cc:304
+#: ../libqalculate/Calculator-calculate.cc:429
+msgid "Stack is empty. Filling remaining function arguments with zeroes."
+msgstr ""
+"La pila està buida. S'omplen els arguments de funció restants amb zeros."
+
+#. logical operator
+#: ../libqalculate/Calculator-calculate.cc:1017
+#: ../libqalculate/Calculator-calculate.cc:1055
+#: ../libqalculate/Calculator.cc:247 ../libqalculate/Calculator.cc:477
+#: ../libqalculate/MathStructure-print.cc:3464 ../libqalculate/Function.cc:1356
+#: ../libqalculate/Function.cc:1364 ../libqalculate/Function.cc:1797
+#: ../libqalculate/Function.cc:1959 ../libqalculate/Function.cc:1967
+msgid "and"
+msgstr ""
+
+#: ../libqalculate/Calculator-calculate.cc:1929
+msgid "calculating..."
+msgstr "calculant..."
+
+#. "where"-operator
+#: ../libqalculate/Calculator-calculate.cc:2103
+#: ../libqalculate/Calculator-calculate.cc:2105
+#: ../libqalculate/Calculator-calculate.cc:2124
+#: ../libqalculate/Calculator-calculate.cc:2126
+#: ../libqalculate/Calculator.cc:1258
+msgid "where"
+msgstr ""
+
+#: ../libqalculate/Calculator-calculate.cc:2322
+#, c-format
+msgid "Unhandled \"where\" expression: %s"
+msgstr "No s'ha manejat l'expressió \"where\": %s"
+
+#: ../libqalculate/Calculator-calculate.cc:2560
+#: ../libqalculate/Calculator-calculate.cc:2607
+msgid "timed out"
+msgstr "s'ha esgotat el temps"
+
+#. division operator
+#: ../libqalculate/Calculator.cc:235 ../libqalculate/Calculator.cc:469
+msgid "per"
+msgstr ""
+
+#. multiplication operator
+#: ../libqalculate/Calculator.cc:238 ../libqalculate/Calculator.cc:471
+msgid "times"
+msgstr ""
+
+#. addition operator
+#: ../libqalculate/Calculator.cc:241 ../libqalculate/Calculator.cc:473
+msgid "plus"
+msgstr ""
+
+#. subtraction operator
+#: ../libqalculate/Calculator.cc:244 ../libqalculate/Calculator.cc:475
+msgid "minus"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:620
+msgid "Gradians unit is missing. Creating one for this session."
+msgstr "Manca la unitat de gradians. Es crea una per a aquesta sessió."
+
+#: ../libqalculate/Calculator.cc:621 ../libqalculate/Calculator.cc:629
+#: ../libqalculate/Calculator.cc:637
+msgid "Angle/Plane Angle"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:628
+msgid "Radians unit is missing. Creating one for this session."
+msgstr "Manca la unitat de radians. Es crea una per a aquesta sessió."
+
+#: ../libqalculate/Calculator.cc:636
+msgid "Degrees unit is missing. Creating one for this session."
+msgstr "Manca la unitat de graus. Es crea una per a aquesta sessió."
+
+#: ../libqalculate/Calculator.cc:1646 ../libqalculate/Calculator.cc:1647
+#: ../libqalculate/Calculator.cc:1651 ../libqalculate/Calculator.cc:1655
+#: ../libqalculate/Calculator-definitions.cc:3410
+#: ../libqalculate/Calculator-definitions.cc:3415
+#: ../libqalculate/Calculator-definitions.cc:3494
+#: ../libqalculate/Calculator-definitions.cc:3685
+#: ../libqalculate/Calculator-definitions.cc:3747
+msgid "Currency"
+msgstr ""
+
+#: ../libqalculate/Calculator.cc:2589
+#, c-format
+msgid ""
+"\"%s\" is not allowed in names anymore. Please change the name of \"%s\", or "
+"the variable will be lost."
+msgstr ""
+"Ja no es permet \"%s\" en noms. Si us plau, canvieu el nom de \"%s\", o es "
+"perdrà la variable."
+
+#: ../libqalculate/Calculator.cc:2607
+#, c-format
+msgid ""
+"\"%s\" is not allowed in names anymore. Please change the name \"%s\", or "
+"the function will be lost."
+msgstr ""
+"Ja no es permet \"%s\" en noms. Si us plau, canvieu el nom de \"%s\", o es "
+"perdrà la funció."
+
+#: ../libqalculate/Calculator.cc:2624
+#, c-format
+msgid ""
+"\"%s\" is not allowed in names anymore. Please change the name \"%s\", or "
+"the unit will be lost."
+msgstr ""
+"Ja no es permet \"%s\" en noms. Si us plau, canvieu el nom de \"%s\", o es "
+"perdrà la unitat."
+
+#: ../libqalculate/Calculator.cc:2831
+#, c-format
+msgid "Name \"%s\" is in use. Replacing with \"%s\"."
+msgstr "El nom \"%s\" està en ús. Es reemplaça amb \"%s\"."
+
+#: ../libqalculate/Calculator-definitions.cc:816 ../libqalculate/DataSet.cc:574
+#, c-format
+msgid "File not identified as Qalculate! definitions file: %s."
+msgstr ""
+"El fitxer no s'ha identificat com a fitxer de definicions del Qalculate!: %s."
+
+#: ../libqalculate/Calculator-definitions.cc:2983
+#: ../libqalculate/DataSet.cc:381
+msgid "Object"
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:2992
+#: ../libqalculate/DataSet.cc:382
+msgid "Property"
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:3291
+msgid "column"
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:3294
+msgid "Column "
+msgstr ""
+
+#: ../libqalculate/Calculator-definitions.cc:3870
+#: ../libqalculate/Calculator-definitions.cc:3871
+#: ../libqalculate/Calculator-definitions.cc:3875
+#: ../libqalculate/Calculator-definitions.cc:3878
+#: ../libqalculate/Calculator-definitions.cc:3910
+#: ../libqalculate/Calculator-definitions.cc:3911
+#: ../libqalculate/Calculator-definitions.cc:3914
+#: ../libqalculate/Calculator-definitions.cc:3933
+#: ../libqalculate/Calculator-definitions.cc:3934
+#: ../libqalculate/Calculator-definitions.cc:3937
+#: ../libqalculate/Calculator-definitions.cc:3957
+#: ../libqalculate/Calculator-definitions.cc:3958
+#: ../libqalculate/Calculator-definitions.cc:3961
+#, c-format
+msgid "Failed to download exchange rates from %s: %s."
+msgstr "S'ha fallat en descarregar les tarifes d'intercanvi de %s: %s."
+
+#. ignore operators
+#: ../libqalculate/Calculator-parse.cc:2106
+#: ../libqalculate/Calculator-parse.cc:2159
+#: ../libqalculate/Calculator-parse.cc:2163
+#: ../libqalculate/Calculator-parse.cc:2167
+#: ../libqalculate/Calculator-parse.cc:2171
+#: ../libqalculate/Calculator-parse.cc:2175
+#: ../libqalculate/Calculator-parse.cc:2179
+#: ../libqalculate/Calculator-parse.cc:3638
+#: ../libqalculate/Calculator-parse.cc:3649
+#: ../libqalculate/Calculator-parse.cc:3727
+#: ../libqalculate/Calculator-parse.cc:3828
+#: ../libqalculate/Calculator-parse.cc:3850
+#: ../libqalculate/Calculator-parse.cc:3851
+#: ../libqalculate/Calculator-parse.cc:3852
+#: ../libqalculate/Calculator-parse.cc:3853
+#: ../libqalculate/Calculator-parse.cc:3854
+#: ../libqalculate/Calculator-parse.cc:3855
+#: ../libqalculate/Calculator-parse.cc:3856
+#, c-format
+msgid "Misplaced operator(s) \"%s\" ignored"
+msgstr "S'han ignorat els operadors fora de lloc \"%s\""
+
+#. ignore operators
+#: ../libqalculate/Calculator-parse.cc:2155
+#: ../libqalculate/Calculator-parse.cc:3857
+#, c-format
+msgid "Misplaced '%c' ignored"
+msgstr "S'ha ignorat '%c' fora de lloc"
+
+#: ../libqalculate/Calculator-parse.cc:2213 ../libqalculate/Function.cc:1514
+#: ../libqalculate/Function.cc:1545
+#, c-format
+msgid "Internal id %s does not exist."
+msgstr "L'identificador intern %s no existeix."
+
+#: ../libqalculate/Calculator-parse.cc:2234
+#, c-format
+msgid "\"%s\" is not a valid variable/function/unit."
+msgstr "\"%s\" no és una variable/funció/unitat vàlida."
+
+#: ../libqalculate/Calculator-parse.cc:2252
+#, c-format
+msgid ""
+"Trailing characters \"%s\" (not a valid variable/function/unit) in number "
+"\"%s\" were ignored."
+msgstr ""
+"S'han ignorat els caràcters finals \"%s\" (no és una variable/funció/unitat "
+"vàlida) en el nombre \"%s\"."
+
+#: ../libqalculate/Calculator-parse.cc:2344
+#: ../libqalculate/Calculator-parse.cc:2360
+#: ../libqalculate/MathStructure-calculate.cc:1702
+msgid ""
+"Please use the cross(), dot(), and hadamard() functions for vector "
+"multiplication."
+msgstr ""
+"Si us plau, useu les funcions cross(), dot() i hadamard() per a "
+"multiplicació vector."
+
+#: ../libqalculate/Calculator-parse.cc:2443
+msgid "Empty expression in parentheses interpreted as zero."
+msgstr "S'ha interpretat una expressió buida entre parèntesis com a zero."
+
+#: ../libqalculate/Calculator-parse.cc:2534
+msgid "RPN syntax error. Values left at the end of the RPN expression."
+msgstr "Error de sintaxi NPI. Queden valors al final de l'expressió NPI."
+
+#: ../libqalculate/Calculator-parse.cc:2537
+#: ../libqalculate/Calculator-parse.cc:2628
+msgid "Unused stack values."
+msgstr "Hi ha valors no usats en la pila."
+
+#: ../libqalculate/Calculator-parse.cc:2687
+#: ../libqalculate/Calculator-parse.cc:2912
+#, c-format
+msgid "RPN syntax error. Operator '%c' not supported."
+msgstr "Error de sintaxi NPI. No s'admet l'operador '%c'."
+
+#: ../libqalculate/Calculator-parse.cc:2733
+msgid "RPN syntax error. Stack is empty."
+msgstr "Error de sintaxi NPI. La pila està buida."
+
+#: ../libqalculate/Calculator-parse.cc:2754
+msgid "RPN syntax error. Operator ignored as there was only one stack value."
+msgstr ""
+"Error de sintaxi NPI. S'ha ignorat l'operador perquè hi havia només un valor "
+"en la pila."
+
+#: ../libqalculate/Calculator-parse.cc:3674
+#: ../libqalculate/Calculator-parse.cc:3754
+msgid ""
+"The expression is ambiguous (be careful when combining implicit "
+"multiplication and division)."
+msgstr ""
+"L'expressió és ambigua (aneu amb compte en combinar la multiplicació i "
+"divisió implícites)."
+
+#: ../libqalculate/Calculator-parse.cc:4030
+#, c-format
+msgid "%s interpreted as 10^%s (1%s)"
+msgstr "%s interpretat com a 10^%s (1%s)"
+
+#: ../libqalculate/Calculator-plot.cc:109
+#: ../libqalculate/Calculator-plot.cc:139
+#: ../libqalculate/Calculator-plot.cc:169
+#: ../libqalculate/Calculator-plot.cc:590
+msgid "It took too long to generate the plot data."
+msgstr "S'ha trigat massa temps en generar les dades a dibuixar."
+
+#: ../libqalculate/Calculator-plot.cc:195
+msgid ""
+"Failed to invoke gnuplot. Make sure that you have gnuplot installed in your "
+"path."
+msgstr ""
+"S'ha fallat en invocar gnuplot. Assegureu-vos que tingueu gnuplot instal·lat "
+"en el vostre camí."
+
+#: ../libqalculate/Calculator-plot.cc:267
+msgid "No extension in file name. Saving as PNG image."
+msgstr "No hi ha extensió en el nom de fitxer. Es desa com a imatge PNG."
+
+#: ../libqalculate/Calculator-plot.cc:286
+msgid "Unknown extension in file name. Saving as PNG image."
+msgstr "No es coneix l'extensió en el nom de fitxer. Es desa com a imatge PNG."
+
+#: ../libqalculate/Calculator-plot.cc:514
+#, c-format
+msgid "Could not create temporary file %s"
+msgstr "No s'ha pogut crear el fitxer temporal %s"
+
+#: ../libqalculate/DataSet.cc:407
+#, c-format
+msgid "Object %s not available in data set."
+msgstr "L'objecte %s no està disponible en el conjunt de dades."
+
+#: ../libqalculate/DataSet.cc:417
+#, c-format
+msgid "Property %s not available in data set."
+msgstr "La propietat %s no està disponible en el conjunt de dades."
+
+#: ../libqalculate/DataSet.cc:422
+#, c-format
+msgid "Property %s not defined for object %s."
+msgstr "La propietat %s no està definida per a l'objecte %s."
+
+#: ../libqalculate/DataSet.cc:551 ../libqalculate/DataSet.cc:559
+#, c-format
+msgid "Unable to load data objects in %s."
+msgstr "No es pot carregar els objectes de dades en %s."
+
+#: ../libqalculate/DataSet.cc:1083
+msgid "data property"
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1085
+msgid "name of a data property"
+msgstr "nom d'una propietat de dada"
+
+#: ../libqalculate/DataSet.cc:1093 ../libqalculate/DataSet.cc:1109
+msgid "no properties available"
+msgstr "sense propietats disponibles"
+
+#: ../libqalculate/DataSet.cc:1143
+#, c-format
+msgid ""
+"Data set \"%s\" has no object key that supports the provided argument type."
+msgstr ""
+"El conjunt de dades \"%s\" no té cap clau d'objecte que sigui compatible amb "
+"el tipus d'argument proveït."
+
+#: ../libqalculate/DataSet.cc:1148
+msgid "data object"
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1151
+msgid "an object from"
+msgstr ""
+
+#: ../libqalculate/DataSet.cc:1178
+msgid "use"
+msgstr ""
+
+#: ../libqalculate/MathStructure-calculate.cc:76
+#, c-format
+msgid "Required assumption: %s."
+msgstr "Suposició requerida: %s."
+
+#: ../libqalculate/MathStructure-calculate.cc:95
+#: ../libqalculate/MathStructure-calculate.cc:117
+#: ../libqalculate/MathStructure-calculate.cc:148
+#: ../libqalculate/MathStructure-integrate.cc:7154
+#, c-format
+msgid "To avoid division by zero, the following must be true: %s."
+msgstr "Per a evitar dividir per zero, ho següent ha de ser cert: %s."
+
+#: ../libqalculate/MathStructure-calculate.cc:1662
+#: ../libqalculate/MathStructure-calculate.cc:1684
+#, c-format
+msgid ""
+"The second matrix must have as many rows (was %s) as the first has columns "
+"(was %s) for matrix multiplication."
+msgstr ""
+"La segona matriu ha de tenir tantes files (eren %s) com la primera té "
+"columnes (eren %s) per a multiplicació de matrius."
+
+#: ../libqalculate/MathStructure-calculate.cc:6342
+#: ../libqalculate/MathStructure-calculate.cc:6381
+#: ../libqalculate/MathStructure-calculate.cc:6413
+#: ../libqalculate/MathStructure-calculate.cc:6478
+#: ../libqalculate/MathStructure-calculate.cc:6506
+#: ../libqalculate/MathStructure-calculate.cc:6525
+#: ../libqalculate/MathStructure-calculate.cc:6544
+#: ../libqalculate/MathStructure-calculate.cc:6563
+#: ../libqalculate/MathStructure-calculate.cc:6671
+#: ../libqalculate/MathStructure-factor.cc:413
+#: ../libqalculate/MathStructure-factor.cc:1304
+msgid "This is a bug. Please report it."
+msgstr "Això és un defecte. Si us plau, reporteu-ho."
+
+#: ../libqalculate/MathStructure-calculate.cc:6760
+#: ../libqalculate/Function.cc:552
+msgid "No unknown variable/symbol was found."
+msgstr "No s'ha trobat cap variable desconeguda o símbol desconegut."
+
+#: ../libqalculate/MathStructure-eval.cc:754
+msgid "Interval potentially calculated wide."
+msgstr "L'interval potencialment s'ha calculat de manera àmplia."
+
+#: ../libqalculate/MathStructure-eval.cc:2292
+msgid ""
+"Calculation of uncertainty propagation partially failed (using interval "
+"arithmetic instead when necessary)."
+msgstr ""
+"El càlcul de propagació d'incertesa ha fallat parcialment (usant "
+"l'aritmètica d'interval en compte quan és necessari)"
+
+#: ../libqalculate/MathStructure-eval.cc:2438
+msgid ""
+"Calculation of uncertainty propagation failed (using interval arithmetic "
+"instead)."
+msgstr ""
+"El càlcul de la propagació d'incertesa ha fallat (usant aritmètica "
+"d'interval en compte)."
+
+#: ../libqalculate/MathStructure-factor.cc:3160
+msgid ""
+"Because of time constraints only a limited number of combinations of terms "
+"were tried during factorization. Repeat factorization to try other random "
+"combinations."
+msgstr ""
+"A cause de límits de temps, només s'ha provat un nombre limitat de "
+"combinacions de terminis durant la factorització. Repetiu la factorització "
+"per a provar altres combinacions aleatòries."
+
+#: ../libqalculate/MathStructure-integrate.cc:7736
+#: ../libqalculate/MathStructure-integrate.cc:7811
+msgid "Unable to integrate the expression exactly."
+msgstr "No es pot integrar l'expressió amb exactitud."
+
+#: ../libqalculate/MathStructure-integrate.cc:7775
+msgid "Definite integral was approximated."
+msgstr "S'ha aproximat l'integral definit."
+
+#: ../libqalculate/MathStructure-isolatex.cc:999
+#: ../libqalculate/MathStructure-isolatex.cc:1176
+#: ../libqalculate/MathStructure-isolatex.cc:1815
+#: ../libqalculate/MathStructure-isolatex.cc:2335
+#: ../libqalculate/MathStructure-isolatex.cc:2401
+#: ../libqalculate/MathStructure-isolatex.cc:2451
+#: ../libqalculate/MathStructure-isolatex.cc:2472
+#: ../libqalculate/MathStructure-isolatex.cc:2530
+#: ../libqalculate/MathStructure-isolatex.cc:2656
+#: ../libqalculate/MathStructure-isolatex.cc:2801
+#, c-format
+msgid "Interval arithmetic was disabled during calculation of %s."
+msgstr "L'aritmètica d'interval estava deshabitat durant el càlcul de %s."
+
+#: ../libqalculate/MathStructure-isolatex.cc:2800
+#, c-format
+msgid "Not all complex roots were calculated for %s."
+msgstr "No s'han calculat totes les arrels complexes per a %s."
+
+#: ../libqalculate/MathStructure-isolatex.cc:4394
+#, c-format
+msgid "Only one or two of the roots were calculated for %s."
+msgstr "Només s'han calculat una o dos de les arrels per a %s."
+
+#: ../libqalculate/MathStructure-limit.cc:967
+#: ../libqalculate/MathStructure-limit.cc:972
+#, c-format
+msgid "Limit for %s determined graphically."
+msgstr "S'ha determinat el límit de %s gràficament."
+
+#: ../libqalculate/MathStructure-matrixvector.cc:62
+#, c-format
+msgid "Unsolvable comparison at element %s when trying to rank vector."
+msgstr ""
+"Hi ha una comparació irresoluble a l'element %s quan s'intenta determinar el "
+"rang del vector."
+
+#: ../libqalculate/MathStructure-matrixvector.cc:112
+#, c-format
+msgid "Unsolvable comparison at element %s when trying to sort vector."
+msgstr ""
+"Hi ha una comparació irresoluble a l'element %s quan s'intenta ordenar el "
+"vector."
+
+#: ../libqalculate/MathStructure-matrixvector.cc:537
+msgid "The determinant can only be calculated for square matrices."
+msgstr "Només es pot calcular el determinant de una matriu quadrada."
+
+#: ../libqalculate/MathStructure-matrixvector.cc:600
+msgid "The permanent can only be calculated for square matrices."
+msgstr "Només es pot calcular el permanent de una matriu quadrada."
+
+#: ../libqalculate/MathStructure-matrixvector.cc:687
+msgid "Inverse of singular matrix."
+msgstr "Inversa d'una matriu singular."
+
+#: ../libqalculate/MathStructure-matrixvector.cc:852
+#: ../libqalculate/MathStructure-matrixvector.cc:898
+msgid "Too many data points"
+msgstr "Hi ha massa dades"
+
+#: ../libqalculate/MathStructure-matrixvector.cc:859
+msgid ""
+"The selected min and max do not result in a positive, finite number of data "
+"points"
+msgstr ""
+"El mínim i màxim seleccionats no resulten en un nombre finit positiu de dades"
+
+#: ../libqalculate/MathStructure-matrixvector.cc:895
+msgid ""
+"The selected min, max and step size do not result in a positive, finite "
+"number of data points"
+msgstr ""
+"El mínim, màxim i mida de pas seleccionats no resulten en un nombre finit "
+"positiu de dades"
+
+#: ../libqalculate/MathStructure-print.cc:3677
+msgid "undefined"
+msgstr ""
+
+#: ../libqalculate/Function.cc:185
+#, c-format
+msgid "%s() requires that %s"
+msgstr "%s() requereix que %s"
+
+#: ../libqalculate/Function.cc:351 ../libqalculate/Function.cc:413
+#: ../libqalculate/Function.cc:469
+#, c-format
+msgid ""
+"Additional arguments for function %s() were ignored. Function can only use "
+"%s argument."
+msgid_plural ""
+"Additional arguments for function %s() were ignored. Function can only use "
+"%s arguments."
+msgstr[0] ""
+"S'han ignorat els arguments addicionals a la funció %s(). La funció només "
+"pot usar %s argument."
+msgstr[1] ""
+"S'han ignorat els arguments addicionals a la funció %s(). La funció només "
+"pot usar %s arguments."
+
+#: ../libqalculate/Function.cc:490
+#, c-format
+msgid "You need at least %s argument (%s) in function %s()."
+msgid_plural "You need at least %s arguments (%s) in function %s()."
+msgstr[0] "Necessiteu al menys %s argument (%s) en la funció %s()."
+msgstr[1] "Necessiteu al menys %s arguments (%s) en la funció %s()."
+
+#: ../libqalculate/Function.cc:492
+#, c-format
+msgid "You need at least %s argument in function %s()."
+msgid_plural "You need at least %s arguments in function %s()."
+msgstr[0] "Necessiteu al menys %s argument en la funció %s()."
+msgstr[1] "Necessiteu al menys %s arguments en la funció %s()."
+
+#: ../libqalculate/Function.cc:1346
+msgid "a free value"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1351
+msgid "that is nonzero"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1359
+msgid "that is rational (polynomial)"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1367
+msgid "that fulfills the condition:"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1434
+#, c-format
+msgid "Argument %s in %s() must be %s."
+msgstr "L'argument %s en %s() ha de ser %s."
+
+#: ../libqalculate/Function.cc:1436
+#, c-format
+msgid "Argument %s, %s, in %s() must be %s."
+msgstr "L'argument %s, %s, en %s() ha de ser %s."
+
+#: ../libqalculate/Function.cc:1778
+msgid "a rational number"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1780
+msgid "a number"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1782
+msgid "a real number"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1787 ../libqalculate/Function.cc:1940
+#: ../libqalculate/Function.cc:1945
+msgid ">="
+msgstr ""
+
+#: ../libqalculate/Function.cc:1789
+msgid ">"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1801 ../libqalculate/Function.cc:1962
+#: ../libqalculate/Function.cc:1969
+msgid "<="
+msgstr ""
+
+#: ../libqalculate/Function.cc:1803
+msgid "<"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1937
+msgid "an integer"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1994
+msgid "symbol"
+msgstr ""
+
+#: ../libqalculate/Function.cc:1995
+msgid "an unknown variable/symbol"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2008
+msgid "text"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2009
+msgid "a text string"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2031
+msgid "date"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2032
+msgid "a date"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2081
+msgid "a vector with "
+msgstr ""
+
+#: ../libqalculate/Function.cc:2093
+msgid "a vector"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2145
+msgid "a square matrix"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2147
+msgid "a matrix"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2162
+msgid "object"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2163
+msgid "a valid function, unit or variable name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2177
+msgid "a valid function name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2190
+msgid "unit"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2191
+msgid "a valid unit name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2205
+msgid "a valid variable name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2218
+msgid "file"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2219
+msgid "a valid file name"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2233
+msgid "a boolean (0 or 1)"
+msgstr ""
+
+#: ../libqalculate/Function.cc:2244
+msgid "an angle or a number (using the default angle unit)"
+msgstr ""
+
+#: ../libqalculate/Number.cc:280 ../libqalculate/Number.cc:10743
+msgid ""
+"Cannot display numbers greater than 9999 or less than -9999 as roman "
+"numerals."
+msgstr ""
+"No es pot mostrar nombres superiors a 9999 o inferiors a -9999 com a "
+"numerals romans."
+
+#: ../libqalculate/Number.cc:380
+#, c-format
+msgid "Character '%s' was ignored in the number \"%s\" in bijective base-26."
+msgstr "S'ha ignorat el caràcter '%s' en el nombre \"%s\" en base 26 bijectiu."
+
+#: ../libqalculate/Number.cc:571
+#, c-format
+msgid "Digits (%s) are higher than expected for number base."
+msgstr "Les xifres (%s) són més altes que s'esperava per a la base numèrica."
+
+#: ../libqalculate/Number.cc:623
+msgid ""
+"Assuming the unusual practice of letting a last capital I mean 2 in a roman "
+"numeral."
+msgstr ""
+"Es presumeix la pràctica inusual de deixar que una I majúscula final vulgui "
+"dir 2 en un numeral romà."
+
+#: ../libqalculate/Number.cc:707 ../libqalculate/Number.cc:734
+#: ../libqalculate/Number.cc:739
+#, c-format
+msgid "Error in roman numerals: %s."
+msgstr "Error en numerals romans: %s."
+
+#: ../libqalculate/Number.cc:744
+#, c-format
+msgid "Unknown roman numeral: %c."
+msgstr "Numeral romà desconegut: %c."
+
+#: ../libqalculate/Number.cc:802
+#, c-format
+msgid ""
+"Errors in roman numerals: \"%s\". Interpreted as %s, which should be written "
+"as %s."
+msgstr ""
+"Errors en numerals romans: \"%s\". S'ha interpretat com a %s, el qual es deu "
+"escriure com a %s."
+
+#: ../libqalculate/Number.cc:905
+msgid "Too large exponent."
+msgstr "L'exponent és massa gran."
+
+#: ../libqalculate/Number.cc:935
+msgid "Misplaced decimal separator ignored"
+msgstr "S'ha ignorat un separador decimal fora de lloc"
+
+#. only allow decimals after last ":"
+#: ../libqalculate/Number.cc:941
+msgid "':' in decimal number ignored (decimal point detected)."
+msgstr ""
+"S'ha ignorat ':' en el nombre decimal (s'ha detectat una coma decimal)."
+
+#: ../libqalculate/Number.cc:2066 ../libqalculate/Number.cc:2191
+msgid "Floating point division by zero exception"
+msgstr "Excepció de punt flotant de divisió per zero"
+
+#: ../libqalculate/Number.cc:2067 ../libqalculate/Number.cc:2194
+msgid "Floating point not a number exception"
+msgstr "Excepció de punt flotant de valor no nombre"
+
+#: ../libqalculate/Number.cc:2068 ../libqalculate/Number.cc:2192
+msgid "Floating point range exception"
+msgstr "Excepció de rang de punt flotant"
+
+#: ../libqalculate/Number.cc:3678
+msgid "Division by zero."
+msgstr "Divisió per zero."
+
+#. 0^0
+#: ../libqalculate/Number.cc:3684
+msgid "0^0 might be considered undefined"
+msgstr "Es pot considerar 0^0 com a no definit"
+
+#: ../libqalculate/Number.cc:3691
+msgid "The result of 0^i is possibly undefined"
+msgstr "El resultat de 0^i possiblement no és definit"
+
+#: ../libqalculate/Number.cc:3740 ../libqalculate/Number.cc:6270
+#: ../libqalculate/Number.cc:6381 ../libqalculate/Number.cc:6705
+#: ../libqalculate/Number.cc:6713 ../libqalculate/Number.cc:6746
+#: ../libqalculate/Number.cc:6843 ../libqalculate/Number.cc:6992
+#: ../libqalculate/Number.cc:7104
+msgid "Interval calculated wide."
+msgstr "L'interval s'ha calculat de manera àmplia."
+
+#: ../libqalculate/Number.cc:5192 ../libqalculate/Number.cc:5418
+#: ../libqalculate/Number.cc:5505 ../libqalculate/Number.cc:5890
+#: ../libqalculate/Number.cc:5976 ../libqalculate/Number.cc:6062
+#: ../libqalculate/Number.cc:7309 ../libqalculate/Number.cc:7327
+#: ../libqalculate/Number.cc:7346 ../libqalculate/Number.cc:7682
+#: ../libqalculate/Number.cc:7729 ../libqalculate/Number.cc:7874
+#: ../libqalculate/Number.cc:8378 ../libqalculate/Number.cc:8534
+#: ../libqalculate/Number.cc:8966 ../libqalculate/Number.cc:9361
+#, c-format
+msgid "%s() lacks proper support interval arithmetic."
+msgstr "A %s() li manca suport per a aritmètica d'interval adequat."
+
+#: ../libqalculate/Number.cc:9971
+#, c-format
+msgid "The value is too high for the number of floating point bits (%s)."
+msgstr "El valor és massa alt per al nombre de bits de punt flotant (%s)."
+
+#: ../libqalculate/Number.cc:10225
+msgid "Unsupported base"
+msgstr "Base no compatible"
+
+#: ../libqalculate/Number.cc:10740
+msgid "Can only display rational numbers as roman numerals."
+msgstr "Només els nombres racionals es poden mostrar com a numerals romans."
+
+#: ../libqalculate/Number.cc:11227 ../libqalculate/Number.cc:11235
+msgid "infinity"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "January"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "February"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "March"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "April"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "May"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "June"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "July"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "August"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "September"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "October"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "November"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:29
+msgid "December"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Thout"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Paopi"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Hathor"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Koiak"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Tobi"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Meshir"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Paremhat"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Parmouti"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Pashons"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Paoni"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Epip"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Mesori"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:30
+msgid "Pi Kogi Enavot"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Mäskäräm"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ṭəqəmt"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ḫədar"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Taḫśaś"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ṭərr"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Yäkatit"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Mägabit"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Miyazya"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Gənbo"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Säne"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ḥamle"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Nähase"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:31
+msgid "Ṗagume"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Muḥarram"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Ṣafar"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Rabī‘ al-awwal"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Rabī‘ ath-thānī"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Jumādá al-ūlá"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Jumādá al-ākhirah"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Rajab"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Sha‘bān"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Ramaḍān"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Shawwāl"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Dhū al-Qa‘dah"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:32
+msgid "Dhū al-Ḥijjah"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Farvardin"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Ordibehesht"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Khordad"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Tir"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Mordad"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Shahrivar"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Mehr"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Aban"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Azar"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Dey"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Bahman"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:33
+msgid "Esfand"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Chaitra"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Vaishākha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Jyēshtha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Āshādha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Shrāvana"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Bhaadra"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Āshwin"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Kārtika"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Agrahayana"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Pausha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Māgha"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:34
+msgid "Phalguna"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Wood"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Fire"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Earth"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Metal"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:35
+msgid "Water"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Rat"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Ox"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Tiger"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Rabbit"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Dragon"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Snake"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Horse"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Goat"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Monkey"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Rooster"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Dog"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:36
+msgid "Pig"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:360
+msgid "now"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:364
+msgid "today"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:368
+msgid "tomorrow"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:373
+msgid "yesterday"
+msgstr ""
+
+#: ../libqalculate/QalculateDateTime.cc:2618
+msgid "leap month"
+msgstr ""
+
+#: ../libqalculate/Unit.cc:1197
+msgid "Error(s) in unitexpression."
+msgstr "Hi ha errors en l'expressió de unitat."
+
+#: ../libqalculate/Variable.cc:508
+#, c-format
+msgid "Recursive variable: %s = %s"
+msgstr "Variable recursiva: %s = %s"
+
+#: ../libqalculate/util.cc:172
+msgid "Yes"
+msgstr ""
+
+#: ../libqalculate/util.cc:173
+msgid "No"
+msgstr ""
+
+#: ../libqalculate/util.cc:180
+msgid "True"
+msgstr ""
+
+#: ../libqalculate/util.cc:181
+msgid "False"
+msgstr ""
+
+#: ../libqalculate/util.cc:188
+msgid "On"
+msgstr ""
+
+#: ../libqalculate/util.cc:189
+msgid "Off"
+msgstr ""


### PR DESCRIPTION
I have only translated messages that are clearly error messages or help text, for three reasons:

1. The translation of many of these terms depends on context which is difficult to determine.

2. Catalan speakers generally expect to enter commands in English, rather than having command syntax translated into Catalan.

3. There is a LOT to translate and the longer descriptions are more helpful to users than loose words.

Once the translation is committed to the libqalculate repository, I will ask for it to be reviewed by Softcatalà and added to <https://www.softcatala.org/recursos/memories/>. Thanks!