### PR TITLE
Added Spanish translation of command interface, and updated descriptions

### DIFF
--- a/po-defs/es.po
+++ b/po-defs/es.po
@@ -6,7 +6,7 @@ msgstr ""
 "Project-Id-Version: Qalculate!\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-03 10:23+0200\n"
-"PO-Revision-Date: 2020-07-22 22:07-0300\n"
+"PO-Revision-Date: 2021-07-11 18:00-0300\n"
 "Last-Translator: VicSanRoPe\n"
 "Language-Team: none\n"
 "Language: es\n"
@@ -2101,6 +2101,8 @@ msgid ""
 "The property uses standard atomic weight, when determined, or the mass "
 "number."
 msgstr ""
+"La propiedad usa peso atómico estándar, cuando determinado, o el número "
+"másico."
 
 #: ../data/datasets.xml.in.h:20
 msgid "r:mass,r:weight"
@@ -3270,14 +3272,12 @@ msgid "r:dot"
 msgstr ""
 
 #: ../data/functions.xml.in.h:129
-#, fuzzy
 msgid "Calculates the dot product of two vectors."
-msgstr "Calcula el producto cruz dedos vectores tridimensionales."
+msgstr "Calcula el producto escalar de dos vectores."
 
 #: ../data/functions.xml.in.h:130
-#, fuzzy
 msgid "Element-wise Multiplication"
-msgstr "Función por cada elemento"
+msgstr "Multiplicación por cada elemento"
 
 #: ../data/functions.xml.in.h:131
 msgid "r:multiply,times"
@@ -3288,9 +3288,8 @@ msgid "Factors"
 msgstr "Factores"
 
 #: ../data/functions.xml.in.h:133
-#, fuzzy
 msgid "Element-wise Right Division"
-msgstr "División entera"
+msgstr "División derecha por cada elemento"
 
 #: ../data/functions.xml.in.h:134
 msgid "r:divide,rdivide"
@@ -3305,9 +3304,8 @@ msgid "Denominator"
 msgstr "Denominador"
 
 #: ../data/functions.xml.in.h:137
-#, fuzzy
 msgid "Element-wise Power"
-msgstr "Elementos"
+msgstr "Potencia por cada elemento"
 
 #: ../data/functions.xml.in.h:138
 msgid "r:pow,r:raise,power"
@@ -3726,6 +3724,8 @@ msgid ""
 "Counts the positive integers up to a given integer n that are relatively "
 "prime to n."
 msgstr ""
+"Cuenta los enteros positivos hasta el enterno n dado, que son primos "
+"relativos de n."
 
 #: ../data/functions.xml.in.h:228
 msgid "r:totient,au:&#x3C6;,phi"
@@ -3874,11 +3874,13 @@ msgstr ""
 "reales por defecto usan los dígitos 0-9 a A-Z.&#10;&#10;El conjunto de "
 "dígitos usados pueden ser seleccionados usando el tercer argumento (por "
 "defecto 0 para selección automática). Defínelo a 1 para los dígitos 0-9 y A-"
-"Z, 2 para 0-9, A-Z y a-z, 3 para dígitos Unicode, y 4 para phonewords, o "
-"ingrese una cadena de texto con todos los dígitos colocados en orden "
-"ascendente (ej. \"0123456789\" o \"0;aA1;bB2;cC3\"). Cuando el conjunto de "
-"dígitos es seleccionado manualmente, la expresión especificada siempre es "
-"convertida a un solo número."
+"Z, 2 para 0-9, A-Z y a-z, 3 para dígitos Unicode, y 4 para phonewords (ej. "
+"ABC=2, CDE=3, etc.), o ingrese una cadena de texto con todos los dígitos "
+"colocados en orden ascendente y opcionalmente separados por un punto y coma "
+"(para permitir múltiples dígitos equivalentes, ej. \"0123456789\" o "
+"\"0;aA1;bB2;cC3\"). Cuando el conjunto de dígitos es seleccionado "
+"manualmente, la expresión especificada siempre es convertida a un solo "
+"número."
 
 #: ../data/functions.xml.in.h:253
 msgid "Set of digits"
@@ -4814,7 +4816,7 @@ msgstr "Número romano"
 
 #: ../data/functions.xml.in.h:468
 msgid "Distance Between GPS Coordinates"
-msgstr ""
+msgstr "Distancia entre coordenadas GPS"
 
 #: ../data/functions.xml.in.h:469
 msgid "r:geodistance,gpsdistance"
@@ -4828,6 +4830,12 @@ msgid ""
 "decimal degrees), an angle (e.g. with degree unit), or a text string ending "
 "with N, S, E, or W (S for negative latitude, W for negative longitude)."
 msgstr ""
+"Calcula la distancia entre dos coordenadas geodéticas usando las fórmulas "
+"de Vincenty (con WGS 84), o en caso de fallo, la formula de Haversine."
+"Cada coordenada puede especificarsse usando un valor numérico "
+"(representando grados decimales), un ángulo (ej. con unidad de grados), "
+"o una cadena de texto que termine en N, S, E, o W (S para latitud "
+"negativa, W para longitud negativa)."
 
 #: ../data/functions.xml.in.h:471
 msgid "Latitude 1"
@@ -5536,9 +5544,8 @@ msgid "Standard deviation (σ)"
 msgstr "Desviación estándar (σ)"
 
 #: ../data/functions.xml.in.h:632
-#, fuzzy
 msgid "Inverse Normal Cumulative Distribution"
-msgstr "Distribución acumulativa inversa de Weibull"
+msgstr "Distribución normal acumulativa inversa"
 
 #: ../data/functions.xml.in.h:633
 msgid "r:normdistinv"
@@ -5665,9 +5672,8 @@ msgid "Degrees of freedom (k)"
 msgstr "Grado de libertad (k)"
 
 #: ../data/functions.xml.in.h:658
-#, fuzzy
 msgid "Inverse of Chi-Square Cumulative Distribution"
-msgstr "Distribución acumulativa inversa de Weibull"
+msgstr "Distribución chi cuadrado acumulativa inversa"
 
 #: ../data/functions.xml.in.h:659
 msgid "r:chisqdistinv"
@@ -5742,9 +5748,8 @@ msgid "Degrees of freedom (v)"
 msgstr "Grado de libertad (v)"
 
 #: ../data/functions.xml.in.h:674
-#, fuzzy
 msgid "Inverse Cumulative Student's t-distribution"
-msgstr "Distribución acumulativa inversa de Weibull"
+msgstr "Distribución t de Student acumulativa inversa"
 
 #: ../data/functions.xml.in.h:675
 msgid "r:tdistinv"
@@ -5775,9 +5780,8 @@ msgid "Degrees of freedom (denominator)"
 msgstr "Grado de libertad (denominador)"
 
 #: ../data/functions.xml.in.h:681
-#, fuzzy
 msgid "Inverse Cumulative F-distribution"
-msgstr "Distribución acumulativa inversa de Weibull"
+msgstr "Distribución F acumulativa inversa"
 
 #: ../data/functions.xml.in.h:682
 msgid "r:fdistinv"
@@ -5801,7 +5805,7 @@ msgstr ""
 
 #: ../data/functions.xml.in.h:686
 msgid "Location (x_0)"
-msgstr ""
+msgstr "Ubicación (x_0)"
 
 #: ../data/functions.xml.in.h:687
 msgid "Scale (γ)"
@@ -6197,20 +6201,23 @@ msgid ""
 "argument is true, each separate code unit (8, 16, or 32 bits depending on "
 "encoding) is placed in a vector."
 msgstr ""
+"Codifica un carácter o cadena de texto Unicode usando el formato "
+"seleccionado. Las codificaciones soportadas son UTF-8 (0), UTF-16 (1), y "
+"UTF-32 (2). Si el tercer argumento es verdadero, cada unidad de código "
+"separada (8, 16, o 32 dependiendo de la codificación) es colocada en un "
+"vector"
 
 #: ../data/functions.xml.in.h:769
 msgid "Character"
 msgstr "Carácter"
 
 #: ../data/functions.xml.in.h:770
-#, fuzzy
 msgid "Encoding"
-msgstr "Redondeo"
+msgstr "Codificación"
 
 #: ../data/functions.xml.in.h:771
-#, fuzzy
 msgid "Use vector"
-msgstr "vector"
+msgstr "Usar vector"
 
 #: ../data/functions.xml.in.h:772
 msgid "Unicode Character"
@@ -6554,7 +6561,7 @@ msgstr "Incertidumbre es relativa"
 
 #: ../data/functions.xml.in.h:856
 msgid "External Command"
-msgstr ""
+msgstr "Comando externo"
 
 #: ../data/functions.xml.in.h:857
 msgid "r:command"
@@ -6562,7 +6569,7 @@ msgstr ""
 
 #: ../data/functions.xml.in.h:858
 msgid "Command"
-msgstr ""
+msgstr "Comando"
 
 #: ../data/functions.xml.in.h:859
 msgid "Logical"
@@ -6836,16 +6843,15 @@ msgstr ""
 
 #: ../data/functions.xml.in.h:916
 msgid "Solve using Newton's Method"
-msgstr ""
+msgstr "Resolver usando el método de Newton"
 
 #: ../data/functions.xml.in.h:917
 msgid "r:newtonsolve"
 msgstr ""
 
 #: ../data/functions.xml.in.h:918
-#, fuzzy
 msgid "Initial estimate"
-msgstr "Valor inicial"
+msgstr "Estimación inicial"
 
 #: ../data/functions.xml.in.h:919 ../data/variables.xml.in.h:199
 msgid "Precision"
@@ -6857,21 +6863,19 @@ msgstr "Iteraciones máximas"
 
 #: ../data/functions.xml.in.h:921
 msgid "Solve using Secant Method"
-msgstr ""
+msgstr "Resolver usando el método de secante"
 
 #: ../data/functions.xml.in.h:922
 msgid "r:secantsolve"
 msgstr ""
 
 #: ../data/functions.xml.in.h:923
-#, fuzzy
 msgid "Initial estimate 1"
-msgstr "Valor inicial"
+msgstr "Estimación inicial 1"
 
 #: ../data/functions.xml.in.h:924
-#, fuzzy
 msgid "Initial estimate 2"
-msgstr "Valor inicial"
+msgstr "Estimación inicial 2"
 
 #: ../data/functions.xml.in.h:925
 msgid "Solve for two variables"
@@ -7908,9 +7912,9 @@ msgid ""
 "it is made at the end of each period."
 msgstr ""
 "Calcula el valor futuro de una inversión. Esto se basa en pagos constantes "
-"periódicos y en una tasa de interés constante.&#10;&#10;Tipo define la fecha "
-"de vencimiento: 1 para pago al comienzo de un período y cero "
-"(predeterminado) para pago al final de un período."
+"periódicos y en una tasa de interés constante.&#10;&#10;Si tipo = 1, el pago "
+"se hace al comienzo de un período. Si tipo = 0 (o omitido) es hecho al final "
+"de un período."
 
 #: ../data/functions.xml.in.h:1157
 msgid "Return on continuously compounded interest"
@@ -8401,7 +8405,7 @@ msgstr "Metro"
 
 #: ../data/units.xml.in.h:4
 msgid "ar:m,meter,p:meters,metre,p:metres"
-msgstr ""
+msgstr "metro,p:metros"
 
 #: ../data/units.xml.in.h:5
 msgid "Kilometer"
@@ -8425,7 +8429,7 @@ msgstr "Milla náutica"
 
 #: ../data/units.xml.in.h:10
 msgid "r:nautical_mile,p:nautical_miles"
-msgstr ""
+msgstr "milla,p:millas"
 
 #: ../data/units.xml.in.h:11
 msgid "&#xC5;ngstr&#xF6;m"
@@ -8449,7 +8453,7 @@ msgstr "Pulgada"
 
 #: ../data/units.xml.in.h:16
 msgid "ar:in,inch,p:inches"
-msgstr ""
+msgstr "pulgada,p:pulgadas"
 
 #: ../data/units.xml.in.h:17
 msgid "Hand"
@@ -8465,7 +8469,7 @@ msgstr "Pie"
 
 #: ../data/units.xml.in.h:20
 msgid "ar:ft,foot,p:feet"
-msgstr ""
+msgstr "pie,p:pie"
 
 #: ../data/units.xml.in.h:21
 msgid "U.S. Survey Foot"
@@ -8489,7 +8493,7 @@ msgstr "Yarda"
 
 #: ../data/units.xml.in.h:26
 msgid "ar:yd,yard,p:yards"
-msgstr ""
+msgstr "yarda,p:yardas"
 
 #: ../data/units.xml.in.h:27
 msgid "Rod (pole/perch)"
@@ -8529,7 +8533,7 @@ msgstr "Milla"
 
 #: ../data/units.xml.in.h:36
 msgid "ar:mi,mile,p:miles"
-msgstr ""
+msgstr "milla,p:millas"
 
 #: ../data/units.xml.in.h:37
 msgid "U.S. Survey Mile"
@@ -8634,7 +8638,7 @@ msgstr "Radián"
 
 #: ../data/units.xml.in.h:63
 msgid "ar:rad,radian,p:radians"
-msgstr ""
+msgstr "radián,p:radianes"
 
 #. angle unit
 #: ../data/units.xml.in.h:65
@@ -8643,7 +8647,7 @@ msgstr "Grado"
 
 #: ../data/units.xml.in.h:66
 msgid "ar:deg,au:&#xB0;,degree,p:degrees"
-msgstr ""
+msgstr "grado,p;grados"
 
 #: ../data/units.xml.in.h:67
 msgid "Gradian (Gon)"
@@ -8651,7 +8655,7 @@ msgstr "Gradián (Gon)"
 
 #: ../data/units.xml.in.h:68
 msgid "ar:gra,gradian,p:gradians,gon,p:gons"
-msgstr ""
+msgstr "gradián,p:gradianes"
 
 #: ../data/units.xml.in.h:69
 msgid "Arcminute"
@@ -8659,7 +8663,7 @@ msgstr "Arcominuto"
 
 #: ../data/units.xml.in.h:70
 msgid "ar:arcmin,arcminute,p:arcminutes"
-msgstr ""
+msgstr "arcominuto,p:arcominutos"
 
 #: ../data/units.xml.in.h:71
 msgid "Arcsecond"
@@ -8667,7 +8671,7 @@ msgstr "Arcosegundo"
 
 #: ../data/units.xml.in.h:72
 msgid "ar:arcsec,arcsecond,p:arcseconds"
-msgstr ""
+msgstr "arcosegundo,p:arcosegundos"
 
 #: ../data/units.xml.in.h:73
 msgid "Turn"
@@ -8687,7 +8691,7 @@ msgstr "Estereorradián"
 
 #: ../data/units.xml.in.h:77
 msgid "ar:sr,steradian,p:steradians"
-msgstr ""
+msgstr "estereorradián,p:estereorradianes"
 
 #: ../data/units.xml.in.h:78
 msgid "Angular Acceleration"
@@ -8716,7 +8720,7 @@ msgstr "Gramo"
 
 #: ../data/units.xml.in.h:85
 msgid "ar:g,gram,p:grams"
-msgstr ""
+msgstr "gramo,p:gramos"
 
 #: ../data/units.xml.in.h:86
 msgid "Kilogram"
@@ -8732,7 +8736,7 @@ msgstr "Tonelada métrica"
 
 #: ../data/units.xml.in.h:89
 msgid "ar:t,tonne,p:tonnes,ton,p:tons"
-msgstr ""
+msgstr "tonelada,p:toneladas"
 
 #: ../data/units.xml.in.h:90
 msgid "Grain"
@@ -8744,7 +8748,7 @@ msgstr ""
 
 #: ../data/units.xml.in.h:92
 msgid "Pennyweight"
-msgstr "Pennyweight"
+msgstr ""
 
 #: ../data/units.xml.in.h:93
 msgid "ar:pwt,pennyweight,p:pennyweights"
@@ -8780,7 +8784,7 @@ msgstr "Onza"
 
 #: ../data/units.xml.in.h:101
 msgid "ar:oz,ounce,p:ounces"
-msgstr ""
+msgstr "onza,p:onzas"
 
 #: ../data/units.xml.in.h:102
 msgid "Pound"
@@ -8788,7 +8792,7 @@ msgstr "Libra"
 
 #: ../data/units.xml.in.h:103
 msgid "ar:lb,aou:&#x2114;,pound,p:pounds"
-msgstr ""
+msgstr "libra,p:libras"
 
 #: ../data/units.xml.in.h:104
 msgid "Short Hundredweight (Cental)"
@@ -8912,19 +8916,19 @@ msgstr "Kilogramo por kilogramo"
 
 #: ../data/units.xml.in.h:138
 msgid "ar:s,second,p:seconds"
-msgstr ""
+msgstr "segundo,p:segundos"
 
 #: ../data/units.xml.in.h:140
 msgid "ar:min,minute,p:minutes"
-msgstr ""
+msgstr "minuto,p:minutos"
 
 #: ../data/units.xml.in.h:142
 msgid "ar:h,hour,p:hours"
-msgstr ""
+msgstr "hora,p:horas"
 
 #: ../data/units.xml.in.h:144
 msgid "ar:d,day,p:days"
-msgstr ""
+msgstr "día,p:días"
 
 #: ../data/units.xml.in.h:145
 msgid "Week"
@@ -8932,7 +8936,7 @@ msgstr "Semana"
 
 #: ../data/units.xml.in.h:146
 msgid "r:week,p:weeks"
-msgstr ""
+msgstr "semana,p:semana"
 
 #: ../data/units.xml.in.h:147
 msgid "Fortnight"
@@ -8948,11 +8952,11 @@ msgstr "Año juliano"
 
 #: ../data/units.xml.in.h:150
 msgid "r:year,p:years,a:yr,annus"
-msgstr ""
+msgstr "año,p:años"
 
 #: ../data/units.xml.in.h:152
 msgid "r:month,p:months"
-msgstr ""
+msgstr "mes,p:meses"
 
 #: ../data/units.xml.in.h:153
 msgid "Planck Time"
@@ -8979,9 +8983,11 @@ msgstr "Frecuencia"
 msgid "Hertz"
 msgstr "Hercio"
 
+# Some people use the english names of electrical units :(
+# ... personal experience
 #: ../data/units.xml.in.h:160
 msgid "ar:Hz,hertz"
-msgstr ""
+msgstr "hercio,p:hercios,hertz"
 
 #: ../data/units.xml.in.h:161
 msgid "Electricity"
@@ -8997,7 +9003,7 @@ msgstr "Amperio"
 
 #: ../data/units.xml.in.h:164
 msgid "ar:A,ampere,p:amperes"
-msgstr ""
+msgstr "amperio,p:amperios,ampere"
 
 #: ../data/units.xml.in.h:165
 msgid "Abampere"
@@ -9025,7 +9031,7 @@ msgstr "Culombio"
 
 #: ../data/units.xml.in.h:171
 msgid "ar:C,coulomb,p:coulombs"
-msgstr ""
+msgstr "culombio,p:culombios,coulomb"
 
 #: ../data/units.xml.in.h:172
 msgid "Abcoulomb"
@@ -9077,7 +9083,7 @@ msgstr "Voltio"
 
 #: ../data/units.xml.in.h:184
 msgid "ar:V,volt,p:volts"
-msgstr ""
+msgstr "voltio,p:voltios,volt"
 
 #: ../data/units.xml.in.h:185
 msgid "Statvolt"
@@ -9109,7 +9115,7 @@ msgstr "Faradio"
 
 #: ../data/units.xml.in.h:192
 msgid "ar:F,farad,p:farads"
-msgstr ""
+msgstr "faradio,p:faradios,farad"
 
 #: ../data/units.xml.in.h:193
 msgid "Electric Resistance"
@@ -9121,7 +9127,7 @@ msgstr "Ohmio"
 
 #: ../data/units.xml.in.h:195
 msgid "au:&#x3A9;,r:ohm,p:ohms,auio:&#x2126;"
-msgstr ""
+msgstr "ohm,p:ohmios"
 
 #: ../data/units.xml.in.h:196
 msgid "Abohm"
@@ -9181,11 +9187,11 @@ msgstr "Henrio"
 
 #: ../data/units.xml.in.h:210
 msgid "ar:H,henry,p:henrys"
-msgstr ""
+msgstr "henrio,p:henrio,henry"
 
 #: ../data/units.xml.in.h:211
 msgid "Abhenry"
-msgstr ""
+msgstr "Abhenrio"
 
 #: ../data/units.xml.in.h:212
 msgid "r:abhenry,p:abhenrys,a:abH"
@@ -9434,7 +9440,7 @@ msgstr "Hectárea"
 
 #: ../data/units.xml.in.h:273
 msgid "ar:ha,hectare,p:hectares"
-msgstr ""
+msgstr "hectárea,p:hectáreas"
 
 #: ../data/units.xml.in.h:274
 msgid "Decare"
@@ -9510,7 +9516,7 @@ msgstr "Litro"
 
 #: ../data/units.xml.in.h:292
 msgid "ar:L,a:l,aou:&#x2113;,liter,p:liters,litre,p:litres"
-msgstr ""
+msgstr "litro,p:litros"
 
 #: ../data/units.xml.in.h:293
 msgid "Milliliter"
@@ -10010,7 +10016,7 @@ msgstr ""
 
 #: ../data/units.xml.in.h:417
 msgid "ar:Pa,pascal,p:pascals"
-msgstr ""
+msgstr "pascal,p:pascales"
 
 #: ../data/units.xml.in.h:418
 msgid "Kilogram-force per Square Centimetre"
@@ -10030,7 +10036,7 @@ msgstr ""
 
 #: ../data/units.xml.in.h:422
 msgid "r:bar,p:bars"
-msgstr ""
+msgstr "bar,p:bares"
 
 #: ../data/units.xml.in.h:423
 msgid "Atmosphere"
@@ -10038,7 +10044,7 @@ msgstr "Atmósfera"
 
 #: ../data/units.xml.in.h:424
 msgid "ar:atm,atmosphere,p:atmospheres"
-msgstr ""
+msgstr "atmósfera,p:atmósferas"
 
 #: ../data/units.xml.in.h:425
 msgid "Torr"
@@ -10066,11 +10072,11 @@ msgstr ""
 
 #: ../data/units.xml.in.h:431
 msgid "Millitorr"
-msgstr ""
+msgstr "Militorr"
 
 #: ../data/units.xml.in.h:432
 msgid "Barye"
-msgstr ""
+msgstr "Baria"
 
 #: ../data/units.xml.in.h:433
 msgid "ar:Ba,barye"
@@ -10134,7 +10140,7 @@ msgstr "Julio"
 
 #: ../data/units.xml.in.h:448
 msgid "ar:J,joule,p:joules"
-msgstr ""
+msgstr "julio,p:julios"
 
 #: ../data/units.xml.in.h:449
 msgid "Watt Hour"
@@ -10266,7 +10272,7 @@ msgstr "Vatio"
 
 #: ../data/units.xml.in.h:481
 msgid "ar:W,watt,p:watts"
-msgstr ""
+msgstr "vatio,p:vatios"
 
 #: ../data/units.xml.in.h:482
 msgid "Horse Power"
@@ -10302,7 +10308,7 @@ msgstr ""
 
 #: ../data/units.xml.in.h:490
 msgid "Erg per Second"
-msgstr "Erg por segundo"
+msgstr "Ergio por segundo"
 
 #: ../data/units.xml.in.h:491
 msgid "Entropy"
@@ -10389,9 +10395,8 @@ msgid "ar:Ci,curie,p:curies"
 msgstr ""
 
 #: ../data/units.xml.in.h:512
-#, fuzzy
 msgid "Rutherford"
-msgstr "Rutherfordio"
+msgstr ""
 
 #: ../data/units.xml.in.h:513
 msgid "ar:Rd,rutherford,p:rutherfords"
@@ -10434,18 +10439,16 @@ msgid "Roentgen Equivalent Man (Rem)"
 msgstr ""
 
 #: ../data/units.xml.in.h:523
-#, fuzzy
 msgid "ros:rem_radioactivity,a:rem"
-msgstr "Radioactividad"
+msgstr ""
 
 #: ../data/units.xml.in.h:524
-#, fuzzy
 msgid "Millirem"
-msgstr "Milímetro"
+msgstr "Milirem"
 
 #: ../data/units.xml.in.h:525
 msgid "Erg per Gram"
-msgstr "Erg por gramo"
+msgstr "Ergio por gramo"
 
 #: ../data/units.xml.in.h:526
 msgid "Exposure"
@@ -10473,7 +10476,7 @@ msgstr "Grays por segundo"
 
 #: ../data/units.xml.in.h:532
 msgid "Millirem per Hour"
-msgstr "Millirem por hora"
+msgstr "Milirem por hora"
 
 #: ../data/units.xml.in.h:533
 msgid "Ratio"
@@ -10501,7 +10504,7 @@ msgstr "Decibelio"
 
 #: ../data/units.xml.in.h:539
 msgid "ar:dB,decibel,p:decibels"
-msgstr ""
+msgstr "decibelio,p:decibelios"
 
 #: ../data/units.xml.in.h:540
 msgid "Information"
@@ -10690,7 +10693,7 @@ msgstr "Por ciento"
 #: ../data/variables.xml.in.h:8
 #, no-c-format
 msgid "a:%,r:percent"
-msgstr ""
+msgstr "porciento"
 
 #: ../data/variables.xml.in.h:9
 msgid "Large Numbers"
@@ -10718,7 +10721,7 @@ msgstr "1E303"
 
 #: ../data/variables.xml.in.h:15
 msgid "-r:centillion"
-msgstr ""
+msgstr "(1E303)"
 
 #: ../data/variables.xml.in.h:16
 msgid "Vigintillion"
@@ -10726,7 +10729,7 @@ msgstr "Mil decillones"
 
 #: ../data/variables.xml.in.h:17
 msgid "-r:vigintillion"
-msgstr ""
+msgstr "(1E63)"
 
 #: ../data/variables.xml.in.h:18
 msgid "Novemdecillion"
@@ -10734,7 +10737,7 @@ msgstr "Decillón"
 
 #: ../data/variables.xml.in.h:19
 msgid "-r:novemdecillion"
-msgstr ""
+msgstr "decillón"
 
 #: ../data/variables.xml.in.h:20
 msgid "Octodecillion"
@@ -10742,7 +10745,7 @@ msgstr "Mil nonillones"
 
 #: ../data/variables.xml.in.h:21
 msgid "-r:octodecillion"
-msgstr ""
+msgstr "(1E57)"
 
 #: ../data/variables.xml.in.h:22
 msgid "Septendecillion"
@@ -10750,7 +10753,7 @@ msgstr "Nonillón"
 
 #: ../data/variables.xml.in.h:23
 msgid "-r:septendecillion"
-msgstr ""
+msgstr "nonillón"
 
 #: ../data/variables.xml.in.h:24
 msgid "Sexdecillion"
@@ -10758,7 +10761,7 @@ msgstr "Mil octillones"
 
 #: ../data/variables.xml.in.h:25
 msgid "-r:sexdecillion"
-msgstr ""
+msgstr "(1E51)"
 
 #: ../data/variables.xml.in.h:26
 msgid "Quindecillion"
@@ -10766,7 +10769,7 @@ msgstr "Octillón"
 
 #: ../data/variables.xml.in.h:27
 msgid "-r:quindecillion"
-msgstr ""
+msgstr "octillón"
 
 #: ../data/variables.xml.in.h:28
 msgid "Quattuordecillion"
@@ -10774,7 +10777,7 @@ msgstr "Mil septillones"
 
 #: ../data/variables.xml.in.h:29
 msgid "-r:quattuordecillion"
-msgstr ""
+msgstr "(1E45)"
 
 #: ../data/variables.xml.in.h:30
 msgid "Tredecillion"
@@ -10782,7 +10785,7 @@ msgstr "Septillón"
 
 #: ../data/variables.xml.in.h:31
 msgid "-r:tredecillion"
-msgstr ""
+msgstr "septillón"
 
 #: ../data/variables.xml.in.h:32
 msgid "Duodecillion"
@@ -10790,7 +10793,7 @@ msgstr "Mil sextillones"
 
 #: ../data/variables.xml.in.h:33
 msgid "-r:duodecillion"
-msgstr ""
+msgstr "(1E39)"
 
 #: ../data/variables.xml.in.h:34
 msgid "Undecillion"
@@ -10798,7 +10801,7 @@ msgstr "Sextillón"
 
 #: ../data/variables.xml.in.h:35
 msgid "-r:undecillion"
-msgstr ""
+msgstr "sextillón"
 
 #: ../data/variables.xml.in.h:36
 msgid "Decillion"
@@ -10806,7 +10809,7 @@ msgstr "Mil quintillones"
 
 #: ../data/variables.xml.in.h:37
 msgid "-r:decillion"
-msgstr ""
+msgstr "(1E33)"
 
 #: ../data/variables.xml.in.h:38
 msgid "Nonillion"
@@ -10814,7 +10817,7 @@ msgstr "Quintillón"
 
 #: ../data/variables.xml.in.h:39
 msgid "-r:nonillion"
-msgstr ""
+msgstr "quintillón"
 
 #: ../data/variables.xml.in.h:40
 msgid "Octillion"
@@ -10822,7 +10825,7 @@ msgstr "Mil cuatrillones"
 
 #: ../data/variables.xml.in.h:41
 msgid "-r:octillion"
-msgstr ""
+msgstr "(1E27)"
 
 #: ../data/variables.xml.in.h:42
 msgid "Septillion"
@@ -10830,15 +10833,15 @@ msgstr "Cuatrillón"
 
 #: ../data/variables.xml.in.h:43
 msgid "-r:septillion"
-msgstr ""
+msgstr "cuatrillón"
 
 #: ../data/variables.xml.in.h:44
 msgid "Sextillion"
-msgstr "Mil trillones"
+msgstr "Trillardo"
 
 #: ../data/variables.xml.in.h:45
 msgid "-r:sextillion"
-msgstr ""
+msgstr "trillardo"
 
 #: ../data/variables.xml.in.h:46
 msgid "Quintillion"
@@ -10846,15 +10849,15 @@ msgstr "Trillón"
 
 #: ../data/variables.xml.in.h:47
 msgid "-r:quintillion"
-msgstr ""
+msgstr "trillón"
 
 #: ../data/variables.xml.in.h:48
 msgid "Quadrillion"
-msgstr "Mil billones"
+msgstr "Billardo"
 
 #: ../data/variables.xml.in.h:49
 msgid "-r:quadrillion"
-msgstr ""
+msgstr "billardo"
 
 #: ../data/variables.xml.in.h:50
 msgid "Trillion"
@@ -10862,15 +10865,15 @@ msgstr "Billón"
 
 #: ../data/variables.xml.in.h:51
 msgid "-r:trillion"
-msgstr ""
+msgstr "billón"
 
 #: ../data/variables.xml.in.h:52
 msgid "Billion"
-msgstr "Mil millones"
+msgstr "Millardo"
 
 #: ../data/variables.xml.in.h:53
 msgid "-r:billion"
-msgstr ""
+msgstr "millardo"
 
 #: ../data/variables.xml.in.h:54
 msgid "Million"
@@ -10878,7 +10881,7 @@ msgstr "Millón"
 
 #: ../data/variables.xml.in.h:55
 msgid "-r:million"
-msgstr ""
+msgstr "millón"
 
 #: ../data/variables.xml.in.h:56
 msgid "Thousand"
@@ -11414,7 +11417,7 @@ msgstr "Infinito positivo"
 
 #: ../data/variables.xml.in.h:189
 msgid "a:&#x221E;,r:plus_infinity,r:infinity"
-msgstr ""
+msgstr "infinito,másinfinito"
 
 #: ../data/variables.xml.in.h:190
 msgid "Negative Infinity"
@@ -11422,7 +11425,7 @@ msgstr "Infinito negativo"
 
 #: ../data/variables.xml.in.h:191
 msgid "r:minus_infinity"
-msgstr ""
+msgstr "menosinfinito"
 
 #: ../data/variables.xml.in.h:192
 msgid "Undefined"
@@ -11430,7 +11433,7 @@ msgstr "Indefinido"
 
 #: ../data/variables.xml.in.h:193
 msgid "r:undefined"
-msgstr ""
+msgstr "indefinido"
 
 #: ../data/variables.xml.in.h:194
 msgid "False"
@@ -11438,7 +11441,7 @@ msgstr "Falso"
 
 #: ../data/variables.xml.in.h:195
 msgid "r:false,r:no"
-msgstr ""
+msgstr "falso"
 
 #: ../data/variables.xml.in.h:196
 msgid "True"
@@ -11446,7 +11449,7 @@ msgstr "Verdadero"
 
 #: ../data/variables.xml.in.h:197
 msgid "r:true,r:yes"
-msgstr ""
+msgstr "verdadero"
 
 #: ../data/variables.xml.in.h:200
 msgid "r:precision"
@@ -11474,7 +11477,7 @@ msgstr "Hoy"
 
 #: ../data/variables.xml.in.h:207
 msgid "r:today"
-msgstr ""
+msgstr "hoy"
 
 #: ../data/variables.xml.in.h:208
 msgid "Tomorrow"
@@ -11482,7 +11485,7 @@ msgstr "Mañana"
 
 #: ../data/variables.xml.in.h:209
 msgid "r:tomorrow"
-msgstr ""
+msgstr "mañana"
 
 #: ../data/variables.xml.in.h:210
 msgid "Yesterday"
@@ -11490,7 +11493,7 @@ msgstr "Ayer"
 
 #: ../data/variables.xml.in.h:211
 msgid "r:yesterday"
-msgstr ""
+msgstr "ayer"
 
 #: ../data/variables.xml.in.h:212
 msgid "Now (date and time)"
@@ -11498,7 +11501,7 @@ msgstr "Ahora (fecha y tiempo)"
 
 #: ../data/variables.xml.in.h:213
 msgid "r:now"
-msgstr ""
+msgstr "ahora"
 
 #~ msgid "Multiply"
 #~ msgstr "Multiplicar"

--- a/po/ca.po
+++ b/po/ca.po
@@ -1982,7 +1982,7 @@ msgstr ""
 "Determina com s'usa la notació científica (per exemple 5 543 000 = 5.543E6)."
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr ""
 "Si està activat, es conserven els zeros al final de nombres aproximats."
 
@@ -2358,7 +2358,7 @@ msgid "- sexa / sexa2 / sexagesimal (show as sexagesimal number)"
 msgstr "- sexa / sexa2 / sexagesimal (mostra com a nombre sexagesimal)"
 
 #: ../src/qalc.cc:4707
-msgid "- latitude / latitude2 (show as sexagesimal longitude)"
+msgid "- latitude / latitude2 (show as sexagesimal latitude)"
 msgstr "- latitude / latitude2 (mostra com a latitud sexagesimal)"
 
 #: ../src/qalc.cc:4708

--- a/po/de.po
+++ b/po/de.po
@@ -2000,7 +2000,7 @@ msgstr ""
 "543 000 = 5,543E6)."
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr "Wenn aktiviert, werden Nullen am Ende von Näherungswerten beibehalten."
 
 #: ../src/qalc.cc:4456
@@ -2385,8 +2385,8 @@ msgid "- sexa / sexa2 / sexagesimal (show as sexagesimal number)"
 msgstr "- sexa / sexa2 / sexagesimal (als sexagesimale Zahl anzeigen)"
 
 #: ../src/qalc.cc:4707
-msgid "- latitude / latitude2 (show as sexagesimal longitude)"
-msgstr "- latitude / latitude2 (Anzeige als sexagesimaler Längengrad)"
+msgid "- latitude / latitude2 (show as sexagesimal latitude)"
+msgstr "- latitude / latitude2 (Anzeige als sexagesimaler Breitengrad)"
 
 #: ../src/qalc.cc:4708
 msgid "- longitude / longitude2 (show as sexagesimal longitude)"

--- a/po/es.po
+++ b/po/es.po
@@ -1,26 +1,24 @@
-# SOME DESCRIPTIVE TITLE.
+# Spanish translations for Qalculate! package.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: Qalculate!\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-07-03 10:25+0200\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2021-07-10 11:30-0300\n"
+"Last-Translator: VicSanRoPe\n"
+"Language-Team: none\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../src/defs2doc.cc:333 ../src/qalc.cc:3922 ../libqalculate/Function.cc:222
 #: ../libqalculate/Function.cc:1370
 msgid "argument"
-msgstr ""
+msgstr "argumento"
 
 #: ../src/defs2doc.cc:356 ../src/qalc.cc:3945
 #, c-format
@@ -28,127 +26,130 @@ msgid ""
 "Retrieves data from the %s data set for a given object and property. If "
 "\"info\" is typed as property, all properties of the object will be listed."
 msgstr ""
+"Extrae datos del conjunto de datos %s para un ojeto y propiedad dados. Si"
+"\"info\" es escrito como propiedad, todas las propiedades del objeto serán "
+"listadas."
 
 #: ../src/defs2doc.cc:363 ../src/qalc.cc:3954
 msgid "Example:"
-msgstr ""
+msgstr "Ejemplo:"
 
 #: ../src/defs2doc.cc:371 ../src/qalc.cc:3963
 msgid "Arguments"
-msgstr ""
+msgstr "Argumentos"
 
 #. optional argument, in description
 #: ../src/defs2doc.cc:388 ../src/qalc.cc:3985
 msgid "optional"
-msgstr ""
+msgstr "opcional"
 
 #. argument default, in description
 #: ../src/defs2doc.cc:391 ../src/qalc.cc:3989
 msgid "default: "
-msgstr ""
+msgstr "predeterminado: "
 
 #: ../src/defs2doc.cc:404 ../src/qalc.cc:4000
 msgid "Requirement"
-msgstr ""
+msgstr "Requisito"
 
 #: ../src/defs2doc.cc:413 ../src/qalc.cc:4013
 msgid "Properties"
-msgstr ""
+msgstr "Propiedades"
 
 #: ../src/defs2doc.cc:429 ../src/qalc.cc:4028
 msgid "key"
-msgstr ""
+msgstr "clave"
 
 #: ../src/defs2doc.cc:461 ../src/qalc.cc:4147
 msgid "a previous result"
-msgstr ""
+msgstr "un resultado previo"
 
 #: ../src/defs2doc.cc:463
 msgid "result of memory operations (MC, MS, M+, M−)"
-msgstr ""
+msgstr "resultado de operaciones de memoria (MC, MS, M+, M−)"
 
 #: ../src/defs2doc.cc:466
 msgid "current precision"
-msgstr ""
+msgstr "precisión actial"
 
 #: ../src/defs2doc.cc:468
 msgid "current date"
-msgstr ""
+msgstr "fecha actual"
 
 #: ../src/defs2doc.cc:470
 msgid "tomorrow's date"
-msgstr ""
+msgstr "fecha de mañana"
 
 #: ../src/defs2doc.cc:472
 msgid "yesterday's date"
-msgstr ""
+msgstr "fecha de ayer"
 
 #: ../src/defs2doc.cc:474
 msgid "current date and time"
-msgstr ""
+msgstr "fecha y tiempo actual"
 
 #: ../src/defs2doc.cc:476
 msgid "current computer uptime"
-msgstr ""
+msgstr "tiempo de actividad actual de la computadora"
 
 #: ../src/defs2doc.cc:480 ../src/defs2doc.cc:579 ../src/qalc.cc:1790
 msgid "relative uncertainty"
-msgstr ""
+msgstr "incertidumbre relativa"
 
 #: ../src/defs2doc.cc:495 ../src/qalc.cc:1812 ../src/qalc.cc:4154
 #: ../libqalculate/Function.cc:2142
 msgid "matrix"
-msgstr ""
+msgstr "matriz"
 
 #: ../src/defs2doc.cc:497 ../src/qalc.cc:1814 ../src/qalc.cc:4156
 #: ../libqalculate/Function.cc:2078
 msgid "vector"
-msgstr ""
+msgstr "vector"
 
 #. positive number
 #: ../src/defs2doc.cc:505 ../src/qalc.cc:297 ../src/qalc.cc:757
 #: ../src/qalc.cc:1832 ../src/qalc.cc:3473 ../src/qalc.cc:4167
 #: ../src/qalc.cc:4314 ../src/qalc.cc:4552
 msgid "positive"
-msgstr ""
+msgstr "positivo"
 
 #: ../src/defs2doc.cc:506 ../src/qalc.cc:304 ../src/qalc.cc:758
 #: ../src/qalc.cc:1833 ../src/qalc.cc:3474 ../src/qalc.cc:4168
 #: ../src/qalc.cc:4318 ../src/qalc.cc:4556
 msgid "non-positive"
-msgstr ""
+msgstr "no-positivo"
 
 #. negative number
 #: ../src/defs2doc.cc:507 ../src/qalc.cc:302 ../src/qalc.cc:759
 #: ../src/qalc.cc:1834 ../src/qalc.cc:3475 ../src/qalc.cc:4169
 #: ../src/qalc.cc:4316 ../src/qalc.cc:4554
 msgid "negative"
-msgstr ""
+msgstr "negativo"
 
 #: ../src/defs2doc.cc:508 ../src/qalc.cc:299 ../src/qalc.cc:760
 #: ../src/qalc.cc:1835 ../src/qalc.cc:3476 ../src/qalc.cc:4170
 #: ../src/qalc.cc:4320 ../src/qalc.cc:4558
 msgid "non-negative"
-msgstr ""
+msgstr "no-negativo"
 
 #: ../src/defs2doc.cc:509 ../src/qalc.cc:294 ../src/qalc.cc:761
 #: ../src/qalc.cc:1836 ../src/qalc.cc:3477 ../src/qalc.cc:4171
 #: ../src/qalc.cc:4312 ../src/qalc.cc:4550
 msgid "non-zero"
-msgstr ""
+msgstr "no-cero"
 
 #: ../src/defs2doc.cc:514 ../src/qalc.cc:290 ../src/qalc.cc:767
 #: ../src/qalc.cc:1842 ../src/qalc.cc:3483 ../src/qalc.cc:4177
 #: ../src/qalc.cc:4328 ../src/qalc.cc:4566 ../libqalculate/Function.cc:1934
 msgid "integer"
-msgstr ""
+msgstr "entero"
 
 #. rational number
 #: ../src/defs2doc.cc:515 ../src/qalc.cc:288 ../src/qalc.cc:769
 #: ../src/qalc.cc:1844 ../src/qalc.cc:3485 ../src/qalc.cc:4179
 #: ../src/qalc.cc:4326 ../src/qalc.cc:4564
 msgid "rational"
-msgstr ""
+msgstr "racional"
 
 #. real number
 #: ../src/defs2doc.cc:516 ../src/qalc.cc:283 ../src/qalc.cc:770
@@ -161,33 +162,33 @@ msgstr ""
 #: ../src/defs2doc.cc:517 ../src/qalc.cc:772 ../src/qalc.cc:1846
 #: ../src/qalc.cc:3487 ../src/qalc.cc:4181
 msgid "complex"
-msgstr ""
+msgstr "complejo"
 
 #: ../src/defs2doc.cc:518 ../src/qalc.cc:285 ../src/qalc.cc:773
 #: ../src/qalc.cc:1847 ../src/qalc.cc:3488 ../src/qalc.cc:4182
 #: ../src/qalc.cc:4322 ../src/qalc.cc:4560 ../libqalculate/Function.cc:1773
 msgid "number"
-msgstr ""
+msgstr "número"
 
 #: ../src/defs2doc.cc:519 ../src/qalc.cc:774 ../src/qalc.cc:1848
 #: ../src/qalc.cc:3489 ../src/qalc.cc:4183
 msgid "non-matrix"
-msgstr ""
+msgstr "no-matriz"
 
 #. assumptions
 #: ../src/defs2doc.cc:522 ../src/qalc.cc:276 ../src/qalc.cc:777
 #: ../src/qalc.cc:1851 ../src/qalc.cc:3492 ../src/qalc.cc:4186
 #: ../src/qalc.cc:4310 ../src/qalc.cc:4548
 msgid "unknown"
-msgstr ""
+msgstr "desconocido"
 
 #: ../src/defs2doc.cc:524 ../src/qalc.cc:1853 ../src/qalc.cc:4188
 msgid "default assumptions"
-msgstr ""
+msgstr "suposiciones predeterminadas"
 
 #: ../src/defs2doc.cc:530
 msgid "variable precision"
-msgstr ""
+msgstr "precisión de variable"
 
 #. approximation mode
 #. qalc command
@@ -197,7 +198,7 @@ msgstr ""
 #: ../src/qalc.cc:4107 ../src/qalc.cc:4214 ../src/qalc.cc:4341
 #: ../src/qalc.cc:4680 ../src/qalc.cc:4771
 msgid "approximate"
-msgstr ""
+msgstr "aproximado"
 
 #: ../src/defs2doc.cc:623 ../src/qalc.cc:2302
 msgid "ans"
@@ -208,64 +209,64 @@ msgstr ""
 #: ../libqalculate/Calculator-definitions.cc:2326
 #: ../libqalculate/Calculator-definitions.cc:2342
 msgid "Temporary"
-msgstr ""
+msgstr "Temporales"
 
 #: ../src/defs2doc.cc:624 ../src/qalc.cc:2303
 msgid "Last Answer"
-msgstr ""
+msgstr "Última respuesta"
 
 #: ../src/defs2doc.cc:625 ../src/qalc.cc:2304
 msgid "answer"
-msgstr ""
+msgstr "respuesta"
 
 #: ../src/defs2doc.cc:627 ../src/qalc.cc:2306
 msgid "Answer 2"
-msgstr ""
+msgstr "Respuesta 2"
 
 #: ../src/defs2doc.cc:628 ../src/qalc.cc:2307
 msgid "Answer 3"
-msgstr ""
+msgstr "Respuesta 3"
 
 #: ../src/defs2doc.cc:629 ../src/qalc.cc:2308
 msgid "Answer 4"
-msgstr ""
+msgstr "Respuesta 4"
 
 #: ../src/defs2doc.cc:630 ../src/qalc.cc:2309
 msgid "Answer 5"
-msgstr ""
+msgstr "Respuesta 5"
 
 #: ../src/defs2doc.cc:631 ../src/qalc.cc:2319
 msgid "Memory"
-msgstr ""
+msgstr "Memoria"
 
 #: ../src/defs2doc.cc:643
 #, c-format
 msgid "Failed to load global definitions!\n"
-msgstr ""
+msgstr "¡Fallo al cargar definiciones globales!\n"
 
 #: ../src/defs2doc.cc:694 ../src/defs2doc.cc:761 ../src/defs2doc.cc:762
 #: ../src/defs2doc.cc:763 ../src/defs2doc.cc:845 ../src/defs2doc.cc:846
 #: ../src/defs2doc.cc:847
 msgid "Uncategorized"
-msgstr ""
+msgstr "No categorizado"
 
 #: ../src/qalc.cc:189 ../src/qalc.cc:261 ../src/qalc.cc:4287
 #: ../libqalculate/util.cc:175
 msgid "yes"
-msgstr ""
+msgstr "sí"
 
 #: ../src/qalc.cc:190 ../src/qalc.cc:263 ../src/qalc.cc:4287
 #: ../libqalculate/util.cc:176
 msgid "no"
-msgstr ""
+msgstr "no"
 
 #: ../src/qalc.cc:191 ../libqalculate/util.cc:183
 msgid "true"
-msgstr ""
+msgstr "verdadero"
 
 #: ../src/qalc.cc:192 ../libqalculate/util.cc:184
 msgid "false"
-msgstr ""
+msgstr "falso"
 
 #: ../src/qalc.cc:193 ../src/qalc.cc:894 ../src/qalc.cc:916 ../src/qalc.cc:1272
 #: ../src/qalc.cc:1321 ../src/qalc.cc:1471 ../src/qalc.cc:3623
@@ -273,7 +274,7 @@ msgstr ""
 #: ../src/qalc.cc:4408 ../src/qalc.cc:4417 ../src/qalc.cc:4468
 #: ../libqalculate/util.cc:191
 msgid "on"
-msgstr ""
+msgstr "encendido"
 
 #: ../src/qalc.cc:194 ../src/qalc.cc:889 ../src/qalc.cc:915 ../src/qalc.cc:1173
 #: ../src/qalc.cc:1243 ../src/qalc.cc:1255 ../src/qalc.cc:1268
@@ -286,21 +287,21 @@ msgstr ""
 #: ../src/qalc.cc:4442 ../src/qalc.cc:4466 ../src/qalc.cc:4501
 #: ../libqalculate/util.cc:192
 msgid "off"
-msgstr ""
+msgstr "apagado"
 
 #: ../src/qalc.cc:268
 msgid "Please answer yes or no"
-msgstr ""
+msgstr "Por favor responda sí o no"
 
 #: ../src/qalc.cc:292 ../src/qalc.cc:768 ../src/qalc.cc:1843
 #: ../src/qalc.cc:3484 ../src/qalc.cc:4178 ../src/qalc.cc:4330
 #: ../src/qalc.cc:4568 ../libqalculate/Function.cc:2232
 msgid "boolean"
-msgstr ""
+msgstr "booleano"
 
 #: ../src/qalc.cc:307
 msgid "Unrecognized assumption."
-msgstr ""
+msgstr "Suposición no reconocida"
 
 #. logical operator
 #: ../src/qalc.cc:472 ../src/qalc.cc:506
@@ -316,18 +317,20 @@ msgstr ""
 #, c-format
 msgid "It has been %s day since the exchange rates last were updated."
 msgid_plural "It has been %s days since the exchange rates last were updated."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Ha pasado %s día desde la última actualización de tasas de cambio."
+msgstr[1] "Han pasado %s días desde la última actualización de tasas de cambio."
 
 #: ../src/qalc.cc:599
 msgid "Do you wish to update the exchange rates now?"
-msgstr ""
+msgstr "¿Quieres actualizar las tasas de cambio ahora?"
 
 #: ../src/qalc.cc:613 ../src/qalc.cc:614
 msgid ""
 "\n"
 "Press Enter to continue."
 msgstr ""
+"\n"
+"Presiona Enter para continuar."
 
 #: ../src/qalc.cc:629 ../src/qalc.cc:630 ../src/qalc.cc:631 ../src/qalc.cc:632
 #: ../src/qalc.cc:633 ../src/qalc.cc:634 ../src/qalc.cc:789 ../src/qalc.cc:800
@@ -340,7 +343,7 @@ msgstr ""
 #: ../src/qalc.cc:1220 ../src/qalc.cc:1283 ../src/qalc.cc:1310
 #: ../src/qalc.cc:1326 ../src/qalc.cc:2845 ../src/qalc.cc:2994
 msgid "Illegal value."
-msgstr ""
+msgstr "Valor ilegal."
 
 #. number base
 #. qalc command
@@ -354,31 +357,31 @@ msgstr ""
 #: ../src/qalc.cc:665 ../src/qalc.cc:667 ../src/qalc.cc:3709
 #: ../src/qalc.cc:4479
 msgid "input base"
-msgstr ""
+msgstr "base de entrada"
 
 #: ../src/qalc.cc:665 ../src/qalc.cc:668
 msgid "output base"
-msgstr ""
+msgstr "base de salida"
 
 #. roman numerals
 #: ../src/qalc.cc:670 ../src/qalc.cc:3101 ../src/qalc.cc:3579
 #: ../src/qalc.cc:3711 ../src/qalc.cc:4387 ../src/qalc.cc:4487
 #: ../src/qalc.cc:5660 ../libqalculate/Calculator-calculate.cc:1446
 msgid "roman"
-msgstr ""
+msgstr "romano"
 
 #. number base
 #: ../src/qalc.cc:672 ../src/qalc.cc:3106 ../src/qalc.cc:3580
 #: ../src/qalc.cc:3712 ../src/qalc.cc:5662
 #: ../libqalculate/Calculator-calculate.cc:1448
 msgid "bijective"
-msgstr ""
+msgstr "biyectiva"
 
 #: ../src/qalc.cc:678 ../src/qalc.cc:3171 ../src/qalc.cc:3593
 #: ../src/qalc.cc:4385 ../src/qalc.cc:5688
 #: ../libqalculate/Calculator-calculate.cc:1474
 msgid "time"
-msgstr ""
+msgstr "tiempo"
 
 #: ../src/qalc.cc:679 ../src/qalc.cc:3076 ../src/qalc.cc:5650
 #: ../libqalculate/Calculator-calculate.cc:1436
@@ -394,7 +397,7 @@ msgstr ""
 #: ../src/qalc.cc:688 ../src/qalc.cc:3081 ../src/qalc.cc:5652
 #: ../libqalculate/Calculator-calculate.cc:1438
 msgid "binary"
-msgstr ""
+msgstr "binaria"
 
 #: ../src/qalc.cc:689 ../src/qalc.cc:3091 ../src/qalc.cc:5656
 #: ../libqalculate/Calculator-calculate.cc:1442
@@ -423,7 +426,7 @@ msgstr ""
 #: ../libqalculate/Calculator-calculate.cc:1460
 #: ../libqalculate/Calculator-calculate.cc:1462
 msgid "latitude"
-msgstr ""
+msgstr "latitud"
 
 #: ../src/qalc.cc:697 ../src/qalc.cc:698 ../src/qalc.cc:3126
 #: ../src/qalc.cc:3131 ../src/qalc.cc:3586 ../src/qalc.cc:3587
@@ -431,26 +434,26 @@ msgstr ""
 #: ../libqalculate/Calculator-calculate.cc:1456
 #: ../libqalculate/Calculator-calculate.cc:1458
 msgid "longitude"
-msgstr ""
+msgstr "longitud"
 
 #. number bases
 #: ../src/qalc.cc:708 ../src/qalc.cc:868 ../src/qalc.cc:3605
 #: ../src/qalc.cc:4399
 msgid "base display"
-msgstr ""
+msgstr "visualización de base"
 
 #: ../src/qalc.cc:738
 msgid "Illegal base."
-msgstr ""
+msgstr "Base ilegal."
 
 #: ../src/qalc.cc:746 ../src/qalc.cc:778 ../src/qalc.cc:3493
 #: ../src/qalc.cc:4307
 msgid "assumptions"
-msgstr ""
+msgstr "suposiciones"
 
 #: ../src/qalc.cc:781 ../src/qalc.cc:3744 ../src/qalc.cc:4505
 msgid "all prefixes"
-msgstr ""
+msgstr "todos los prefijos"
 
 #: ../src/qalc.cc:782 ../src/qalc.cc:3546 ../src/qalc.cc:4363
 msgid "color"
@@ -459,105 +462,105 @@ msgstr ""
 #. light color
 #: ../src/qalc.cc:785 ../src/qalc.cc:3549 ../src/qalc.cc:4363
 msgid "light"
-msgstr ""
+msgstr "claro"
 
 #: ../src/qalc.cc:786 ../src/qalc.cc:3550 ../src/qalc.cc:4363
 #: ../src/qalc.cc:5469 ../src/qalc.cc:5544 ../src/qalc.cc:5550
 msgid "default"
-msgstr ""
+msgstr "predeterminado"
 
 #: ../src/qalc.cc:794 ../src/qalc.cc:3535 ../src/qalc.cc:4352
 msgid "complex numbers"
-msgstr ""
+msgstr "números complejos"
 
 #: ../src/qalc.cc:795 ../src/qalc.cc:3560 ../src/qalc.cc:4365
 msgid "excessive parentheses"
-msgstr ""
+msgstr "Paréntesis excesivos"
 
 #: ../src/qalc.cc:796 ../src/qalc.cc:3536 ../src/qalc.cc:3856
 #: ../src/qalc.cc:3862 ../src/qalc.cc:4353
 msgid "functions"
-msgstr ""
+msgstr "funciones"
 
 #: ../src/qalc.cc:797 ../src/qalc.cc:3537 ../src/qalc.cc:4354
 msgid "infinite numbers"
-msgstr ""
+msgstr "números infinitos"
 
 #: ../src/qalc.cc:798 ../src/qalc.cc:3762 ../src/qalc.cc:4526
 msgid "show negative exponents"
-msgstr ""
+msgstr "mostrar exponentes negativos"
 
 #: ../src/qalc.cc:799 ../src/qalc.cc:3561 ../src/qalc.cc:4366
 msgid "minus last"
-msgstr ""
+msgstr "menos al final"
 
 #: ../src/qalc.cc:801 ../src/qalc.cc:3468 ../src/qalc.cc:4304
 msgid "assume nonzero denominators"
-msgstr ""
+msgstr "asumir denominadores distintos de cero"
 
 #: ../src/qalc.cc:802 ../src/qalc.cc:3469 ../src/qalc.cc:4305
 msgid "warn nonzero denominators"
-msgstr ""
+msgstr "advertir de denominadores distintos de cero"
 
 #. unit prefixes
 #: ../src/qalc.cc:804 ../src/qalc.cc:3761 ../src/qalc.cc:3859
 #: ../src/qalc.cc:3865 ../src/qalc.cc:4525
 msgid "prefixes"
-msgstr ""
+msgstr "prefijos"
 
 #: ../src/qalc.cc:805 ../src/qalc.cc:3757 ../src/qalc.cc:4521
 msgid "binary prefixes"
-msgstr ""
+msgstr "prefijos binarios"
 
 #: ../src/qalc.cc:812 ../src/qalc.cc:3759 ../src/qalc.cc:4523
 msgid "denominator prefixes"
-msgstr ""
+msgstr "prefijos de denominador"
 
 #: ../src/qalc.cc:813 ../src/qalc.cc:3760 ../src/qalc.cc:4524
 msgid "place units separately"
-msgstr ""
+msgstr "colocar unidades por separado"
 
 #: ../src/qalc.cc:814 ../src/qalc.cc:3534 ../src/qalc.cc:4351
 msgid "calculate variables"
-msgstr ""
+msgstr "calcular variables"
 
 #: ../src/qalc.cc:815 ../src/qalc.cc:3533 ../src/qalc.cc:4350
 msgid "calculate functions"
-msgstr ""
+msgstr "calcular funciones"
 
 #: ../src/qalc.cc:816 ../src/qalc.cc:3763 ../src/qalc.cc:4527
 msgid "sync units"
-msgstr ""
+msgstr "sincronizar unidades"
 
 #: ../src/qalc.cc:817 ../src/qalc.cc:3764 ../src/qalc.cc:4528
 msgid "temperature calculation"
-msgstr ""
+msgstr "cálculo de temperatura"
 
 #. temperature calculation mode
 #: ../src/qalc.cc:820 ../src/qalc.cc:3766 ../src/qalc.cc:4528
 #: ../src/qalc.cc:5483 ../src/qalc.cc:5505
 msgid "relative"
-msgstr ""
+msgstr "relativo"
 
 #. temperature calculation mode
 #: ../src/qalc.cc:822 ../src/qalc.cc:3768 ../src/qalc.cc:4528
 #: ../src/qalc.cc:5469 ../src/qalc.cc:5506
 msgid "hybrid"
-msgstr ""
+msgstr "híbrido"
 
 #. temperature calculation mode
 #: ../src/qalc.cc:824 ../src/qalc.cc:3767 ../src/qalc.cc:4528
 #: ../src/qalc.cc:5476 ../src/qalc.cc:5507
 msgid "absolute"
-msgstr ""
+msgstr "absoluto"
 
 #: ../src/qalc.cc:835 ../src/qalc.cc:3680 ../src/qalc.cc:4438
 msgid "round to even"
-msgstr ""
+msgstr "redondear a par"
 
 #: ../src/qalc.cc:836
 msgid "rpn syntax"
-msgstr ""
+msgstr "sintaxis rpn"
 
 #. qalc command
 #: ../src/qalc.cc:848 ../src/qalc.cc:983 ../src/qalc.cc:2825
@@ -569,20 +572,20 @@ msgstr ""
 
 #: ../src/qalc.cc:849 ../src/qalc.cc:3570 ../src/qalc.cc:4368
 msgid "short multiplication"
-msgstr ""
+msgstr "multiplicación corta"
 
 #: ../src/qalc.cc:850 ../src/qalc.cc:3663 ../src/qalc.cc:4421
 msgid "lowercase e"
-msgstr ""
+msgstr "e minúscula"
 
 #: ../src/qalc.cc:851 ../src/qalc.cc:3664 ../src/qalc.cc:4422
 msgid "lowercase numbers"
-msgstr ""
+msgstr "números minúsculos"
 
 #: ../src/qalc.cc:852 ../src/qalc.cc:3647 ../src/qalc.cc:3708
 #: ../src/qalc.cc:4419 ../src/qalc.cc:4478
 msgid "imaginary j"
-msgstr ""
+msgstr "j imaginaria"
 
 #. base display mode
 #. digit grouping mode
@@ -594,7 +597,7 @@ msgstr ""
 #: ../src/qalc.cc:3523 ../src/qalc.cc:3609 ../src/qalc.cc:3749
 #: ../src/qalc.cc:4337 ../src/qalc.cc:4399 ../src/qalc.cc:4509
 msgid "none"
-msgstr ""
+msgstr "ninguno"
 
 #. base display mode
 #: ../src/qalc.cc:873 ../src/qalc.cc:3607 ../src/qalc.cc:4399
@@ -604,56 +607,56 @@ msgstr ""
 #. base display mode
 #: ../src/qalc.cc:875 ../src/qalc.cc:3608 ../src/qalc.cc:4399
 msgid "alternative"
-msgstr ""
+msgstr "alternativo"
 
 #: ../src/qalc.cc:885 ../src/qalc.cc:3692 ../src/qalc.cc:4456
 msgid "two's complement"
-msgstr ""
+msgstr "complemento a dos"
 
 #: ../src/qalc.cc:886 ../src/qalc.cc:3646 ../src/qalc.cc:4418
 msgid "hexadecimal two's"
-msgstr ""
+msgstr "complemento a dos hexadecimal"
 
 #: ../src/qalc.cc:887 ../src/qalc.cc:3625 ../src/qalc.cc:4412
 msgid "digit grouping"
-msgstr ""
+msgstr "agrupamiento de dígitos"
 
 #. digit grouping mode
 #: ../src/qalc.cc:893 ../src/qalc.cc:3628 ../src/qalc.cc:4412
 msgid "standard"
-msgstr ""
+msgstr "estándar"
 
 #: ../src/qalc.cc:895 ../src/qalc.cc:917 ../src/qalc.cc:3621
 #: ../src/qalc.cc:3629 ../src/qalc.cc:3698 ../src/qalc.cc:4404
 #: ../src/qalc.cc:4412 ../src/qalc.cc:4464
 msgid "locale"
-msgstr ""
+msgstr "local"
 
 #: ../src/qalc.cc:905 ../src/qalc.cc:3572 ../src/qalc.cc:4370
 msgid "spell out logical"
-msgstr ""
+msgstr "escribir lógicos"
 
 #: ../src/qalc.cc:906 ../src/qalc.cc:3706 ../src/qalc.cc:4476
 msgid "ignore dot"
-msgstr ""
+msgstr "ignorar punto"
 
 #: ../src/qalc.cc:909 ../src/qalc.cc:3703 ../src/qalc.cc:4473
 msgid "ignore comma"
-msgstr ""
+msgstr "ignorar coma"
 
 #: ../src/qalc.cc:913 ../src/qalc.cc:3620 ../src/qalc.cc:3697
 #: ../src/qalc.cc:4401 ../src/qalc.cc:4461
 msgid "decimal comma"
-msgstr ""
+msgstr "coma decimal"
 
 #: ../src/qalc.cc:932 ../src/qalc.cc:3723 ../src/qalc.cc:4499
 msgid "limit implicit multiplication"
-msgstr ""
+msgstr "limitar multiplicación implícita"
 
 #. extra space next to operators
 #: ../src/qalc.cc:935 ../src/qalc.cc:3571 ../src/qalc.cc:4369
 msgid "spacious"
-msgstr ""
+msgstr "espacioso"
 
 #: ../src/qalc.cc:936 ../src/qalc.cc:3573 ../src/qalc.cc:4371
 msgid "unicode"
@@ -662,12 +665,12 @@ msgstr ""
 #: ../src/qalc.cc:944 ../src/qalc.cc:3538 ../src/qalc.cc:3858
 #: ../src/qalc.cc:3864 ../src/qalc.cc:4355
 msgid "units"
-msgstr ""
+msgstr "unidades"
 
 #. automatic unknown variables
 #: ../src/qalc.cc:946 ../src/qalc.cc:3539 ../src/qalc.cc:4356
 msgid "unknowns"
-msgstr ""
+msgstr "incógnitas"
 
 #: ../src/qalc.cc:947 ../src/qalc.cc:3540 ../src/qalc.cc:3857
 #: ../src/qalc.cc:3863 ../src/qalc.cc:4357
@@ -676,19 +679,19 @@ msgstr ""
 
 #: ../src/qalc.cc:948 ../src/qalc.cc:3545 ../src/qalc.cc:4362
 msgid "abbreviations"
-msgstr ""
+msgstr "abreviaciones"
 
 #: ../src/qalc.cc:949 ../src/qalc.cc:3691 ../src/qalc.cc:4455
 msgid "show ending zeroes"
-msgstr ""
+msgstr "mostrar ceros finales"
 
 #: ../src/qalc.cc:950 ../src/qalc.cc:3679 ../src/qalc.cc:4437
 msgid "repeating decimals"
-msgstr ""
+msgstr "decimales repetidos"
 
 #: ../src/qalc.cc:951 ../src/qalc.cc:3497 ../src/qalc.cc:4337
 msgid "angle unit"
-msgstr ""
+msgstr "unidad de ángulo"
 
 #. angle unit
 #: ../src/qalc.cc:954 ../src/qalc.cc:3499 ../src/qalc.cc:3500
@@ -697,7 +700,7 @@ msgstr ""
 
 #: ../src/qalc.cc:954 ../src/qalc.cc:4337
 msgid "radians"
-msgstr ""
+msgstr "radianes"
 
 #. angle unit
 #: ../src/qalc.cc:956
@@ -706,7 +709,7 @@ msgstr ""
 
 #: ../src/qalc.cc:956 ../src/qalc.cc:4337
 msgid "degrees"
-msgstr ""
+msgstr "grados"
 
 #. angle unit
 #: ../src/qalc.cc:958 ../src/qalc.cc:3501
@@ -715,16 +718,16 @@ msgstr ""
 
 #: ../src/qalc.cc:958 ../src/qalc.cc:4337
 msgid "gradians"
-msgstr ""
+msgstr "gradianes"
 
 #: ../src/qalc.cc:972 ../src/qalc.cc:3696 ../src/qalc.cc:4460
 msgid "caret as xor"
-msgstr ""
+msgstr "circunflejo como xor"
 
 #: ../src/qalc.cc:973 ../src/qalc.cc:3724 ../src/qalc.cc:4500
 #: ../src/qalc.cc:4740
 msgid "parsing mode"
-msgstr ""
+msgstr "modo de análisis"
 
 #. parsing mode
 #. interval display mode
@@ -732,53 +735,53 @@ msgstr ""
 #: ../src/qalc.cc:3726 ../src/qalc.cc:4420 ../src/qalc.cc:4500
 #: ../src/qalc.cc:4748
 msgid "adaptive"
-msgstr ""
+msgstr "adaptativo"
 
 #. parsing mode
 #: ../src/qalc.cc:978 ../src/qalc.cc:3727 ../src/qalc.cc:4500
 #: ../src/qalc.cc:4745
 msgid "implicit first"
-msgstr ""
+msgstr "primero implícito"
 
 #. parsing mode
 #: ../src/qalc.cc:980 ../src/qalc.cc:3728 ../src/qalc.cc:4500
 #: ../src/qalc.cc:4742
 msgid "conventional"
-msgstr ""
+msgstr "convencional"
 
 #. chain calculation mode (parsing mode)
 #: ../src/qalc.cc:982 ../src/qalc.cc:3729 ../src/qalc.cc:4500
 #: ../src/qalc.cc:4756
 msgid "chain"
-msgstr ""
+msgstr "cadena"
 
 #: ../src/qalc.cc:993 ../src/qalc.cc:2057 ../src/qalc.cc:3771
 #: ../src/qalc.cc:4529
 msgid "update exchange rates"
-msgstr ""
+msgstr "actualizar tasas de cambio"
 
 #. exchange rates updates
 #: ../src/qalc.cc:995 ../src/qalc.cc:3774 ../src/qalc.cc:4531
 msgid "never"
-msgstr ""
+msgstr "nunca"
 
 #. exchange rates updates
 #: ../src/qalc.cc:998 ../src/qalc.cc:3773 ../src/qalc.cc:4530
 msgid "ask"
-msgstr ""
+msgstr "preguntar"
 
 #: ../src/qalc.cc:1006 ../src/qalc.cc:3562 ../src/qalc.cc:4367
 msgid "multiplication sign"
-msgstr ""
+msgstr "signo de multiplicación"
 
 #: ../src/qalc.cc:1021 ../src/qalc.cc:3553 ../src/qalc.cc:4364
 msgid "division sign"
-msgstr ""
+msgstr "signo de división"
 
 #: ../src/qalc.cc:1035 ../src/qalc.cc:1433 ../src/qalc.cc:3505
 #: ../src/qalc.cc:4341
 msgid "approximation"
-msgstr ""
+msgstr "aproximación"
 
 #. approximation mode
 #. fraction mode
@@ -788,7 +791,7 @@ msgstr ""
 #: ../src/qalc.cc:3640 ../src/qalc.cc:3799 ../src/qalc.cc:4341
 #: ../src/qalc.cc:4417 ../src/qalc.cc:4676 ../src/qalc.cc:4771
 msgid "exact"
-msgstr ""
+msgstr "exacta"
 
 #. automatic
 #: ../src/qalc.cc:1040 ../src/qalc.cc:1174 ../src/qalc.cc:1269
@@ -809,47 +812,47 @@ msgstr ""
 #: ../src/qalc.cc:1044 ../src/qalc.cc:1437 ../src/qalc.cc:3514
 #: ../src/qalc.cc:4341
 msgid "try exact"
-msgstr ""
+msgstr "intentar exacta"
 
 #: ../src/qalc.cc:1065 ../src/qalc.cc:3521 ../src/qalc.cc:4343
 msgid "interval calculation"
-msgstr ""
+msgstr "cálculo de intervalo"
 
 #: ../src/qalc.cc:1065
 msgid "uncertainty propagation"
-msgstr ""
+msgstr "propagación de incertidumbre"
 
 #: ../src/qalc.cc:1067 ../src/qalc.cc:3524 ../src/qalc.cc:4343
 msgid "variance formula"
-msgstr ""
+msgstr "fórmula de varianza"
 
 #: ../src/qalc.cc:1067
 msgid "variance"
-msgstr ""
+msgstr "varianza"
 
 #: ../src/qalc.cc:1068 ../src/qalc.cc:1227 ../src/qalc.cc:3520
 #: ../src/qalc.cc:3525 ../src/qalc.cc:4342 ../src/qalc.cc:4343
 msgid "interval arithmetic"
-msgstr ""
+msgstr "aritmética de intervalo"
 
 #: ../src/qalc.cc:1078 ../src/qalc.cc:3745 ../src/qalc.cc:4506
 msgid "autoconversion"
-msgstr ""
+msgstr "autoconversión"
 
 #: ../src/qalc.cc:1083 ../src/qalc.cc:3360
 msgid "best"
-msgstr ""
+msgstr "mejor"
 
 #: ../src/qalc.cc:1084 ../src/qalc.cc:3754 ../src/qalc.cc:4515
 msgid "optimalsi"
-msgstr ""
+msgstr "óptimosi"
 
 #. optimal units
 #: ../src/qalc.cc:1086 ../src/qalc.cc:3360 ../src/qalc.cc:3752
 #: ../src/qalc.cc:4511 ../src/qalc.cc:5752
 #: ../libqalculate/Calculator-calculate.cc:1534
 msgid "optimal"
-msgstr ""
+msgstr "óptimo"
 
 #. base units
 #: ../src/qalc.cc:1088 ../src/qalc.cc:3367 ../src/qalc.cc:3753
@@ -864,157 +867,157 @@ msgstr ""
 #: ../src/qalc.cc:5789 ../libqalculate/Calculator-calculate.cc:1563
 msgctxt "units"
 msgid "mixed"
-msgstr ""
+msgstr "mixtas"
 
 #: ../src/qalc.cc:1110 ../src/qalc.cc:3758 ../src/qalc.cc:4522
 msgid "currency conversion"
-msgstr ""
+msgstr "conversión de divisas"
 
 #: ../src/qalc.cc:1111 ../src/qalc.cc:3461 ../src/qalc.cc:4303
 msgid "algebra mode"
-msgstr ""
+msgstr "modo de álgebra"
 
 #. algebra mode
 #. qalc command
 #: ../src/qalc.cc:1116 ../src/qalc.cc:3449 ../src/qalc.cc:4278
 #: ../src/qalc.cc:4771
 msgid "simplify"
-msgstr ""
+msgstr "simplificar"
 
 #: ../src/qalc.cc:1116 ../src/qalc.cc:3449 ../src/qalc.cc:3465
 #: ../src/qalc.cc:3800 ../src/qalc.cc:4278 ../src/qalc.cc:4303
 #: ../src/qalc.cc:4771 ../src/qalc.cc:5821
 #: ../libqalculate/Calculator-calculate.cc:1602
 msgid "expand"
-msgstr ""
+msgstr "expandir"
 
 #. algebra mode
 #: ../src/qalc.cc:1118 ../src/qalc.cc:3464 ../src/qalc.cc:4303
 #: ../src/qalc.cc:5818 ../libqalculate/Calculator-calculate.cc:1598
 msgid "factorize"
-msgstr ""
+msgstr "factorizar"
 
 #: ../src/qalc.cc:1140 ../src/qalc.cc:3781 ../src/qalc.cc:4539
 msgid "ignore locale"
-msgstr ""
+msgstr "ignorar local"
 
 #: ../src/qalc.cc:1152 ../src/qalc.cc:3784 ../src/qalc.cc:3814
 #: ../src/qalc.cc:4542
 msgid "save mode"
-msgstr ""
+msgstr "guardar modo"
 
 #: ../src/qalc.cc:1161 ../src/qalc.cc:3783 ../src/qalc.cc:3813
 #: ../src/qalc.cc:4541
 msgid "save definitions"
-msgstr ""
+msgstr "guardad definiciones"
 
 #: ../src/qalc.cc:1170 ../src/qalc.cc:3681 ../src/qalc.cc:4439
 msgid "scientific notation"
-msgstr ""
+msgstr "notación científica"
 
 #: ../src/qalc.cc:1175 ../src/qalc.cc:3685 ../src/qalc.cc:4448
 msgid "pure"
-msgstr ""
+msgstr "pura"
 
 #: ../src/qalc.cc:1176 ../src/qalc.cc:3686 ../src/qalc.cc:4450
 msgid "scientific"
-msgstr ""
+msgstr "científica"
 
 #: ../src/qalc.cc:1177 ../src/qalc.cc:3687 ../src/qalc.cc:4446
 msgid "engineering"
-msgstr ""
+msgstr "ingeniería"
 
 #: ../src/qalc.cc:1186 ../src/qalc.cc:3529 ../src/qalc.cc:4344
 msgid "precision"
-msgstr ""
+msgstr "precisión"
 
 #: ../src/qalc.cc:1195 ../src/qalc.cc:3648 ../src/qalc.cc:4420
 msgid "interval display"
-msgstr ""
+msgstr "visualización de intervalo"
 
 #. interval display mode
 #: ../src/qalc.cc:1200 ../src/qalc.cc:3653 ../src/qalc.cc:4420
 msgid "significant"
-msgstr ""
+msgstr "significativas"
 
 #. interval display mode
 #: ../src/qalc.cc:1202 ../src/qalc.cc:3654 ../src/qalc.cc:4420
 msgid "interval"
-msgstr ""
+msgstr "intervalo"
 
 #: ../src/qalc.cc:1203 ../src/qalc.cc:3655 ../src/qalc.cc:4420
 msgid "plusminus"
-msgstr ""
+msgstr "masmenos"
 
 #. interval display mode: midpoint number in range
 #: ../src/qalc.cc:1205 ../src/qalc.cc:3656 ../src/qalc.cc:4420
 msgid "midpoint"
-msgstr ""
+msgstr "mitad"
 
 #. interval display mode: upper number in range
 #: ../src/qalc.cc:1207 ../src/qalc.cc:3658 ../src/qalc.cc:4420
 msgid "upper"
-msgstr ""
+msgstr "superior"
 
 #. interval display mode: lower number in range
 #: ../src/qalc.cc:1209 ../src/qalc.cc:3657 ../src/qalc.cc:4420
 msgid "lower"
-msgstr ""
+msgstr "inferior"
 
 #: ../src/qalc.cc:1234 ../src/qalc.cc:3541 ../src/qalc.cc:4358
 msgid "variable units"
-msgstr ""
+msgstr "unidades de variables"
 
 #: ../src/qalc.cc:1241 ../src/qalc.cc:3665 ../src/qalc.cc:4423
 msgid "max decimals"
-msgstr ""
+msgstr "decimales máximos"
 
 #: ../src/qalc.cc:1253 ../src/qalc.cc:3672 ../src/qalc.cc:4430
 msgid "min decimals"
-msgstr ""
+msgstr "decimales mínimos"
 
 #: ../src/qalc.cc:1266 ../src/qalc.cc:3632 ../src/qalc.cc:4417
 msgid "fractions"
-msgstr ""
+msgstr "fracciones"
 
 #. fraction mode
 #: ../src/qalc.cc:1274
 msgid "combined"
-msgstr ""
+msgstr "combinadas"
 
 #. fraction mode
 #: ../src/qalc.cc:1274 ../src/qalc.cc:1463 ../src/qalc.cc:3642
 #: ../src/qalc.cc:4417
 msgid "mixed"
-msgstr ""
+msgstr "mixtas"
 
 #. fraction mode
 #: ../src/qalc.cc:1276 ../src/qalc.cc:3641 ../src/qalc.cc:4417
 msgid "long"
-msgstr ""
+msgstr "larga"
 
 #: ../src/qalc.cc:1294 ../src/qalc.cc:3612 ../src/qalc.cc:4400
 msgid "complex form"
-msgstr ""
+msgstr "forma compleja"
 
 #. complex form
 #: ../src/qalc.cc:1297 ../src/qalc.cc:3231 ../src/qalc.cc:3614
 #: ../src/qalc.cc:4400 ../src/qalc.cc:5737
 #: ../libqalculate/Calculator-calculate.cc:1512
 msgid "rectangular"
-msgstr ""
+msgstr "rectangular"
 
 #: ../src/qalc.cc:1297 ../src/qalc.cc:3231 ../src/qalc.cc:5737
 #: ../libqalculate/Calculator-calculate.cc:1512
 msgid "cartesian"
-msgstr ""
+msgstr "cartesiana"
 
 #. complex form
 #: ../src/qalc.cc:1299 ../src/qalc.cc:3243 ../src/qalc.cc:3615
 #: ../src/qalc.cc:4400 ../src/qalc.cc:5740
 #: ../libqalculate/Calculator-calculate.cc:1514
 msgid "exponential"
-msgstr ""
+msgstr "exponencial"
 
 #. complex form
 #: ../src/qalc.cc:1301 ../src/qalc.cc:3255 ../src/qalc.cc:3616
@@ -1029,126 +1032,128 @@ msgstr ""
 #: ../libqalculate/Calculator-calculate.cc:1518
 #: ../libqalculate/Function.cc:2243
 msgid "angle"
-msgstr ""
+msgstr "ángulo"
 
 #: ../src/qalc.cc:1303 ../src/qalc.cc:3267 ../src/qalc.cc:5746
 #: ../libqalculate/Calculator-calculate.cc:1518
 msgid "phasor"
-msgstr ""
+msgstr "fasor"
 
 #: ../src/qalc.cc:1317 ../src/qalc.cc:3733 ../src/qalc.cc:4501
 msgid "read precision"
-msgstr ""
+msgstr "leer precisión"
 
 #: ../src/qalc.cc:1320 ../src/qalc.cc:3736 ../src/qalc.cc:4501
 msgid "always"
-msgstr ""
+msgstr "siempre"
 
 #: ../src/qalc.cc:1321 ../src/qalc.cc:3737 ../src/qalc.cc:4501
 msgid "when decimals"
-msgstr ""
+msgstr "con decimales"
 
 #: ../src/qalc.cc:1353
 msgid "Unrecognized option."
-msgstr ""
+msgstr "Opción no reconocida."
 
 #. The qalc command "set" as in "set precision 10". The original text string for commands is kept in addition to the translation.
 #: ../src/qalc.cc:1433 ../src/qalc.cc:1458 ../src/qalc.cc:2562
 #: ../src/qalc.cc:3815 ../src/qalc.cc:4282 ../src/qalc.cc:4778
 msgid "set"
-msgstr ""
+msgstr "fijar"
 
 #: ../src/qalc.cc:1458 ../src/qalc.cc:3348 ../src/qalc.cc:5726
 #: ../libqalculate/Calculator-calculate.cc:1523
 msgid "fraction"
-msgstr ""
+msgstr "fracción"
 
 #: ../src/qalc.cc:1499 ../src/qalc.cc:1777 ../src/qalc.cc:2568
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #: ../src/qalc.cc:1515 ../src/qalc.cc:2640 ../src/qalc.cc:2704
 #: ../src/qalc.cc:2765
 msgid "Illegal name."
-msgstr ""
+msgstr "Nombre ilegal."
 
 #: ../src/qalc.cc:1518 ../src/qalc.cc:1520 ../src/qalc.cc:2643
 #: ../src/qalc.cc:2645 ../src/qalc.cc:2707 ../src/qalc.cc:2709
 #: ../src/qalc.cc:2768 ../src/qalc.cc:2770
 #, c-format
 msgid "Illegal name. Save as %s instead (default: no)?"
-msgstr ""
+msgstr "Nombre ilegal. Guardar como %s en su lugar (predeterminado: no)?"
 
 #: ../src/qalc.cc:1530 ../src/qalc.cc:2655 ../src/qalc.cc:2719
 msgid ""
 "A unit or variable with the same name already exists.\n"
 "Do you want to overwrite it (default: no)?"
 msgstr ""
+"Una unidad o variable con el mismo nombre ya existe.\n"
+"¿Quiere sobreescribirla (predeterminado: no)?"
 
 #: ../src/qalc.cc:1625
 msgid "Calendar"
-msgstr ""
+msgstr "Calendario"
 
 #: ../src/qalc.cc:1625
 msgid "Day"
-msgstr ""
+msgstr "Día"
 
 #: ../src/qalc.cc:1625
 msgid "Month"
-msgstr ""
+msgstr "Mes"
 
 #: ../src/qalc.cc:1625
 msgid "Year"
-msgstr ""
+msgstr "Año"
 
 #: ../src/qalc.cc:1626 ../libqalculate/Calculator-calculate.cc:1731
 msgid "failed"
-msgstr ""
+msgstr "fallo"
 
 #: ../src/qalc.cc:1627 ../libqalculate/Calculator-calculate.cc:1732
 msgid "Gregorian:"
-msgstr ""
+msgstr "Gregoriano:"
 
 #: ../src/qalc.cc:1628 ../libqalculate/Calculator-calculate.cc:1733
 msgid "Hebrew:"
-msgstr ""
+msgstr "Hebreo:"
 
 #: ../src/qalc.cc:1629 ../libqalculate/Calculator-calculate.cc:1734
 msgid "Islamic:"
-msgstr ""
+msgstr "Islámico:"
 
 #: ../src/qalc.cc:1630 ../libqalculate/Calculator-calculate.cc:1735
 msgid "Persian:"
-msgstr ""
+msgstr "Persa:"
 
 #: ../src/qalc.cc:1631 ../libqalculate/Calculator-calculate.cc:1736
 msgid "Indian national:"
-msgstr ""
+msgstr "Nacional hindú:"
 
 #: ../src/qalc.cc:1632 ../libqalculate/Calculator-calculate.cc:1737
 msgid "Chinese:"
-msgstr ""
+msgstr "Chino:"
 
 #: ../src/qalc.cc:1637 ../libqalculate/Calculator-calculate.cc:1741
 msgid "Julian:"
-msgstr ""
+msgstr "Juliano:"
 
 #: ../src/qalc.cc:1638 ../libqalculate/Calculator-calculate.cc:1742
 msgid "Revised julian:"
-msgstr ""
+msgstr "Juliano revisado:"
 
 #: ../src/qalc.cc:1639 ../libqalculate/Calculator-calculate.cc:1743
 msgid "Coptic:"
-msgstr ""
+msgstr "Copto"
 
 #: ../src/qalc.cc:1640 ../libqalculate/Calculator-calculate.cc:1744
 msgid "Ethiopian:"
-msgstr ""
+msgstr "Etíope"
 
 #: ../src/qalc.cc:1729 ../libqalculate/BuiltinFunctions-matrixvector.cc:1066
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:1096
 msgid "No matching item found."
-msgstr ""
+msgstr "No se encontró un elemento coincidente."
 
 #: ../src/qalc.cc:1760 ../src/qalc.cc:1761 ../src/qalc.cc:1895
 #: ../src/qalc.cc:1896 ../src/qalc.cc:1980 ../src/qalc.cc:1981
@@ -1156,6 +1161,8 @@ msgid ""
 "For more information about a specific function, variable, unit, or prefix, "
 "please use the info command (in interactive mode)."
 msgstr ""
+"Para más información acerca de una función, variable, unidad o prefijo "
+"específico, por favor use el comando info (en modo interactivo)."
 
 #: ../src/qalc.cc:1775
 msgid "Variables:"
@@ -1164,27 +1171,27 @@ msgstr ""
 #: ../src/qalc.cc:1778 ../src/qalc.cc:4194 ../src/qalc.cc:4201
 #: ../src/qalc.cc:4255
 msgid "Value"
-msgstr ""
+msgstr "Valor"
 
 #: ../src/qalc.cc:1869
 msgid "Functions:"
-msgstr ""
+msgstr "Funciones:"
 
 #: ../src/qalc.cc:1883
 msgid "Units:"
-msgstr ""
+msgstr "Unidades:"
 
 #: ../src/qalc.cc:1890
 msgid "No local variables, functions or units have been defined."
-msgstr ""
+msgstr "No se han definido variables, funciones o unidades."
 
 #: ../src/qalc.cc:2047
 msgid "usage: qalc [options] [expression]"
-msgstr ""
+msgstr "uso: qalc [opciones] [expresión]"
 
 #: ../src/qalc.cc:2049
 msgid "where options are:"
-msgstr ""
+msgstr "donde las opciones son:"
 
 #. number base
 #: ../src/qalc.cc:2051 ../src/qalc.cc:2087 ../src/qalc.cc:3797
@@ -1193,123 +1200,137 @@ msgstr ""
 
 #: ../src/qalc.cc:2052
 msgid "set the number base for results and, optionally, expressions"
-msgstr ""
+msgstr "fija la base numérica para resultados, y opcionalmente, expresiones"
 
 #: ../src/qalc.cc:2054
 msgid "use colors to highlight different elements of expressions and results"
-msgstr ""
+msgstr "usar colores para resaltar diferentes elementos de expresiones y "
+"resultados"
 
 #: ../src/qalc.cc:2059
 msgid "FILE"
-msgstr ""
+msgstr "ARCHIVO"
 
 #: ../src/qalc.cc:2060
 msgid "execute commands from a file first"
-msgstr ""
+msgstr "primero ejecutar comandos desde un archivo"
 
 #: ../src/qalc.cc:2062
 msgid "start in interactive mode"
-msgstr ""
+msgstr "iniciar en modo interactivo"
 
 #: ../src/qalc.cc:2063 ../src/qalc.cc:2065 ../src/qalc.cc:2067
 #: ../src/qalc.cc:2069 ../src/qalc.cc:2071
 msgid "SEARCH TERM"
-msgstr ""
+msgstr "TÉRMINO DE BÚSQUEDA"
 
 #: ../src/qalc.cc:2064
 msgid ""
 "displays a list of all user-defined or matching variables, functions, units, "
 "and prefixes"
 msgstr ""
+"muestra una lista de todas las variables, funciones, unidades o prefijos "
+"definidos por el usuario, o coincidentes"
 
 #: ../src/qalc.cc:2066
 msgid "displays a list of all or matching functions"
-msgstr ""
+msgstr "muestra una lista de todas las funciones coincidentes"
 
 #: ../src/qalc.cc:2068
 msgid "displays a list of all or matching prefixes"
-msgstr ""
+msgstr "muestra una lista de todas los prefijos coincidentes"
 
 #: ../src/qalc.cc:2070
 msgid "displays a list of all or matching units"
-msgstr ""
+msgstr "muestra una lista de todas las unidades coincidentes"
 
 #: ../src/qalc.cc:2072
 msgid "displays a list of all or matching variables"
-msgstr ""
+msgstr "muestra una lista de todas las variables coincidentes"
 
 #: ../src/qalc.cc:2073
 msgid "MILLISECONDS"
-msgstr ""
+msgstr "MILISEGUNDOS"
 
 #: ../src/qalc.cc:2074
 msgid ""
 "terminate calculation and display of result after specified amount of time"
 msgstr ""
+"terminar el cálculo y mostrar el resultado después de una cantidad de "
+"tiempo especificada"
 
 #: ../src/qalc.cc:2076
 msgid "do not load any functions, units, or variables from file"
-msgstr ""
+msgstr "no cargar ninguna función, unidad, o variable del archivo"
 
 #: ../src/qalc.cc:2078
 msgid "do not load any global currencies from file"
-msgstr ""
+msgstr "no cargar ninguna divisa global del archivo"
 
 #: ../src/qalc.cc:2080
 msgid "do not load any global data sets from file"
-msgstr ""
+msgstr "no cargar ningún conjunto de datos globales del archivo"
 
 #: ../src/qalc.cc:2082
 msgid "do not load any global functions from file"
-msgstr ""
+msgstr "no cargar ninguna función global del archivo"
 
 #: ../src/qalc.cc:2084
 msgid "do not load any global units from file"
-msgstr ""
+msgstr "no cargar ninguna unidad global del archivo"
 
 #: ../src/qalc.cc:2086
 msgid "do not load any global variables from file"
-msgstr ""
+msgstr "no cargar ninguna variable global del archivo"
 
 #: ../src/qalc.cc:2088
 msgid ""
 "start in programming mode (same as -b \"BASE BASE\" -s \"xor^\", with base "
 "conversion)"
 msgstr ""
+"iniciar en modo de programación (igual a -b \"BASE BASE\" -s \"xor^\", con "
+"conversión de base)"
 
 #: ../src/qalc.cc:2089 ../src/qalc.cc:3815
 msgid "OPTION"
-msgstr ""
+msgstr "OPCIÓN"
 
 #: ../src/qalc.cc:2089 ../src/qalc.cc:3815
 msgid "VALUE"
-msgstr ""
+msgstr "VALOR"
 
 #: ../src/qalc.cc:2090
 msgid "as set command in interactive program session (e.g. -set \"base 16\")"
 msgstr ""
+"como el comando fijar en la sesión interactiva del programa (ej. -set "
+"\"base 16\")"
 
 #: ../src/qalc.cc:2092
 msgid "reduce output to just the result of the input expression"
 msgstr ""
+"reducir la salida a solamente el resultado de la expresión de entrada"
 
 #: ../src/qalc.cc:2094
 msgid "switch unicode support on/off"
-msgstr ""
+msgstr "activar/desactivar soporte para unicode"
 
 #: ../src/qalc.cc:2096
 msgid "show application version and exit"
-msgstr ""
+msgstr "mostrar la versión de la aplicación y salir"
 
 #: ../src/qalc.cc:2098
 msgid ""
 "The program will start in interactive mode if no expression and no file is "
 "specified (or interactive mode is explicitly selected)."
 msgstr ""
+"El programa iniciará en modo interactivo si no se especifica una expresión "
+"o archivo (o si el modo interactivo es seleccionado explícitamente)"
 
 #: ../src/qalc.cc:2098
 msgid "Type help in interactive mode for information about available commands."
 msgstr ""
+"Escribe ayuda en modo interactivo para información acerca de los comandos "
+"disponibles."
 
 #: ../src/qalc.cc:2101 ../src/qalc.cc:3834
 msgid ""
@@ -1318,6 +1339,10 @@ msgid ""
 "sections in the manual of the graphical user interface (available at https://"
 "qalculate.github.io/manual/index.html)."
 msgstr ""
+"Para más información acerca de las expresiones matemáticas y diferentes "
+"opciones, y una lista completa de funciones, variables, y unidades, mire "
+"las secciones relevantes en el manual de la interfaz gráfica de usuario "
+"(disponible en https://qalculate.github.io/manual/index.html)."
 
 #: ../src/qalc.cc:2103 ../src/qalc.cc:3836
 msgid ""
@@ -1327,57 +1352,62 @@ msgid ""
 "index.html), which also includes a complete list of functions, variables, "
 "and units."
 msgstr ""
+"Para más información acerca de las expresiones matemáticas y diferentes "
+"opciones, por favor consulte la página de man, o las secciones relevantes "
+"en el manual de la interfaz gráfica de usuario (disponible en https://"
+"qalculate.github.io/manual/index.html), que también incluye una lista "
+"completa de funciones, variables, y unidades."
 
 #: ../src/qalc.cc:2235
 msgid "No option and value specified for set command."
-msgstr ""
+msgstr "No se especificaron opción y valor para el comando fijar."
 
 #: ../src/qalc.cc:2246
 msgid "No file specified."
-msgstr ""
+msgstr "No se especificó el archivo."
 
 #: ../src/qalc.cc:2338
 msgid "Failed to load global definitions!"
-msgstr ""
+msgstr "¡Fallo al cargar definiciones globales!"
 
 #: ../src/qalc.cc:2384
 #, c-format
 msgid "Could not open \"%s\".\n"
-msgstr ""
+msgstr "No se pudo abrir \"%s\".\n"
 
 #: ../src/qalc.cc:2430 ../src/qalc.cc:2495 ../src/qalc.cc:4791
 #, c-format
 msgid "Illegal character, '%c', in expression."
-msgstr ""
+msgstr "Carácter ilegal, \"%c\", en la expresión"
 
 #. qalc command
 #: ../src/qalc.cc:2566 ../src/qalc.cc:3812 ../src/qalc.cc:4573
 #: ../src/qalc.cc:4778
 msgid "save"
-msgstr ""
+msgstr "guardar"
 
 #: ../src/qalc.cc:2566 ../src/qalc.cc:3812 ../src/qalc.cc:4573
 #: ../src/qalc.cc:4778
 msgid "store"
-msgstr ""
+msgstr "guardar"
 
 #. qalc command
 #: ../src/qalc.cc:2586 ../src/qalc.cc:3452 ../src/qalc.cc:3810
 #: ../src/qalc.cc:4599 ../src/qalc.cc:4771
 msgid "mode"
-msgstr ""
+msgstr "modo"
 
 #: ../src/qalc.cc:2588
 msgid "mode saved"
-msgstr ""
+msgstr "modo guardado"
 
 #: ../src/qalc.cc:2590
 msgid "definitions"
-msgstr ""
+msgstr "definiciones"
 
 #: ../src/qalc.cc:2592
 msgid "definitions saved"
-msgstr ""
+msgstr "definiciones guardadas"
 
 #. qalc command
 #: ../src/qalc.cc:2675 ../src/qalc.cc:3817 ../src/qalc.cc:4580
@@ -1389,112 +1419,117 @@ msgstr ""
 #: ../src/qalc.cc:2736 ../src/qalc.cc:3807 ../src/qalc.cc:4586
 #: ../src/qalc.cc:4778 ../libqalculate/Function.cc:2176
 msgid "function"
-msgstr ""
+msgstr "función"
 
 #: ../src/qalc.cc:2778
 msgid ""
 "A function with the same name already exists.\n"
 "Do you want to overwrite it (default: no)?"
 msgstr ""
+"Una función con el mismo nombre ya existe.\n"
+"¿Quieres sobreescribirla (predeterminado: no)?"
 
 #. qalc command
 #: ../src/qalc.cc:2803 ../src/qalc.cc:3798 ../src/qalc.cc:4593
 #: ../src/qalc.cc:4778
 msgid "delete"
-msgstr ""
+msgstr "eliminar"
 
 #: ../src/qalc.cc:2814
 msgid "No user-defined variable or function with the specified name exist."
 msgstr ""
+"No existe una variable o función definida por el usuario y con el nombre "
+"especificado"
 
 #. qalc command
 #: ../src/qalc.cc:2818 ../src/qalc.cc:3796 ../src/qalc.cc:4544
 #: ../src/qalc.cc:4778
 msgid "assume"
-msgstr ""
+msgstr "asumir"
 
 #: ../src/qalc.cc:2828
 msgid "syntax"
-msgstr ""
+msgstr "sintaxis"
 
 #. qalc command
 #: ../src/qalc.cc:2836 ../src/qalc.cc:2883 ../src/qalc.cc:3821
 #: ../src/qalc.cc:4638 ../src/qalc.cc:4771
 msgid "stack"
-msgstr ""
+msgstr "pila"
 
 #. qalc command
 #: ../src/qalc.cc:2861 ../src/qalc.cc:3802 ../src/qalc.cc:4618
 #: ../src/qalc.cc:4771
 msgid "exrates"
-msgstr ""
+msgstr "tasascambio"
 
 #: ../src/qalc.cc:2885 ../src/qalc.cc:2903 ../src/qalc.cc:2912
 #: ../src/qalc.cc:2945 ../src/qalc.cc:2974 ../src/qalc.cc:2983
 #: ../src/qalc.cc:3000 ../src/qalc.cc:3007 ../src/qalc.cc:3025
 #: ../src/qalc.cc:3032
 msgid "The RPN stack is empty."
-msgstr ""
+msgstr "La pila RPN está vacía."
 
 #. qalc command
 #: ../src/qalc.cc:2901 ../src/qalc.cc:2910 ../src/qalc.cc:3827
 #: ../src/qalc.cc:4642
 msgid "swap"
-msgstr ""
+msgstr "intercambiar"
 
 #: ../src/qalc.cc:2905 ../src/qalc.cc:2914 ../src/qalc.cc:2947
 #: ../src/qalc.cc:2976 ../src/qalc.cc:2985
 msgid "The RPN stack only contains one value."
-msgstr ""
+msgstr "La pila RPN solo contiene un valor."
 
 #: ../src/qalc.cc:2933 ../src/qalc.cc:2966 ../src/qalc.cc:3014
 #: ../src/qalc.cc:3038
 msgid "The specified RPN stack index does not exist."
-msgstr ""
+msgstr "El índice de pila RPN especificado no existe."
 
 #. qalc command
 #: ../src/qalc.cc:2943 ../src/qalc.cc:3824 ../src/qalc.cc:4664
 #: ../src/qalc.cc:4778
 msgid "move"
-msgstr ""
+msgstr "mover"
 
 #. qalc command
 #: ../src/qalc.cc:2972 ../src/qalc.cc:2981 ../src/qalc.cc:3826
 #: ../src/qalc.cc:4660
 msgid "rotate"
-msgstr ""
+msgstr "rotar"
 
 #: ../src/qalc.cc:2989
 msgid "up"
-msgstr ""
+msgstr "arriba"
 
 #: ../src/qalc.cc:2991
 msgid "down"
-msgstr ""
+msgstr "abajo"
 
 #. qalc command
 #: ../src/qalc.cc:2998 ../src/qalc.cc:3005 ../src/qalc.cc:3823
 #: ../src/qalc.cc:4652
 msgid "copy"
-msgstr ""
+msgstr "copiar"
 
 #. qalc command
 #: ../src/qalc.cc:3020 ../src/qalc.cc:3822 ../src/qalc.cc:4628
 msgid "clear stack"
-msgstr ""
+msgstr "limpiar pila"
 
 #. qalc command
 #: ../src/qalc.cc:3023 ../src/qalc.cc:3030 ../src/qalc.cc:3825
 #: ../src/qalc.cc:4632
 msgid "pop"
-msgstr ""
+msgstr "sacar"
 
 #. qalc command
 #: ../src/qalc.cc:3058 ../src/qalc.cc:3059 ../src/qalc.cc:3816
 #: ../src/qalc.cc:4684 ../src/qalc.cc:4778
 msgid "convert"
-msgstr ""
+msgstr "convert"
 
+# "a" is a unit I have never heard without a prefix, "ha" is used
 #. "to"-operator
 #: ../src/qalc.cc:3058 ../src/qalc.cc:3059 ../src/qalc.cc:3816
 #: ../src/qalc.cc:4684 ../src/qalc.cc:4732 ../src/qalc.cc:4778
@@ -1507,12 +1542,12 @@ msgstr ""
 #: ../libqalculate/Calculator.cc:305 ../libqalculate/Calculator.cc:535
 #: ../libqalculate/Calculator.cc:1256 ../libqalculate/Calculator.cc:1257
 msgid "to"
-msgstr ""
+msgstr "a"
 
 #: ../src/qalc.cc:3218 ../src/qalc.cc:5719
 #: ../libqalculate/Calculator-calculate.cc:1505
 msgid "Time zone parsing failed."
-msgstr ""
+msgstr "Análisis de huso horario falló."
 
 #. number bases
 #: ../src/qalc.cc:3292 ../src/qalc.cc:5733
@@ -1523,102 +1558,102 @@ msgstr ""
 #: ../src/qalc.cc:3338 ../src/qalc.cc:5735
 #: ../libqalculate/Calculator-calculate.cc:1532
 msgid "calendars"
-msgstr ""
+msgstr "calendarios"
 
 #: ../src/qalc.cc:3356 ../src/qalc.cc:5729
 #: ../libqalculate/Calculator-calculate.cc:1525
 msgid "factors"
-msgstr ""
+msgstr "factores"
 
 #. qalc command
 #: ../src/qalc.cc:3358 ../src/qalc.cc:3446 ../src/qalc.cc:3811
 #: ../src/qalc.cc:4274 ../src/qalc.cc:5731
 #: ../libqalculate/Calculator-calculate.cc:1528
 msgid "partial fraction"
-msgstr ""
+msgstr "fracciones parciales"
 
 #. qalc command
 #: ../src/qalc.cc:3443 ../src/qalc.cc:3805 ../src/qalc.cc:4270
 #: ../src/qalc.cc:4771
 msgid "factor"
-msgstr ""
+msgstr "factorizar"
 
 #: ../src/qalc.cc:3457 ../src/qalc.cc:4301
 msgid "Algebraic Mode"
-msgstr ""
+msgstr "Modo algebraico"
 
 #: ../src/qalc.cc:3495 ../src/qalc.cc:4335
 msgid "Calculation"
-msgstr ""
+msgstr "Cálculo"
 
 #: ../src/qalc.cc:3526
 msgid "simplified"
-msgstr ""
+msgstr "simplificado"
 
 #: ../src/qalc.cc:3531 ../src/qalc.cc:4348
 msgid "Enabled Objects"
-msgstr ""
+msgstr "Objetos habilitados"
 
 #: ../src/qalc.cc:3543 ../src/qalc.cc:4360
 msgid "Generic Display Options"
-msgstr ""
+msgstr "Opciones de visualización genéricas"
 
 #: ../src/qalc.cc:3575 ../src/qalc.cc:4373
 msgid "Numerical Display"
-msgstr ""
+msgstr "Visualización numérica"
 
 #: ../src/qalc.cc:3694 ../src/qalc.cc:4458
 msgid "Parsing"
-msgstr ""
+msgstr "Análisis"
 
 #: ../src/qalc.cc:3741 ../src/qalc.cc:4503
 msgid "Units"
-msgstr ""
+msgstr "Unidades"
 
 #: ../src/qalc.cc:3779 ../src/qalc.cc:4537
 msgid "Other"
-msgstr ""
+msgstr "Otros"
 
 #. qalc command
 #: ../src/qalc.cc:3787 ../src/qalc.cc:4266
 msgid "help"
-msgstr ""
+msgstr "ayuda"
 
 #: ../src/qalc.cc:3790
 msgid "Enter a mathematical expression or a command and press enter."
-msgstr ""
+msgstr "Ingrese una expresión matemática o un comando y presione enter."
 
 #: ../src/qalc.cc:3791
 msgid "Complete functions, units and variables with the tabulator key."
-msgstr ""
+msgstr "Completa funciones, unidades y variables con la tecla tabulador."
 
 #: ../src/qalc.cc:3793
 msgid "Available commands are:"
-msgstr ""
+msgstr "Los comandos disponibles son:"
 
 #: ../src/qalc.cc:3796
 msgid "ASSUMPTIONS"
-msgstr ""
+msgstr "SUPOSICIONES"
 
 #: ../src/qalc.cc:3798 ../src/qalc.cc:3806 ../src/qalc.cc:3807
 #: ../src/qalc.cc:3808 ../src/qalc.cc:3812 ../src/qalc.cc:3817
 msgid "NAME"
-msgstr ""
+msgstr "NOMBRE"
 
 #: ../src/qalc.cc:3806 ../src/qalc.cc:3842 ../src/qalc.cc:4603
 #: ../src/qalc.cc:4778
 msgid "find"
-msgstr ""
+msgstr "buscar"
 
 #. qalc command
 #: ../src/qalc.cc:3806 ../src/qalc.cc:3840 ../src/qalc.cc:3842
 #: ../src/qalc.cc:4603
 msgid "list"
-msgstr ""
+msgstr "listar"
 
 #: ../src/qalc.cc:3807 ../src/qalc.cc:3817
 msgid "EXPRESSION"
-msgstr ""
+msgstr "EXPRESIÓN"
 
 #. qalc command
 #: ../src/qalc.cc:3808 ../src/qalc.cc:3870 ../src/qalc.cc:4612
@@ -1630,118 +1665,123 @@ msgstr ""
 
 #: ../src/qalc.cc:3809
 msgid "MC/MS/M+/M- (memory operations)"
-msgstr ""
+msgstr "MC/MS/M+/M- (operaciones de memoria)"
 
 #: ../src/qalc.cc:3812
 msgid "CATEGORY"
-msgstr ""
+msgstr "CATEGORÍA"
 
 #: ../src/qalc.cc:3812
 msgid "TITLE"
-msgstr ""
+msgstr "TÍTULO"
 
 #: ../src/qalc.cc:3816
 msgid "UNIT or \"TO\" COMMAND"
-msgstr ""
+msgstr "UNIDAD o COMANDO \"a\""
 
 #. qalc command
 #: ../src/qalc.cc:3818 ../src/qalc.cc:4736 ../src/qalc.cc:4763
 #: ../src/qalc.cc:4771
 msgid "quit"
-msgstr ""
+msgstr "salir"
 
 #: ../src/qalc.cc:3818 ../src/qalc.cc:4736 ../src/qalc.cc:4763
 #: ../src/qalc.cc:4771
 msgid "exit"
-msgstr ""
+msgstr "salir"
 
 #: ../src/qalc.cc:3819
 msgid "Commands for RPN mode:"
-msgstr ""
+msgstr "Comandos para el modo RPN:"
 
 #: ../src/qalc.cc:3820
 msgid "STATE"
-msgstr ""
+msgstr "ESTADO"
 
 #: ../src/qalc.cc:3823 ../src/qalc.cc:3825
 msgid "INDEX"
-msgstr ""
+msgstr "ÍNDICE"
 
 #: ../src/qalc.cc:3824 ../src/qalc.cc:3827
 msgid "INDEX 1"
-msgstr ""
+msgstr "ÍNDICE 1"
 
 #: ../src/qalc.cc:3824 ../src/qalc.cc:3827
 msgid "INDEX 2"
-msgstr ""
+msgstr "ÍNDICE 2"
 
 #: ../src/qalc.cc:3826
 msgid "DIRECTION"
-msgstr ""
+msgstr "DIRECCIÓN"
 
 #: ../src/qalc.cc:3829
 msgid "Type help COMMAND for more information (example: help save)."
-msgstr ""
+msgstr "Escriba ayuda COMANDO para más información (ejemplo: ayuda guardar)."
 
 #: ../src/qalc.cc:3830
 msgid ""
 "Type info NAME for information about a function, variable, unit, or prefix "
 "(example: info sin)."
 msgstr ""
+"Escriba info NOMBRE para más información acerca de una función, variable, "
+"unidad, o prefijo (ejemplo: info cos)."
 
 #: ../src/qalc.cc:3831
 msgid ""
 "When a line begins with '/', the following text is always interpreted as a "
 "command."
 msgstr ""
+"Cuando una linea empieza con \"/\", el texto siguiente siempre es "
+"interpretado como un comando."
 
 #: ../src/qalc.cc:3855 ../src/qalc.cc:3861
 msgid "currencies"
-msgstr ""
+msgstr "divisas"
 
 #: ../src/qalc.cc:3881
 msgid "No function, variable, unit, or prefix with specified name exist."
-msgstr ""
+msgstr "No existe ninguna función, variable, unidad o prefijo con el nombre "
+"especificado."
 
 #: ../src/qalc.cc:3895
 msgid "Function"
-msgstr ""
+msgstr "Función"
 
 #: ../src/qalc.cc:4043
 msgid "Expression:"
-msgstr ""
+msgstr "Expresión:"
 
 #: ../src/qalc.cc:4051 ../src/qalc.cc:4054 ../src/qalc.cc:4229
 msgid "Unit"
-msgstr ""
+msgstr "Unidad"
 
 #: ../src/qalc.cc:4057 ../src/qalc.cc:4135 ../src/qalc.cc:4245
 msgid "Names"
-msgstr ""
+msgstr "Nombres"
 
 #: ../src/qalc.cc:4075
 msgid "Base Unit"
-msgstr ""
+msgstr "Unidad base"
 
 #: ../src/qalc.cc:4087
 msgid "Relation"
-msgstr ""
+msgstr "Relación"
 
 #: ../src/qalc.cc:4092 ../src/qalc.cc:4197
 msgid "Relative uncertainty"
-msgstr ""
+msgstr "Incertidumbre relativa"
 
 #: ../src/qalc.cc:4093 ../src/qalc.cc:4198
 msgid "Uncertainty"
-msgstr ""
+msgstr "Incertidumbre"
 
 #: ../src/qalc.cc:4103
 msgid "Inverse Relation"
-msgstr ""
+msgstr "Relación inversa"
 
 #: ../src/qalc.cc:4115
 msgid "Base Units"
-msgstr ""
+msgstr "Unidades base"
 
 #: ../src/qalc.cc:4129 ../src/qalc.cc:4132
 msgid "Variable"
@@ -1749,59 +1789,63 @@ msgstr ""
 
 #: ../src/qalc.cc:4243
 msgid "Prefix"
-msgstr ""
+msgstr "Prefijo"
 
 #: ../src/qalc.cc:4272
 msgid "Factorizes the current result."
-msgstr ""
+msgstr "Factoriza el resultado actual."
 
 #: ../src/qalc.cc:4276
 msgid "Applies partial fraction decomposition to the current result."
-msgstr ""
+msgstr "Aplica descomposición parcial de fracciones al resultado actual."
 
 #: ../src/qalc.cc:4280
 msgid "Expands the current result."
-msgstr ""
+msgstr "Expande el resultado actual."
 
 #: ../src/qalc.cc:4296
 msgid "Sets the value of an option."
-msgstr ""
+msgstr "Fija el valor de una opción."
 
 #: ../src/qalc.cc:4297
 msgid "Example: set base 16."
-msgstr ""
+msgstr "Ejemplo: fijar base 16."
 
 #: ../src/qalc.cc:4299
 msgid ""
 "Available options and accepted values are (the current value is marked with "
 "'*'):"
 msgstr ""
+"Las opciones disponibles y valores aceptados son (el valor actual está "
+"marcado con \"*\"):"
 
 #: ../src/qalc.cc:4303
 msgid "Determines if the expression is factorized or not after calculation."
-msgstr ""
+msgstr "Determina si la expresión es factorizada o no después del cálculo."
 
 #: ../src/qalc.cc:4304
 msgid "Determines if unknown values will be assumed non-zero (x/x=1)."
-msgstr ""
+msgstr "Determina si valores desconocidos son asumidos como no cero (x/x=1)."
 
 #: ../src/qalc.cc:4305
 msgid "Display a message after a value has been assumed non-zero."
-msgstr ""
+msgstr "Muestra un mensaje después de que un valor se asuma como no cero"
 
 #: ../src/qalc.cc:4308
 msgid "Default assumptions for unknown variables."
-msgstr ""
+msgstr "Suposiciones predeterminadas para variables desconocidas."
 
 #: ../src/qalc.cc:4337
 msgid "Default angle unit for trigonometric functions."
-msgstr ""
+msgstr "Unidad de ángulo predeterminada para funciones trigonométricas."
 
 #: ../src/qalc.cc:4341
 msgid ""
 "How approximate variables and calculations are handled. In exact mode "
 "approximate values will not be calculated."
 msgstr ""
+"Como se manejan variables y cálculos aproximados. En el modo exacto, los "
+"valores aproximados no se calcularán."
 
 #: ../src/qalc.cc:4342
 msgid ""
@@ -1809,47 +1853,59 @@ msgid ""
 "calculations (avoids wrong results after loss of significance) with "
 "approximate functions and/or irrational numbers."
 msgstr ""
+"Si está activado, la aritmética de intervalo define la precisión final de "
+"los cálculos (evita resultados incorrectos luego de pérdida de "
+"significancia) con funciones aproximadas y/o números irracionales."
 
 #: ../src/qalc.cc:4343
 msgid ""
 "Determines the method used for interval calculation / uncertainty "
 "propagation."
 msgstr ""
+"Determina el método usado para el cálculo de intervalo / propagación de "
+"incertidumbre."
 
 #: ../src/qalc.cc:4345
 msgid ""
 "Specifies the default number of significant digits displayed and determines "
 "the precision used for approximate calculations."
 msgstr ""
+"Especifica el número predeterminado de cifras significativas mostradas y "
+"determina la precisión usada para cálculos aproximados."
 
 #: ../src/qalc.cc:4356
 msgid "Interpret undefined symbols in expressions as unknown variables."
 msgstr ""
+"Interpretar símbolos indefinidos en expresiones como variables "
+"desconocidas."
 
 #: ../src/qalc.cc:4358
 msgid ""
 "If activated physical constants include units (e.g. c = 299 792 458 m∕s)."
 msgstr ""
+"Si está activado las constantes físicas incluyen unidades (ej. "
+"c = 299 792 458 m∕s)."
 
 #: ../src/qalc.cc:4362
 msgid "Use abbreviated names for units and variables."
-msgstr ""
+msgstr "Usar nombres abreviados para unidades y variables."
 
 #: ../src/qalc.cc:4363
 msgid "Use colors to highlight different elements of expressions and results."
 msgstr ""
+"Usar colores para resaltar diferentes elementos de expresiones y resultados"
 
 #: ../src/qalc.cc:4366
 msgid "Always place negative values last."
-msgstr ""
+msgstr "Siempre colocar valores negativos al final."
 
 #: ../src/qalc.cc:4369
 msgid "Add extra space around operators."
-msgstr ""
+msgstr "Añadir espacio extra al rededor de los operadores."
 
 #: ../src/qalc.cc:4371
 msgid "Display Unicode characters."
-msgstr ""
+msgstr "Mostrar caracteres Unicode"
 
 #: ../src/qalc.cc:4375 ../src/qalc.cc:4479
 msgid "bin"
@@ -1873,82 +1929,98 @@ msgstr ""
 
 #: ../src/qalc.cc:4402 ../src/qalc.cc:4462
 msgid "Determines the default decimal separator."
-msgstr ""
+msgstr "Determina el separador decimal predefinido."
 
 #: ../src/qalc.cc:4417
 msgid ""
 "Determines how rational numbers are displayed (e.g. 5/4 = 1 + 1/4 = 1.25). "
 "'long' removes limits on the size of the numerator and denominator."
 msgstr ""
+"Determina como se muestran los números racionales (ej. 5/4 = 1 + 1/4 = 1.25"
+"). \"largo\" elimina los límites en el tamaño del numerador y denominador."
 
 #: ../src/qalc.cc:4418
 msgid ""
 "Enables two's complement representation for display of negative hexadecimal "
 "numbers."
 msgstr ""
+"Habilita la representación de complemento a dos para números hexadecimales "
+"negativos."
 
 #: ../src/qalc.cc:4419 ../src/qalc.cc:4478
 msgid "Use 'j' (instead of 'i') as default symbol for the imaginary unit."
 msgstr ""
+"Usar \"j\" (en lugar de \"i\") como símbolo predefinido para la unidad "
+"imaginaria."
 
 #: ../src/qalc.cc:4421
 msgid "Use lowercase e for E-notation (5e2 = 5 * 10^2)."
-msgstr ""
+msgstr "Usar e minúscula para la notación E (5e2 = 5 * 10^2)."
 
 #: ../src/qalc.cc:4422
 msgid "Use lowercase letters for number bases > 10."
-msgstr ""
+msgstr "Usar letras minúsculas para bases numéricas mayores a 10."
 
 #: ../src/qalc.cc:4437
 msgid ""
 "If activated, 1/6 is displayed as '0.1 666...', otherwise as '0.166667'."
 msgstr ""
+"Si está activado 1/6 se muestra como \"0.1 666...\", sino como "
+"\"0.166667\"."
 
 #: ../src/qalc.cc:4438
 msgid ""
 "Determines whether halfway numbers are rounded upwards or towards the "
 "nearest even integer."
 msgstr ""
+"Determina si los números medios se redondean hacia arriba o hacia el "
+"entero par más cercano."
 
 #: ../src/qalc.cc:4440
 msgid "Determines how scientific notation is used (e.g. 5 543 000 = 5.543E6)."
-msgstr ""
+msgstr "Determina como se usa la notación científica "
+"(ej. 5 543 000 = 5.543E6)."
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr ""
+"Si está activado, se mantienen los ceros al final de números aproximados."
 
 #: ../src/qalc.cc:4456
 msgid ""
 "Enables two's complement representation for display of negative binary "
 "numbers."
 msgstr ""
+"Habilita la representación de complemento a dos para la visualización de "
+"números binarios negativos."
 
 #: ../src/qalc.cc:4460
 msgid "Use ^ as bitwise exclusive OR operator."
-msgstr ""
+msgstr "Usar ^ como el operador de OR exclusivo bit a bit."
 
 #: ../src/qalc.cc:4473
 msgid "Allows use of ',' as thousands separator."
-msgstr ""
+msgstr "Permite el uso de \",\" como el separador de miles."
 
 #: ../src/qalc.cc:4476
 msgid "Allows use of '.' as thousands separator."
-msgstr ""
+msgstr "Permite el uso de \".\" como el separador de miles."
 
 #: ../src/qalc.cc:4500
 msgid "See 'help parsing mode'."
-msgstr ""
+msgstr "Vea \"ayuda modo de análisis\"."
 
 #: ../src/qalc.cc:4501
 msgid ""
 "If activated, numbers are interpreted as approximate with precision equal to "
 "the number of significant digits (3.20 = 3.20+/-0.005)."
 msgstr ""
+"Si está activado, los números se interpretan como aproximados con precisión "
+"igual al número de cifras significativas (3.20 = 3.20+/-0.005)."
 
 #: ../src/qalc.cc:4505
 msgid "Enables automatic use of hecto, deca, deci, and centi."
-msgstr ""
+msgstr "Habilita el uso automático de hecto, deca, deci, y centi."
 
 #: ../src/qalc.cc:4507
 msgid ""
@@ -1956,37 +2028,51 @@ msgid ""
 "converts non-SI units, while 'optimal' only converts to more optimal unit "
 "expressions, with less units and exponents."
 msgstr ""
+"Controla la conversión automática de la unidad del resultado. \"óptimosi\" "
+"siempre convierte unidades que no sean del SI, mientras que \"óptimo\" solo "
+"convierte a expresiones de unidad más óptimas, con menos unidades y "
+"exponentes."
 
 #: ../src/qalc.cc:4521
 msgid ""
 "If activated, binary prefixes are used by default for information units."
 msgstr ""
+"Si está activado, se usan por defecto los prefijos binarios para unidades "
+"de información."
 
 #: ../src/qalc.cc:4522
 msgid ""
 "Enables automatic conversion to the local currency when optimal unit "
 "conversion is enabled."
 msgstr ""
+"Habilita la conversión automática a la moneda local cuando la conversión a "
+"unidades óptimas está habilitada."
 
 #: ../src/qalc.cc:4523
 msgid ""
 "Enables automatic use of prefixes in the denominator of unit expressions."
 msgstr ""
+"Habilita el uso automático de prefijos en el denominador de las "
+"expresiones de unidad."
 
 #: ../src/qalc.cc:4524
 msgid ""
 "If activated, units are separated from variables at the end of the result."
 msgstr ""
+"Si está activado, las unidades se separan de las variables al final del "
+"resultado."
 
 #: ../src/qalc.cc:4525
 msgid "Enables automatic use of prefixes in the result."
-msgstr ""
+msgstr "Habilita el uso automático de prefijos en el resultado."
 
 #: ../src/qalc.cc:4526
 msgid ""
 "Use negative exponents instead of division for units in result (m/s = "
 "m*s^-1)."
 msgstr ""
+"Usar exponentes negativos en lugar de división para unidades en el "
+"resultado (m/s = m*s^-1)."
 
 #: ../src/qalc.cc:4528
 msgid ""
@@ -1994,82 +2080,94 @@ msgid ""
 "acts as absolute if the expression contains different temperature units, "
 "otherwise as relative)."
 msgstr ""
+"Determina como las expresiones con unidades de temperatura con calculadas "
+"(híbrido actúa como absoluto si la expresión contiene unidades de "
+"temperatura distintas, en otros casos, como relativo)."
 
 #: ../src/qalc.cc:4532
 msgid "days"
-msgstr ""
+msgstr "días"
 
 #: ../src/qalc.cc:4539
 msgid "Ignore system language and use English (requires restart)."
-msgstr ""
+msgstr "Ignora el idioma del sistema y usa inglés (requiere reinicio)."
 
 #: ../src/qalc.cc:4540
 msgid "Activates the Reverse Polish Notation stack."
-msgstr ""
+msgstr "Activa la pila de notación polaca inversa (RPN)."
 
 #: ../src/qalc.cc:4541
 msgid "Save functions, units, and variables on exit."
-msgstr ""
+msgstr "Guardar funciones, unidades, y variables al salir."
 
 #: ../src/qalc.cc:4542
 msgid "Save settings on exit."
-msgstr ""
+msgstr "Guardar configuración al salir."
 
 #: ../src/qalc.cc:4546
 msgid "Set default assumptions for unknown variables."
-msgstr ""
+msgstr "Fijar las suposiciones predefinidas para variables desconocidas."
 
 #: ../src/qalc.cc:4575
 msgid ""
 "Saves the current result in a variable with the specified name. You may "
 "optionally also provide a category (default \"Temporary\") and a title."
 msgstr ""
+"Guarda el resultado actual en una variable con el nombre especificado. "
+"Puedes, opcionalmente, también designar una categoría (por defecto "
+"\"Temporal\") y un título."
 
 #: ../src/qalc.cc:4576
 msgid ""
 "If name equals \"mode\" or \"definitions\", the current mode and "
 "definitions, respectively, will be saved."
 msgstr ""
+"Si el nombre es igual a \"modo\" o \"definiciones\", se guardará el modo "
+"o las definiciones actuales respectivamente."
 
 #: ../src/qalc.cc:4578
 msgid "Example: store var1."
-msgstr ""
+msgstr "Ejemplo: guardar var1."
 
 #: ../src/qalc.cc:4582
 msgid "Create a variable with the specified name and expression."
-msgstr ""
+msgstr "Crea una variable con nombre y expresión especificados."
 
 #: ../src/qalc.cc:4584
 msgid "Example: variable var1 pi / 2."
-msgstr ""
+msgstr "Ejemplo: variable var1 pi / 2."
 
 #: ../src/qalc.cc:4588
 msgid "Creates a function with the specified name and expression."
-msgstr ""
+msgstr "Crea una función con nombre y expresión especificados."
 
 #: ../src/qalc.cc:4589
 msgid "Use '\\x', '\\y', '\\z', '\\a', etc. for arguments in the expression."
 msgstr ""
+"Use \"\\x\", \"\\y\", \"\\z\", \"\\a\", etc. para argumentos en la "
+" expresión."
 
 #: ../src/qalc.cc:4591
 msgid "Example: function func1 5*\\x."
-msgstr ""
+msgstr "Ejemplo función func1 5*\\x"
 
 #: ../src/qalc.cc:4595
 msgid "Removes the user-defined variable or function with the specified name."
 msgstr ""
+"Elimina la variable o función definida por el usuario con el nombre "
+"especificado."
 
 #: ../src/qalc.cc:4597
 msgid "Example: delete var1."
-msgstr ""
+msgstr "Ejemplo: eliminar var1."
 
 #: ../src/qalc.cc:4601
 msgid "Displays the current mode."
-msgstr ""
+msgstr "Muestra el modo actual."
 
 #: ../src/qalc.cc:4605
 msgid "Displays a list of variables, functions, units, and prefixes."
-msgstr ""
+msgstr "Muestra una lista de variables, funciones, unidades, y prefijos."
 
 #: ../src/qalc.cc:4606
 msgid ""
@@ -2079,47 +2177,55 @@ msgid ""
 "and/or prefixes. If command is called with no argument all user-definied "
 "objects are listed."
 msgstr ""
+"Ingrese con argumento \"divisas\", \"funciones\", \"variables\", "
+"\"unidades\", \"prefijos\" para mostrar una lista de todas las divisas, "
+"funciones, variables, unidades, o prefijos. Ingrese un término de búsqueda "
+"para encontrar funciones, variables, unidades, y/o prefijos coincidentes. "
+"Si el comando se llama sin argumentos, se listan todos los objetos "
+"definidos por el usuario."
 
 #: ../src/qalc.cc:4608
 msgid "Example: list functions."
-msgstr ""
+msgstr "Ejemplo: listar funciones."
 
 #: ../src/qalc.cc:4609
 msgid "Example: find dinar."
-msgstr ""
+msgstr "Ejemplo: buscar dinar."
 
 #: ../src/qalc.cc:4610
 msgid "Example: find variables planck."
-msgstr ""
+msgstr "Ejemplo: buscar variables planck."
 
 #: ../src/qalc.cc:4614
 msgid "Displays information about a function, variable, unit, or prefix."
 msgstr ""
+"Muestra información acerca de una función, variable, unidad, o prefijo."
 
 #: ../src/qalc.cc:4616
 msgid "Example: info sin."
-msgstr ""
+msgstr "Ejemplo: info cos."
 
 #: ../src/qalc.cc:4620
 msgid "Downloads current exchange rates from the Internet."
-msgstr ""
+msgstr "Descarga las tasas de cambio actuales del internet."
 
 #: ../src/qalc.cc:4624
 msgid "(De)activates the Reverse Polish Notation stack and syntax."
-msgstr ""
+msgstr "(Des)activa la pila y sintaxis de notación polaca inversa (RPN)."
 
 #: ../src/qalc.cc:4626
 msgid ""
 "\"syntax\" activates only the RPN syntax and \"stack\" enables the RPN stack."
 msgstr ""
+"\"sintaxis\" solo activa la sintaxis RPN y \"pila\" activa la pila PRN."
 
 #: ../src/qalc.cc:4630
 msgid "Clears the entire RPN stack."
-msgstr ""
+msgstr "Limpia toda la pila RPN."
 
 #: ../src/qalc.cc:4634
 msgid "Removes the top of the RPN stack or the value at the specified index."
-msgstr ""
+msgstr "Elimina la cima de la pila RPN o el valor en el índice especificado."
 
 #: ../src/qalc.cc:4636 ../src/qalc.cc:4648 ../src/qalc.cc:4658
 #: ../src/qalc.cc:4668
@@ -2127,14 +2233,16 @@ msgid ""
 "Index 1 is the top of stack and negative index values count from the bottom "
 "of the stack."
 msgstr ""
+"Índice 1 es la cima de la pila, e índices negativos cuentan desde el fondo "
+"de la pila."
 
 #: ../src/qalc.cc:4640
 msgid "Displays the RPN stack."
-msgstr ""
+msgstr "Muestra la pila RPN."
 
 #: ../src/qalc.cc:4644
 msgid "Swaps position of values on the RPN stack."
-msgstr ""
+msgstr "Intercambia la posición de valores en la pila RPN."
 
 #: ../src/qalc.cc:4646
 msgid ""
@@ -2142,214 +2250,233 @@ msgid ""
 "index 2) will be swapped and if only one index is specified, the value at "
 "this index will be swapped with the top value."
 msgstr ""
+"Si no se especifica un índice, se intercambian los valores en la cima de "
+"la pila (índices 1 y 2). Si solo se especifica un índice, el valor en ese "
+"índice se intercambia con el valor en la cima."
 
 #: ../src/qalc.cc:4650
 msgid "Example: swap 2 4"
-msgstr ""
+msgstr "Ejemplo: intercambiar 2 4"
 
 #: ../src/qalc.cc:4654
 msgid "Duplicates a value on the RPN stack to the top of the stack."
-msgstr ""
+msgstr "Duplica un valor en la pila RPN a la cima de la pila."
 
 #: ../src/qalc.cc:4656
 msgid "If no index is specified, the top of the stack is duplicated."
-msgstr ""
+msgstr "Si no se especifica un índice, se duplica la cima de la pila."
 
 #: ../src/qalc.cc:4662
 msgid "Rotates the RPN stack up (default) or down."
-msgstr ""
+msgstr "Rota la pila RPN arriba (por defecto) o abajo."
 
 #: ../src/qalc.cc:4666
 msgid "Changes the position of a value on the RPN stack."
-msgstr ""
+msgstr "Cambia la posición de un valor en la pila RPN."
 
 #: ../src/qalc.cc:4670
 msgid "Example: move 2 4"
-msgstr ""
+msgstr "Ejemplo: mover 2 4"
 
 #: ../src/qalc.cc:4674
 msgid "Sets the result number base (equivalent to set base)."
-msgstr ""
+msgstr "Fija la base numérica del resultado (equivalente a fijar base)."
 
 #: ../src/qalc.cc:4678
 msgid "Equivalent to set approximation exact."
-msgstr ""
+msgstr "Equivalente a fijar aproximación exacta."
 
 #: ../src/qalc.cc:4682
 msgid "Equivalent to set approximation try exact."
-msgstr ""
+msgstr "Equivalente a fijar aproximación intentar exacta."
 
 #: ../src/qalc.cc:4687
 msgid ""
 "Converts the current result (equivalent to using \"to\" at the end of an "
 "expression)."
 msgstr ""
+"Convierte el resultado actual (equivalente a usar \"a\" al final de una "
+"expresión)."
 
 #: ../src/qalc.cc:4689
 msgid "Possible values:"
-msgstr ""
+msgstr "Valores posibles:"
 
 #: ../src/qalc.cc:4691
 msgid "- a unit or unit expression (e.g. meter or km/h)"
-msgstr ""
+msgstr "- una unidad o expresión de unidad (ej. m o km/h)"
 
 #: ../src/qalc.cc:4692
 msgid "prepend with ? to request the optimal prefix"
-msgstr ""
+msgstr "anteponer con ? para pedir el prefijo óptimo"
 
 #: ../src/qalc.cc:4693
 msgid "prepend with b? to request the optimal binary prefix"
-msgstr ""
+msgstr "anteponer con b? para pedir el prefijo binario óptimo"
 
 #: ../src/qalc.cc:4694
 msgid "prepend with + or - to force/disable use of mixed units"
 msgstr ""
+"anteponer con + o - para forzar/deshabilitar el uso de unidades mixtas"
 
 #: ../src/qalc.cc:4695
 msgid "- a variable or physical constant (e.g. c)"
-msgstr ""
+msgstr "- una variable o contante física (ej. c)"
 
 #: ../src/qalc.cc:4696
 msgid "- base (convert to base units)"
-msgstr ""
+msgstr "- base (convertir a unidades base)"
 
 #: ../src/qalc.cc:4697
 msgid "- optimal (convert to optimal unit)"
-msgstr ""
+msgstr "- óptimo (convertir a unidades óptimas)"
 
 #: ../src/qalc.cc:4698
 msgid "- mixed (convert to mixed units, e.g. hours + minutes)"
-msgstr ""
+msgstr "- mixto (convertir a unidades mixtas, ej. h + min)"
 
 #: ../src/qalc.cc:4700
 msgid "- bin / binary (show as binary number)"
-msgstr ""
+msgstr "- bin / binario (mostrar como número binario)"
 
 #: ../src/qalc.cc:4701
 msgid "- bin# (show as binary number with specified number of bits)"
-msgstr ""
+msgstr "- bin# (mostrar como número binario con número especificado de bits)"
 
 #: ../src/qalc.cc:4702
 msgid "- oct / octal (show as octal number)"
-msgstr ""
+msgstr "- oct / octal (mostrar como número octal)"
 
 #: ../src/qalc.cc:4703
 msgid "- duo / duodecimal (show as duodecimal number)"
-msgstr ""
+msgstr "- duo / duodecimal (mostrar como número duodecimal)"
 
 #: ../src/qalc.cc:4704
 msgid "- hex / hexadecimal (show as hexadecimal number)"
-msgstr ""
+msgstr "- hex / hexadecimal (mostrar como número hexadecimal)"
 
 #: ../src/qalc.cc:4705
 msgid "- hex# (show as hexadecimal number with specified number of bits)"
 msgstr ""
+"- hex# / (mostrar como número hexadecimal con número especificado de bits)"
 
 #: ../src/qalc.cc:4706
 msgid "- sexa / sexa2 / sexagesimal (show as sexagesimal number)"
-msgstr ""
+msgstr "- sexa / sexa2 / sexagesimal (mostrar como número sexagesimal)"
 
 #: ../src/qalc.cc:4707
-msgid "- latitude / latitude2 (show as sexagesimal longitude)"
-msgstr ""
+msgid "- latitude / latitude2 (show as sexagesimal latitude)"
+msgstr "- latitud / latitud2 (mostrar como latitud sexagesimal)"
 
 #: ../src/qalc.cc:4708
 msgid "- longitude / longitude2 (show as sexagesimal longitude)"
-msgstr ""
+msgstr "- longitud / longitud2 (mostrar como longitud sexagesimal)"
 
 #: ../src/qalc.cc:4709
 msgid "- bijective (shown in bijective base-26)"
-msgstr ""
+msgstr "- biyectiva (mostrar como base biyectiva 26)"
 
 #: ../src/qalc.cc:4710
 msgid "- fp16, fp32, fp64, fp80, fp128 (show in binary floating-point format)"
 msgstr ""
+"- fp16, fp32, fp64, fp80, fp128 (mostrar en formato binario de punto "
+"flotante)"
 
 #: ../src/qalc.cc:4711
 msgid "- roman (show as roman numerals)"
-msgstr ""
+msgstr "- romana (mostrar como números romanos)"
 
 #: ../src/qalc.cc:4712
 msgid "- time (show in time format)"
-msgstr ""
+msgstr "- tiempo (mostrar en formato de tiempo)"
 
 #: ../src/qalc.cc:4713
 msgid "- unicode"
-msgstr ""
+msgstr "- unicode"
 
 #: ../src/qalc.cc:4714
 msgid "- base # (show in specified number base)"
-msgstr ""
+msgstr "- base # (mostrar en la base numérica especificada)"
 
 #: ../src/qalc.cc:4715
 msgid "- bases (show as binary, octal, decimal and hexadecimal number)"
 msgstr ""
+"- bases (mostrar como un número binario, octal, decimal, y hexadecimal)"
 
 #: ../src/qalc.cc:4717
 msgid "- rectangular / cartesian (show complex numbers in rectangular form)"
 msgstr ""
+"- rectangular / cartesiana (mostrar números complejos en forma rectangular)"
 
 #: ../src/qalc.cc:4718
 msgid "- exponential (show complex numbers in exponential form)"
-msgstr ""
+msgstr "- exponencial (mostrar números complejos en forma exponencial)"
 
 #: ../src/qalc.cc:4719
 msgid "- polar (show complex numbers in polar form)"
-msgstr ""
+msgstr "- polar (mostrar números complejos en forma polar)"
 
 #: ../src/qalc.cc:4720
 msgid "- cis (show complex numbers in cis form)"
-msgstr ""
+msgstr "- cis (mostrar números complejos en forma cis)"
 
 #: ../src/qalc.cc:4721
 msgid "- angle / phasor (show complex numbers in angle/phasor notation)"
 msgstr ""
+"- ángulo / fasor (mostrar números complejos con la notación ángulo/fasor)"
 
 #: ../src/qalc.cc:4723
 msgid "- fraction (show result as mixed fraction)"
-msgstr ""
+msgstr "- fracción (mostrar resultado como una fracción mixta)"
 
 #: ../src/qalc.cc:4724
 msgid "- factors (factorize result)"
-msgstr ""
+msgstr "- factores (factorizar resultado)"
 
 #: ../src/qalc.cc:4726
 msgid "- UTC (show date and time in UTC time zone)"
-msgstr ""
+msgstr "- UTC (mostrar fecha y tiempo en el huso horario UTC)"
 
 #: ../src/qalc.cc:4727
 msgid "- UTC+/-hh[:mm] (show date and time in specified time zone)"
 msgstr ""
+"- UTC+/-hh[:mm] (mostrar fecha y tiempo en el huso horario especificado)"
 
 #: ../src/qalc.cc:4728
 msgid "- calendars"
-msgstr ""
+msgstr "- calendarios"
 
 #: ../src/qalc.cc:4730
 msgid "Example: to ?g"
-msgstr ""
+msgstr "Ejemplo: a ?g"
 
 #: ../src/qalc.cc:4733
 msgid ""
 "This command can also be typed directly at the end of the mathematical "
 "expression (e.g. 5 ft + 2 in to meter)."
 msgstr ""
+"Este comando también puede ser escrito directamente al final de la "
+"expresión matemática (ej. 5 ft + 2 in a m)."
 
 #: ../src/qalc.cc:4738
 msgid "Terminates this program."
-msgstr ""
+msgstr "Termina este programa."
 
 #: ../src/qalc.cc:4743
 msgid ""
 "Implicit multiplication does not differ from explicit multiplication "
 "(\"12/2(1+2) = 12/2*3 = 18\", \"5x/5y = 5*x/5*y = xy\")."
 msgstr ""
+"La multiplicación implícita no es diferente de la multiplicación explicita "
+"(\"12/2(1+2) = 12/2*3 = 18\", \"5x/5y = 5*x/5*y = xy\")."
 
 #: ../src/qalc.cc:4746
 msgid ""
 "Implicit multiplication is parsed before explicit multiplication "
 "(\"12/2(1+2) = 12/(2*3) = 2\", \"5x/5y = (5*x)/(5*y) = x/y\")."
 msgstr ""
+"La multiplicación implícita es analizada antes de la multiplicación "
+"explicita (\"12/2(1+2) = 12/(2*3) = 2\", \"5x/5y = (5*x)/(5*y) = x/y\")."
 
 #: ../src/qalc.cc:4749
 msgid ""
@@ -2358,6 +2485,10 @@ msgid ""
 "adaptive mode unit expressions are parsed separately (\"5 m/5 m/s = (5*m)/"
 "(5*(m/s)) = 1 s\")."
 msgstr ""
+"El modo predefinido \"adaptativo\" funciona igual que el modo \"primero "
+"implícito\", amenos que se encuentren espacios (\"1/5x = 1/(5*x)\", pero "
+"\"1/5 x = (1/5)*x\"). En el modo adaptativo las expresiones de unidad son "
+"analizadas por separado (\"5 m/5 m/s = (5*m)/(5*(m/s)) = 1 s\")."
 
 #: ../src/qalc.cc:4751
 msgid ""
@@ -2365,31 +2496,38 @@ msgid ""
 "multiplication in front of variables and units is parsed first regardless of "
 "mode (\"sqrt 2x = sqrt(2x)\")."
 msgstr ""
+"Los argumentos de funciones sin paréntesis son una excepción, donde la "
+"multiplicación implícita en frente de variables siempre se analiza primero, "
+"sin importar el modo (\"sqrt 2x = sqrt(2x)\")."
 
 #: ../src/qalc.cc:4754
 msgid ""
 "Parse expressions using reverse Polish notation (\"1 2 3+* = 1*(2+3) = 5\")"
 msgstr ""
+"Analizar expresiones usando la notación polaca invertida (RPN) "
+"(\"1 2 3+* = 1*(2+3) = 5\")."
 
 #: ../src/qalc.cc:4757
 msgid ""
 "Perform operations from left to right, like the immediate execution mode of "
 "a traditional calculator (\"1+2*3 = (1+2)*3 = 9\")"
 msgstr ""
+"Realizar operaciones de izquierda a derecha, como el modo de ejecución "
+"inmediata de una calculadora tradicional (\"1+2*3 = (1+2)*3 = 9\")."
 
 #: ../src/qalc.cc:4776
 #, c-format
 msgid "%s does not accept any arguments."
-msgstr ""
+msgstr "%s no acepta ningún argumento."
 
 #: ../src/qalc.cc:4782
 #, c-format
 msgid "%s requires at least one argument."
-msgstr ""
+msgstr "%s requiere al menos un argumento"
 
 #: ../src/qalc.cc:4785
 msgid "Unknown command."
-msgstr ""
+msgstr "Comando desconocido."
 
 #: ../src/qalc.cc:4841
 msgid "error"
@@ -2397,13 +2535,13 @@ msgstr ""
 
 #: ../src/qalc.cc:4843
 msgid "warning"
-msgstr ""
+msgstr "advertencia"
 
 #: ../src/qalc.cc:4969 ../src/qalc.cc:6238
 #: ../libqalculate/Calculator-calculate.cc:1785
 #: ../libqalculate/Calculator-calculate.cc:1805
 msgid "approx."
-msgstr ""
+msgstr "aprox."
 
 #: ../src/qalc.cc:4990 ../src/qalc.cc:5338 ../src/qalc.cc:5986
 #: ../libqalculate/Calculator-calculate.cc:1091
@@ -2411,65 +2549,68 @@ msgstr ""
 #: ../libqalculate/MathStructure.cc:448
 #, c-format
 msgid "aborted"
-msgstr ""
+msgstr "cancelado"
 
 #: ../src/qalc.cc:5002
 msgid "RPN Register Moved"
-msgstr ""
+msgstr "Registro RPN movido"
 
 #: ../src/qalc.cc:5023 ../src/qalc.cc:6192
 msgid "RPN Operation"
-msgstr ""
+msgstr "Operación RPN"
 
 #: ../src/qalc.cc:5060
 msgid "Processing (press Enter to abort)"
-msgstr ""
+msgstr "Procesando (presione enter para cancelar)"
 
 #: ../src/qalc.cc:5355
 msgid "Factorizing (press Enter to abort)"
-msgstr ""
+msgstr "Factorizando (presione enter para cancelar)"
 
 #: ../src/qalc.cc:5359
 msgid "Expanding partial fractions…"
-msgstr ""
+msgstr "Expandiendo fracciones parciales…"
 
 #: ../src/qalc.cc:5363
 msgid "Expanding (press Enter to abort)"
-msgstr ""
+msgstr "Expandiendo (presione enter para cancelar)"
 
 #: ../src/qalc.cc:5367 ../src/qalc.cc:6000
 msgid "Calculating (press Enter to abort)"
-msgstr ""
+msgstr "Calculando (presione enter para cancelar)"
 
 #: ../src/qalc.cc:5465
 msgid ""
 "The expression is ambiguous. Please select temperature calculation mode (the "
 "mode can later be changed using \"set temp\" command)."
 msgstr ""
+"La expresión es ambigua. Por valor seleccione el modo de cálculo de "
+"temperatura (el modo puede ser cambiado después usando el comando "
+"\"fijar temp\")."
 
 #: ../src/qalc.cc:5490 ../src/qalc.cc:5518
 msgid "Temperature calculation mode"
-msgstr ""
+msgstr "Modo de cálculo de temperatura"
 
 #: ../src/qalc.cc:5539
 msgid "Please select interpretation of dots (\".\")."
-msgstr ""
+msgstr "Por favor seleccione la interpretación de los puntos (\".\")."
 
 #: ../src/qalc.cc:5543
 msgid "Both dot and comma as decimal separators"
-msgstr ""
+msgstr "Ambos punto y coma como separadores decimales"
 
 #: ../src/qalc.cc:5549
 msgid "Dot as thousands separator"
-msgstr ""
+msgstr "Punto como separador de miles"
 
 #: ../src/qalc.cc:5555
 msgid "Only dot as decimal separator"
-msgstr ""
+msgstr "Solo punto como separador decimal"
 
 #: ../src/qalc.cc:5560 ../src/qalc.cc:5594
 msgid "Dot interpretation"
-msgstr ""
+msgstr "Interpretación del punto"
 
 #: ../src/qalc.cc:6794
 #, c-format
@@ -2477,10 +2618,12 @@ msgid ""
 "Couldn't write preferences to\n"
 "%s"
 msgstr ""
+"No se pudieron escribir las preferencias a\n"
+"%s"
 
 #: ../src/qalc.cc:6912
 msgid "Couldn't write definitions"
-msgstr ""
+msgstr "No se pudieron escribir las definiciones"
 
 #. thread cancellation is not safe
 #: ../src/test.cc:13 ../src/test.cc:28
@@ -2489,38 +2632,42 @@ msgid ""
 "The calculation has been forcibly terminated. Please restart the application "
 "and report this as a bug."
 msgstr ""
+"El cálculo ha sido terminado forzosamente. Por favor reinicie la aplicación "
+"y reporte esto como un bug."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:359
 msgid ""
 "No equality or inequality to solve. The entered expression to solve is not "
 "correct (e.g. \"x + 5 = 3\" is correct)"
 msgstr ""
+"No hay una igualdad o desigualdad que resolver. La expresión ingresada no "
+"es correcta (ej. \"x + 5 = 3\" es correcta)."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:406
 #, c-format
 msgid "The comparison is true for all %s (with current assumptions)."
-msgstr ""
+msgstr "La comparación es verdadera para todo %s (con suposiciones actuales)."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:410
 msgid "No possible solution was found (with current assumptions)."
-msgstr ""
+msgstr "No se encontró una solución posible (con suposiciones actuales)."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:414
 #, c-format
 msgid "Was unable to completely isolate %s."
-msgstr ""
+msgstr "No se pudo aislar completamente %s."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:418
 #: ../libqalculate/BuiltinFunctions-algebra.cc:581
 #: ../libqalculate/BuiltinFunctions-algebra.cc:673
 #, c-format
 msgid "The comparison is true for all %s if %s."
-msgstr ""
+msgstr "La comparación es verdadera para todo %s if %s."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:422
 #, c-format
 msgid "Was unable to isolate %s."
-msgstr ""
+msgstr "No se pudo aislar %s."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:542
 #: ../libqalculate/BuiltinFunctions-algebra.cc:569
@@ -2530,6 +2677,8 @@ msgid ""
 "Was unable to isolate %s with the current assumptions. The assumed sign was "
 "therefore temporarily set as unknown."
 msgstr ""
+"No se pudo aislar %s con suposiciones actuales. El signo asumido fue "
+"temporalmente fijado como desconocido."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:545
 #: ../libqalculate/BuiltinFunctions-algebra.cc:572
@@ -2539,17 +2688,19 @@ msgid ""
 "Was unable to isolate %s with the current assumptions. The assumed type and "
 "sign was therefore temporarily set as unknown."
 msgstr ""
+"No se pudo aislar %s con suposiciones actuales. El tipo asumido fue "
+"temporalmente fijado como desconocido."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:577
 #: ../libqalculate/BuiltinFunctions-algebra.cc:660
 #, c-format
 msgid "The solution requires that %s."
-msgstr ""
+msgstr "La solución requiere que %s."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:667
 #, c-format
 msgid "Solution %s requires that %s."
-msgstr ""
+msgstr "La solución %s requiere que %s."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:738
 #, c-format
@@ -2560,102 +2711,106 @@ msgid ""
 "so that each equation at least contains the corresponding variable (if "
 "automatic reordering failed)."
 msgstr ""
+"No se pudo aislar %s.\n"
+"Puede que tenga que colocar las ecuaciones y variables en un orden "
+"apropiado tal que cada ecuación contenga al menos la variable "
+"correspondiente (si el reordenado automático falló)."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:740
 #: ../libqalculate/BuiltinFunctions-algebra.cc:754
 #: ../libqalculate/BuiltinFunctions-algebra.cc:763
 #, c-format
 msgid "Unable to isolate %s."
-msgstr ""
+msgstr "No se pudo aislar %s."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:747
 #, c-format
 msgid "Inequalities are not allowed in %s()."
-msgstr ""
+msgstr "No se permiten desigualdades en %s()."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:1089
 #: ../libqalculate/BuiltinFunctions-algebra.cc:1094
 msgid "No differential equation found."
-msgstr ""
+msgstr "No se encontró una ecuación diferencial."
 
 #: ../libqalculate/BuiltinFunctions-algebra.cc:1098
 #: ../libqalculate/BuiltinFunctions-algebra.cc:1127
 #: ../libqalculate/BuiltinFunctions-algebra.cc:1133
 msgid "Unable to solve differential equation."
-msgstr ""
+msgstr "No se pudo resolver la ecuación diferencial."
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:34
 #: ../libqalculate/BuiltinFunctions-datetime.cc:68
 msgid "gregorian"
-msgstr ""
+msgstr "gregoriano"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:35
 msgid "milankovic"
-msgstr ""
+msgstr "milankovitch"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:36
 msgid "julian"
-msgstr ""
+msgstr "juliano"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:37
 msgid "islamic"
-msgstr ""
+msgstr "islámico"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:38
 msgid "hebrew"
-msgstr ""
+msgstr "hebreo"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:39
 msgid "egyptian"
-msgstr ""
+msgstr "egipcio"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:40
 msgid "persian"
-msgstr ""
+msgstr "persa"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:41
 msgid "coptic"
-msgstr ""
+msgstr "copto"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:42
 msgid "ethiopian"
-msgstr ""
+msgstr "etíope"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:43
 msgid "indian"
-msgstr ""
+msgstr "hindú"
 
 #: ../libqalculate/BuiltinFunctions-datetime.cc:44
 msgid "chinese"
-msgstr ""
+msgstr "chino"
 
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:57
 #, c-format
 msgid "Too many elements (%s) for the dimensions (%sx%s) of the matrix."
-msgstr ""
+msgstr "Demasiados elementos (%s) para las dimensiones (%sx%s) de la matriz."
 
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:137
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:199
 #, c-format
 msgid "Row %s does not exist in matrix."
-msgstr ""
+msgstr "Fila %s no existe en la matriz."
 
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:150
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:195
 #, c-format
 msgid "Column %s does not exist in matrix."
-msgstr ""
+msgstr "Columna %s no existe en la matriz."
 
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:210
 #, c-format
 msgid "Argument 3, %s, is ignored for vectors."
-msgstr ""
+msgstr "Argumento 3, %s, es ignorado para vectores."
 
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:214
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:235
 #, c-format
 msgid "Element %s does not exist in vector."
-msgstr ""
+msgstr "Elemento %s no existe en el vector."
 
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:429
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:433
@@ -2664,27 +2819,31 @@ msgstr ""
 #, c-format
 msgid "%s() requires that all matrices/vectors have the same dimensions."
 msgstr ""
+"%s() requiere que todas las matrices/vectores tengan las mismas "
+"dimensiones."
 
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:1038
 msgid ""
 "The number of requested elements in generate vector function must be a "
 "positive integer."
 msgstr ""
+"El número pedido de elementos en la función generar vector tiene que ser "
+"un entero positivo."
 
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:1061
 #: ../libqalculate/BuiltinFunctions-matrixvector.cc:1078
 msgid "Comparison failed."
-msgstr ""
+msgstr "La comparación falló."
 
 #: ../libqalculate/BuiltinFunctions-statistics.cc:181
 #: ../libqalculate/BuiltinFunctions-statistics.cc:224
 #, c-format
 msgid "Unsolvable comparison in %s()."
-msgstr ""
+msgstr "Comparación irresoluble en %s() "
 
 #: ../libqalculate/BuiltinFunctions-calculus.cc:710
 msgid "Unable to find limit."
-msgstr ""
+msgstr "So se pudo encontrar el límite."
 
 #: ../libqalculate/BuiltinFunctions-calculus.cc:805
 #: ../libqalculate/BuiltinFunctions-calculus.cc:837
@@ -2698,7 +2857,7 @@ msgstr ""
 #: ../libqalculate/MathStructure-integrate.cc:7780
 #: ../libqalculate/MathStructure-integrate.cc:7822
 msgid "Unable to integrate the expression."
-msgstr ""
+msgstr "So se pudo integrar la expresión."
 
 #: ../libqalculate/BuiltinFunctions-number.cc:818
 msgid "phoneword"
@@ -2709,18 +2868,18 @@ msgstr ""
 #: ../libqalculate/Number.cc:994
 #, c-format
 msgid "Character '%s' was ignored in the number \"%s\" with base %s."
-msgstr ""
+msgstr "El carácter \"%s\" fue ignorado en el número \"%s\" con base %s."
 
 #: ../libqalculate/BuiltinFunctions-number.cc:1528
 #: ../libqalculate/Number.cc:2065 ../libqalculate/Number.cc:2190
 msgid "Floating point overflow"
-msgstr ""
+msgstr "Desbordamiento de punto flotante"
 
 #. test calculated floating point value and show mpfr errors (show as errors if error_level > 1, show as warnings if error_level = 1, do not generate message if error_level is zero)
 #: ../libqalculate/BuiltinFunctions-number.cc:1529
 #: ../libqalculate/Number.cc:2064 ../libqalculate/Number.cc:2189
 msgid "Floating point underflow"
-msgstr ""
+msgstr "Subflujo de punto flotante"
 
 #. if left value is a function without any arguments, do function replacement
 #: ../libqalculate/BuiltinFunctions-util.cc:479
@@ -2737,83 +2896,92 @@ msgstr ""
 #: ../libqalculate/Calculator-calculate.cc:2300
 #, c-format
 msgid "Original value (%s) was not found."
-msgstr ""
+msgstr "No se encontró el valor (%s)."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:709
 #: ../libqalculate/BuiltinFunctions-util.cc:713
 #, c-format
 msgid "Too few elements (%s) in vector (%s required)"
-msgstr ""
+msgstr "Muy pocos elementos (%s) en el vector (se requieren %s)."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:759
 #, c-format
 msgid "Object %s does not exist."
-msgstr ""
+msgstr "El objeto %s no existe."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:802
 #, c-format
 msgid "Invalid function name (%s)."
-msgstr ""
+msgstr "Nombre de función (%s) inválido."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:857
 msgid ""
 "A global function was deactivated. It will be restored after the new "
 "function has been removed."
 msgstr ""
+"Una función global fue desactivada. Será restaurada después de que la "
+"nueva función sea eliminada."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:868
 #, c-format
 msgid "Invalid variable name (%s)."
-msgstr ""
+msgstr "Nombre de variable (%s) inválido."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:887
 msgid ""
 "A global unit or variable was deactivated. It will be restored after the new "
 "variable has been removed."
 msgstr ""
+"Una unidad o variable global fue desactivada. Será restaurada después de "
+"que la nueva variable sea eliminada."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:902
 #, c-format
 msgid "Register %s does not exist. Returning zero."
-msgstr ""
+msgstr "El registro %s no existe. Devolviendo cero."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:950
 #: ../libqalculate/BuiltinFunctions-util.cc:961
 #, c-format
 msgid "Failed to run external command (%s)."
-msgstr ""
+msgstr "Fallo al ejecutar comando externo (%s)."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:1027
 #: ../libqalculate/BuiltinFunctions-util.cc:1041
 msgid "Matrix"
-msgstr ""
+msgstr "Matriz"
 
 #: ../libqalculate/BuiltinFunctions-util.cc:1052
 #: ../libqalculate/BuiltinFunctions-util.cc:1102
 msgid "Vector"
-msgstr ""
+msgstr "Vector"
 
 #: ../libqalculate/BuiltinFunctions-util.cc:1067
 #: ../libqalculate/BuiltinFunctions-util.cc:1113
 #: ../libqalculate/Calculator-plot.cc:143
 msgid "Unable to generate plot data with current min, max and step size."
 msgstr ""
+"No se pudo generar los datos de la gráfica con el min, max, y paso actual."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:1069
 #: ../libqalculate/BuiltinFunctions-util.cc:1115
 msgid "Sampling rate must be a positive integer."
-msgstr ""
+msgstr "Tasa de muestreo debe ser un entero positivo."
 
 #: ../libqalculate/BuiltinFunctions-util.cc:1078
 #: ../libqalculate/BuiltinFunctions-util.cc:1124
 #: ../libqalculate/Calculator-plot.cc:113
 msgid "Unable to generate plot data with current min, max and sampling rate."
 msgstr ""
+"No se pudo generar los datos de la gráfica con el min, max, y tasa de "
+"muestreo actual."
 
 #: ../libqalculate/Calculator-calculate.cc:304
 #: ../libqalculate/Calculator-calculate.cc:429
 msgid "Stack is empty. Filling remaining function arguments with zeroes."
 msgstr ""
+"La pila está vacía. Llenando los argumentos restantes de la función con "
+"ceros."
 
 #. logical operator
 #: ../libqalculate/Calculator-calculate.cc:1017
@@ -2827,7 +2995,7 @@ msgstr ""
 
 #: ../libqalculate/Calculator-calculate.cc:1929
 msgid "calculating..."
-msgstr ""
+msgstr "calculando..."
 
 #. "where"-operator
 #: ../libqalculate/Calculator-calculate.cc:2103
@@ -2836,54 +3004,54 @@ msgstr ""
 #: ../libqalculate/Calculator-calculate.cc:2126
 #: ../libqalculate/Calculator.cc:1260
 msgid "where"
-msgstr ""
+msgstr "donde"
 
 #: ../libqalculate/Calculator-calculate.cc:2322
 #, c-format
 msgid "Unhandled \"where\" expression: %s"
-msgstr ""
+msgstr "Expresión \"donde\" no manejada: %s"
 
 #: ../libqalculate/Calculator-calculate.cc:2568
 #: ../libqalculate/Calculator-calculate.cc:2615
 msgid "timed out"
-msgstr ""
+msgstr "agotado el tiempo"
 
 #. division operator
 #: ../libqalculate/Calculator.cc:236 ../libqalculate/Calculator.cc:471
 msgid "per"
-msgstr ""
+msgstr "entre"
 
 #. multiplication operator
 #: ../libqalculate/Calculator.cc:239 ../libqalculate/Calculator.cc:473
 msgid "times"
-msgstr ""
+msgstr "por"
 
 #. addition operator
 #: ../libqalculate/Calculator.cc:242 ../libqalculate/Calculator.cc:475
 msgid "plus"
-msgstr ""
+msgstr "más"
 
 #. subtraction operator
 #: ../libqalculate/Calculator.cc:245 ../libqalculate/Calculator.cc:477
 msgid "minus"
-msgstr ""
+msgstr "menos"
 
 #: ../libqalculate/Calculator.cc:622
 msgid "Gradians unit is missing. Creating one for this session."
-msgstr ""
+msgstr "Falta la unidad gradianes. Creándola para esta sesión."
 
 #: ../libqalculate/Calculator.cc:623 ../libqalculate/Calculator.cc:631
 #: ../libqalculate/Calculator.cc:639
 msgid "Angle/Plane Angle"
-msgstr ""
+msgstr "Ángulo/Plano Ángulo"
 
 #: ../libqalculate/Calculator.cc:630
 msgid "Radians unit is missing. Creating one for this session."
-msgstr ""
+msgstr "Falta la unidad radianes. Creándola para esta sesión."
 
 #: ../libqalculate/Calculator.cc:638
 msgid "Degrees unit is missing. Creating one for this session."
-msgstr ""
+msgstr "Falta la unidad grados. Creándola para esta sesión."
 
 #: ../libqalculate/Calculator.cc:1653 ../libqalculate/Calculator.cc:1654
 #: ../libqalculate/Calculator.cc:1658 ../libqalculate/Calculator.cc:1662
@@ -2893,7 +3061,7 @@ msgstr ""
 #: ../libqalculate/Calculator-definitions.cc:3685
 #: ../libqalculate/Calculator-definitions.cc:3747
 msgid "Currency"
-msgstr ""
+msgstr "Divisa"
 
 #: ../libqalculate/Calculator.cc:2600
 #, c-format
@@ -2901,6 +3069,8 @@ msgid ""
 "\"%s\" is not allowed in names anymore. Please change the name of \"%s\", or "
 "the variable will be lost."
 msgstr ""
+"Ya no se permite \"%s\" en nombres. Por favor cambie el nombre de \"%s\", "
+"o se perderá la variable."
 
 #: ../libqalculate/Calculator.cc:2618
 #, c-format
@@ -2908,6 +3078,8 @@ msgid ""
 "\"%s\" is not allowed in names anymore. Please change the name \"%s\", or "
 "the function will be lost."
 msgstr ""
+"Ya no se permite \"%s\" en nombres. Por favor cambie el nombre de \"%s\", "
+"o se perderá la función."
 
 #: ../libqalculate/Calculator.cc:2635
 #, c-format
@@ -2915,34 +3087,38 @@ msgid ""
 "\"%s\" is not allowed in names anymore. Please change the name \"%s\", or "
 "the unit will be lost."
 msgstr ""
+"Ya no se permite \"%s\" en nombres. Por favor cambie el nombre de \"%s\", "
+"o se perderá la unidad."
 
 #: ../libqalculate/Calculator.cc:2842
 #, c-format
 msgid "Name \"%s\" is in use. Replacing with \"%s\"."
-msgstr ""
+msgstr "El nombre \"%s\" está en uso. Reemplazándolo con \"%s\"."
 
 #: ../libqalculate/Calculator-definitions.cc:816 ../libqalculate/DataSet.cc:563
 #, c-format
 msgid "File not identified as Qalculate! definitions file: %s."
 msgstr ""
+"El archivo no se identificó como un archivo de definiciones de Qalculate!: "
+"%s."
 
 #: ../libqalculate/Calculator-definitions.cc:2983
 #: ../libqalculate/DataSet.cc:370
 msgid "Object"
-msgstr ""
+msgstr "Objeto"
 
 #: ../libqalculate/Calculator-definitions.cc:2992
 #: ../libqalculate/DataSet.cc:371
 msgid "Property"
-msgstr ""
+msgstr "Propiedad"
 
 #: ../libqalculate/Calculator-definitions.cc:3291
 msgid "column"
-msgstr ""
+msgstr "columna"
 
 #: ../libqalculate/Calculator-definitions.cc:3294
 msgid "Column "
-msgstr ""
+msgstr "Columna "
 
 #: ../libqalculate/Calculator-definitions.cc:3870
 #: ../libqalculate/Calculator-definitions.cc:3871
@@ -2959,7 +3135,7 @@ msgstr ""
 #: ../libqalculate/Calculator-definitions.cc:3961
 #, c-format
 msgid "Failed to download exchange rates from %s: %s."
-msgstr ""
+msgstr "Fallo al descargar tasas de cambio de %s: %s."
 
 #. ignore operators
 #: ../libqalculate/Calculator-parse.cc:2120
@@ -2988,25 +3164,25 @@ msgstr ""
 #: ../libqalculate/Calculator-parse.cc:3903
 #, c-format
 msgid "Misplaced operator(s) \"%s\" ignored"
-msgstr ""
+msgstr "Operador(es) \"%s\" mal colocado(s) ignorado(s)"
 
 #. ignore operators
 #: ../libqalculate/Calculator-parse.cc:2169
 #: ../libqalculate/Calculator-parse.cc:3904
 #, c-format
 msgid "Misplaced '%c' ignored"
-msgstr ""
+msgstr "\"%c\" mal colocado ignorado"
 
 #: ../libqalculate/Calculator-parse.cc:2243 ../libqalculate/Function.cc:1514
 #: ../libqalculate/Function.cc:1545
 #, c-format
 msgid "Internal id %s does not exist."
-msgstr ""
+msgstr "ID interna %s no existe."
 
 #: ../libqalculate/Calculator-parse.cc:2264
 #, c-format
 msgid "\"%s\" is not a valid variable/function/unit."
-msgstr ""
+msgstr "\"%s\" no es una variable/función/unidad válida."
 
 #: ../libqalculate/Calculator-parse.cc:2282
 #, c-format
@@ -3014,6 +3190,8 @@ msgid ""
 "Trailing characters \"%s\" (not a valid variable/function/unit) in number "
 "\"%s\" were ignored."
 msgstr ""
+"Caracteres finales \"%s\" (variable/función/unidad inválida) en el número "
+"fueron ignorados."
 
 #: ../libqalculate/Calculator-parse.cc:2374
 #: ../libqalculate/Calculator-parse.cc:2390
@@ -3022,33 +3200,38 @@ msgid ""
 "Please use the cross(), dot(), and hadamard() functions for vector "
 "multiplication."
 msgstr ""
+"Por favor use las funciones cross(), dot(), y hadamard() para "
+"multiplicación de vectores."
 
 #: ../libqalculate/Calculator-parse.cc:2473
 msgid "Empty expression in parentheses interpreted as zero."
-msgstr ""
+msgstr "Expresión vacía en paréntesis interpretada como cero."
 
 #: ../libqalculate/Calculator-parse.cc:2564
 msgid "RPN syntax error. Values left at the end of the RPN expression."
 msgstr ""
+"Error de sintaxis RPN. Valores restantes al final de la expresión RPN."
 
 #: ../libqalculate/Calculator-parse.cc:2567
 #: ../libqalculate/Calculator-parse.cc:2658
 msgid "Unused stack values."
-msgstr ""
+msgstr "Valores de la pila sin usar."
 
 #: ../libqalculate/Calculator-parse.cc:2717
 #: ../libqalculate/Calculator-parse.cc:2942
 #, c-format
 msgid "RPN syntax error. Operator '%c' not supported."
-msgstr ""
+msgstr "Error de sintaxis RPN. El operador \"%c\" no está soportado."
 
 #: ../libqalculate/Calculator-parse.cc:2763
 msgid "RPN syntax error. Stack is empty."
-msgstr ""
+msgstr "Error de sintaxis RPN. La pila está vacía."
 
 #: ../libqalculate/Calculator-parse.cc:2784
 msgid "RPN syntax error. Operator ignored as there was only one stack value."
 msgstr ""
+"Error de sintaxis RPN. Se ignoró un operador porque solo quedaba un valor "
+"en la pila."
 
 #: ../libqalculate/Calculator-parse.cc:3704
 #: ../libqalculate/Calculator-parse.cc:3786
@@ -3056,92 +3239,99 @@ msgid ""
 "The expression is ambiguous (be careful when combining implicit "
 "multiplication and division)."
 msgstr ""
+"La expresión es ambigua (tenga cuidado al combinar multiplicación "
+"implícita y división)."
 
 #: ../libqalculate/Calculator-parse.cc:4095
 #, c-format
 msgid "%s interpreted as 10^%s (1%s)"
-msgstr ""
+msgstr "%s interpretado como 10^%s (1%s)"
 
 #: ../libqalculate/Calculator-plot.cc:109
 #: ../libqalculate/Calculator-plot.cc:139
 #: ../libqalculate/Calculator-plot.cc:169
 #: ../libqalculate/Calculator-plot.cc:590
 msgid "It took too long to generate the plot data."
-msgstr ""
+msgstr "Tomó demasiado tiempo generar los datos de la gráfica."
 
 #: ../libqalculate/Calculator-plot.cc:195
 msgid ""
 "Failed to invoke gnuplot. Make sure that you have gnuplot installed in your "
 "path."
 msgstr ""
+"Fallo al invocar gnuplot. Asegurate que tienes gnuplot instalado en tu "
+"\"PATH\"."
 
 #: ../libqalculate/Calculator-plot.cc:267
 msgid "No extension in file name. Saving as PNG image."
-msgstr ""
+msgstr "No hay extensión en el nombre del archivo. Guardando como imagen PNG."
 
 #: ../libqalculate/Calculator-plot.cc:286
 msgid "Unknown extension in file name. Saving as PNG image."
-msgstr ""
+msgstr "Extensión desconocida en el nombre del archivo. Guardando como "
+"imagen PNG."
 
 #: ../libqalculate/Calculator-plot.cc:514
 #, c-format
 msgid "Could not create temporary file %s"
-msgstr ""
+msgstr "No se pudo crear el archivo temporal %s"
 
 #: ../libqalculate/DataSet.cc:396
 #, c-format
 msgid "Object %s not available in data set."
-msgstr ""
+msgstr "El objeto %s no está disponible en el conjunto de datos."
 
 #: ../libqalculate/DataSet.cc:406
 #, c-format
 msgid "Property %s not available in data set."
-msgstr ""
+msgstr "La propiedad %s no está disponible en el conjunto de datos."
 
 #: ../libqalculate/DataSet.cc:411
 #, c-format
 msgid "Property %s not defined for object %s."
-msgstr ""
+msgstr "La propiedad %s no está definida para el objeto %s."
 
 #: ../libqalculate/DataSet.cc:540 ../libqalculate/DataSet.cc:548
 #, c-format
 msgid "Unable to load data objects in %s."
-msgstr ""
+msgstr "No se pudieron cargar objetos de datos en %s."
 
 #: ../libqalculate/DataSet.cc:1072
 msgid "data property"
-msgstr ""
+msgstr "propiedad de datos"
 
 #: ../libqalculate/DataSet.cc:1074
 msgid "name of a data property"
-msgstr ""
+msgstr "nombre de una propiedad de datos"
 
 #: ../libqalculate/DataSet.cc:1082 ../libqalculate/DataSet.cc:1098
 msgid "no properties available"
-msgstr ""
+msgstr "no hay propiedades disponibles"
 
 #: ../libqalculate/DataSet.cc:1132
 #, c-format
 msgid ""
 "Data set \"%s\" has no object key that supports the provided argument type."
 msgstr ""
+"El conjunto de datos \"%s\" no tiene una clave de objeto que soporte el "
+"tipo de argumento entregado."
 
 #: ../libqalculate/DataSet.cc:1137
 msgid "data object"
-msgstr ""
+msgstr "objeto de datos"
 
 #: ../libqalculate/DataSet.cc:1140
 msgid "an object from"
-msgstr ""
+msgstr "un objeto de"
 
 #: ../libqalculate/DataSet.cc:1167
 msgid "use"
-msgstr ""
+msgstr "usar"
 
 #: ../libqalculate/MathStructure-calculate.cc:76
 #, c-format
 msgid "Required assumption: %s."
-msgstr ""
+msgstr "Suposición requerida :%s."
 
 #: ../libqalculate/MathStructure-calculate.cc:95
 #: ../libqalculate/MathStructure-calculate.cc:117
@@ -3149,7 +3339,7 @@ msgstr ""
 #: ../libqalculate/MathStructure-integrate.cc:7154
 #, c-format
 msgid "To avoid division by zero, the following must be true: %s."
-msgstr ""
+msgstr "Para evitar división entre cero, lo siguiente debe ser verdadero: %s."
 
 #: ../libqalculate/MathStructure-calculate.cc:1735
 #: ../libqalculate/MathStructure-calculate.cc:1757
@@ -3158,6 +3348,8 @@ msgid ""
 "The second matrix must have as many rows (was %s) as the first has columns "
 "(was %s) for matrix multiplication."
 msgstr ""
+"Para multiplicación de matrices, la segunda matriz tiene que tener tantas "
+"filas (eran %s) como la primera matriz tiene columnas (era %s)."
 
 #: ../libqalculate/MathStructure-calculate.cc:6415
 #: ../libqalculate/MathStructure-calculate.cc:6454
@@ -3171,28 +3363,32 @@ msgstr ""
 #: ../libqalculate/MathStructure-factor.cc:413
 #: ../libqalculate/MathStructure-factor.cc:1304
 msgid "This is a bug. Please report it."
-msgstr ""
+msgstr "Esto es un bug. Por favor repórtelo."
 
 #: ../libqalculate/MathStructure-calculate.cc:6833
 #: ../libqalculate/Function.cc:552
 msgid "No unknown variable/symbol was found."
-msgstr ""
+msgstr "No se encontró una variable/símbolo desconocido."
 
 #: ../libqalculate/MathStructure-eval.cc:754
 msgid "Interval potentially calculated wide."
-msgstr ""
+msgstr "El intervalo se ha calculado potencialmente ancho."
 
 #: ../libqalculate/MathStructure-eval.cc:2292
 msgid ""
 "Calculation of uncertainty propagation partially failed (using interval "
 "arithmetic instead when necessary)."
 msgstr ""
+"Fallo parcial de cálculo de propagación de incertidumbre (usando "
+"aritmética de intervalo cuando sea necesario)."
 
 #: ../libqalculate/MathStructure-eval.cc:2438
 msgid ""
 "Calculation of uncertainty propagation failed (using interval arithmetic "
 "instead)."
 msgstr ""
+"Fallo de cálculo de propagación de incertidumbre (usando aritmética de "
+"intervalo en su lugar)."
 
 #: ../libqalculate/MathStructure-factor.cc:3160
 msgid ""
@@ -3200,15 +3396,18 @@ msgid ""
 "were tried during factorization. Repeat factorization to try other random "
 "combinations."
 msgstr ""
+"Debido a límites de tiempo, solo se intentaron un número limitado de "
+"combinaciones de términos durante la factorización. Repita la "
+"factorización para intentar otras combinaciones aleatorias."
 
 #: ../libqalculate/MathStructure-integrate.cc:7736
 #: ../libqalculate/MathStructure-integrate.cc:7811
 msgid "Unable to integrate the expression exactly."
-msgstr ""
+msgstr "No se pudo integrar exactamente la expresión."
 
 #: ../libqalculate/MathStructure-integrate.cc:7775
 msgid "Definite integral was approximated."
-msgstr ""
+msgstr "Integral definida fue aproximada."
 
 #: ../libqalculate/MathStructure-isolatex.cc:999
 #: ../libqalculate/MathStructure-isolatex.cc:1176
@@ -3222,71 +3421,76 @@ msgstr ""
 #: ../libqalculate/MathStructure-isolatex.cc:2801
 #, c-format
 msgid "Interval arithmetic was disabled during calculation of %s."
-msgstr ""
+msgstr "Se desactivó la aritmética de intervalo durante el cálculo de %s."
 
 #: ../libqalculate/MathStructure-isolatex.cc:2800
 #, c-format
 msgid "Not all complex roots were calculated for %s."
-msgstr ""
+msgstr "No se calcularon todas las raíces complejas de %s."
 
 #: ../libqalculate/MathStructure-isolatex.cc:4394
 #, c-format
 msgid "Only one or two of the roots were calculated for %s."
-msgstr ""
+msgstr "Solo se calculó una de las dos raíces de %s."
 
 #: ../libqalculate/MathStructure-limit.cc:967
 #: ../libqalculate/MathStructure-limit.cc:972
 #, c-format
 msgid "Limit for %s determined graphically."
-msgstr ""
+msgstr "Límite de %s determinado gráficamente."
 
 #: ../libqalculate/MathStructure-matrixvector.cc:62
 #, c-format
 msgid "Unsolvable comparison at element %s when trying to rank vector."
 msgstr ""
+"Comparación irresoluble en el elemento %s al tratar de hallar el rango del "
+"vector."
 
 #: ../libqalculate/MathStructure-matrixvector.cc:112
 #, c-format
 msgid "Unsolvable comparison at element %s when trying to sort vector."
 msgstr ""
+"Comparación irresoluble en el elemento %s al tratar de ordenar el vector."
 
 #: ../libqalculate/MathStructure-matrixvector.cc:537
 msgid "The determinant can only be calculated for square matrices."
-msgstr ""
+msgstr "Solo se puede calcular el determinante de matrices cuadradas."
 
 #: ../libqalculate/MathStructure-matrixvector.cc:600
 msgid "The permanent can only be calculated for square matrices."
-msgstr ""
+msgstr "Solo se puede calcular el permanente de matrices cuadradas."
 
 #: ../libqalculate/MathStructure-matrixvector.cc:687
 msgid "Inverse of singular matrix."
-msgstr ""
+msgstr "Inversa de matriz singular."
 
 #: ../libqalculate/MathStructure-matrixvector.cc:852
 #: ../libqalculate/MathStructure-matrixvector.cc:898
 msgid "Too many data points"
-msgstr ""
+msgstr "Demasiados puntos de datos"
 
 #: ../libqalculate/MathStructure-matrixvector.cc:859
 msgid ""
 "The selected min and max do not result in a positive, finite number of data "
 "points"
-msgstr ""
+msgstr "Los min y max seleccionados no resultan un un número positivo y "
+"finito de puntos de datos"
 
 #: ../libqalculate/MathStructure-matrixvector.cc:895
 msgid ""
 "The selected min, max and step size do not result in a positive, finite "
 "number of data points"
-msgstr ""
+msgstr "Los min, max, y tamaño de paso seleccionados no resultan un un "
+"número positivo y finito de puntos de datos"
 
 #: ../libqalculate/MathStructure-print.cc:3863
 msgid "undefined"
-msgstr ""
+msgstr "indefinido"
 
 #: ../libqalculate/Function.cc:185
 #, c-format
 msgid "%s() requires that %s"
-msgstr ""
+msgstr "%s() requiere que %s"
 
 #: ../libqalculate/Function.cc:351 ../libqalculate/Function.cc:413
 #: ../libqalculate/Function.cc:469
@@ -3298,59 +3502,61 @@ msgid_plural ""
 "Additional arguments for function %s() were ignored. Function can only use "
 "%s arguments."
 msgstr[0] ""
+"Se ignoraron los argumentos adicionales para la función %s(). La función solo puede usar %s argumento."
 msgstr[1] ""
+"Se ignoraron los argumentos adicionales para la función %s(). La función solo puede usar %s argumentos."
 
 #: ../libqalculate/Function.cc:490
 #, c-format
 msgid "You need at least %s argument (%s) in function %s()."
 msgid_plural "You need at least %s arguments (%s) in function %s()."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Se necesita al menos %s argumento (%s) en la función %s()."
+msgstr[1] "Se necesitan al menos %s argumentos (%s) en la función %s()."
 
 #: ../libqalculate/Function.cc:492
 #, c-format
 msgid "You need at least %s argument in function %s()."
 msgid_plural "You need at least %s arguments in function %s()."
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Se necesita al menos %s argumento en la función %s()."
+msgstr[1] "Se necesitan al menos %s argumentos en la función %s()."
 
 #: ../libqalculate/Function.cc:1346
 msgid "a free value"
-msgstr ""
+msgstr "un valor libre"
 
 #: ../libqalculate/Function.cc:1351
 msgid "that is nonzero"
-msgstr ""
+msgstr "que no es cero"
 
 #: ../libqalculate/Function.cc:1359
 msgid "that is rational (polynomial)"
-msgstr ""
+msgstr "que es racional (polinómico)"
 
 #: ../libqalculate/Function.cc:1367
 msgid "that fulfills the condition:"
-msgstr ""
+msgstr "que satisface la condición:"
 
 #: ../libqalculate/Function.cc:1434
 #, c-format
 msgid "Argument %s in %s() must be %s."
-msgstr ""
+msgstr "El argumento %s en %s() tiene que ser %s."
 
 #: ../libqalculate/Function.cc:1436
 #, c-format
 msgid "Argument %s, %s, in %s() must be %s."
-msgstr ""
+msgstr "El argumento %s, %s, en %s() tiene que ser %s."
 
 #: ../libqalculate/Function.cc:1778
 msgid "a rational number"
-msgstr ""
+msgstr "un número racional"
 
 #: ../libqalculate/Function.cc:1780
 msgid "a number"
-msgstr ""
+msgstr "un número"
 
 #: ../libqalculate/Function.cc:1782
 msgid "a real number"
-msgstr ""
+msgstr "un número real"
 
 #: ../libqalculate/Function.cc:1787 ../libqalculate/Function.cc:1940
 #: ../libqalculate/Function.cc:1945
@@ -3372,120 +3578,126 @@ msgstr ""
 
 #: ../libqalculate/Function.cc:1937
 msgid "an integer"
-msgstr ""
+msgstr "un entero"
 
 #: ../libqalculate/Function.cc:1994
 msgid "symbol"
-msgstr ""
+msgstr "símbolo"
 
 #: ../libqalculate/Function.cc:1995
 msgid "an unknown variable/symbol"
-msgstr ""
+msgstr "una variable/símbolo desconocido"
 
 #: ../libqalculate/Function.cc:2008
 msgid "text"
-msgstr ""
+msgstr "texto"
 
 #: ../libqalculate/Function.cc:2009
 msgid "a text string"
-msgstr ""
+msgstr "una cadena de texto"
 
 #: ../libqalculate/Function.cc:2031
 msgid "date"
-msgstr ""
+msgstr "fecha"
 
 #: ../libqalculate/Function.cc:2032
 msgid "a date"
-msgstr ""
+msgstr "una fecha"
 
 #: ../libqalculate/Function.cc:2081
 msgid "a vector with "
-msgstr ""
+msgstr "un vector con "
 
 #: ../libqalculate/Function.cc:2093
 msgid "a vector"
-msgstr ""
+msgstr "un vector"
 
 #: ../libqalculate/Function.cc:2145
 msgid "a square matrix"
-msgstr ""
+msgstr "una matriz cuadrada"
 
 #: ../libqalculate/Function.cc:2147
 msgid "a matrix"
-msgstr ""
+msgstr "una matriz"
 
 #: ../libqalculate/Function.cc:2162
 msgid "object"
-msgstr ""
+msgstr "objeto"
 
 #: ../libqalculate/Function.cc:2163
 msgid "a valid function, unit or variable name"
-msgstr ""
+msgstr "un nombre válido de función, unidad, o variable"
 
 #: ../libqalculate/Function.cc:2177
 msgid "a valid function name"
-msgstr ""
+msgstr "un nombre válido de función"
 
 #: ../libqalculate/Function.cc:2190
 msgid "unit"
-msgstr ""
+msgstr "unidad"
 
 #: ../libqalculate/Function.cc:2191
 msgid "a valid unit name"
-msgstr ""
+msgstr "un nombre válido de unidad"
 
 #: ../libqalculate/Function.cc:2205
 msgid "a valid variable name"
-msgstr ""
+msgstr "un nombre válido de variable"
 
 #: ../libqalculate/Function.cc:2218
 msgid "file"
-msgstr ""
+msgstr "archivo"
 
 #: ../libqalculate/Function.cc:2219
 msgid "a valid file name"
-msgstr ""
+msgstr "un nombre válido de archivo"
 
 #: ../libqalculate/Function.cc:2233
 msgid "a boolean (0 or 1)"
-msgstr ""
+msgstr "un booleano (0 o 1)"
 
 #: ../libqalculate/Function.cc:2244
 msgid "an angle or a number (using the default angle unit)"
-msgstr ""
+msgstr "un ángulo o un número (usando la unidad de ángulo predefinida)"
 
 #: ../libqalculate/Number.cc:280 ../libqalculate/Number.cc:10743
 msgid ""
 "Cannot display numbers greater than 9999 or less than -9999 as roman "
 "numerals."
 msgstr ""
+"No se pueden mostrar números mayores a 9999 o menores a -9999 usando "
+"números romanos."
 
 #: ../libqalculate/Number.cc:380
 #, c-format
 msgid "Character '%s' was ignored in the number \"%s\" in bijective base-26."
 msgstr ""
+"El carácter \"%s\" fue ignorado en el número \"%s\" en base biyectiva 26"
 
 #: ../libqalculate/Number.cc:571
 #, c-format
 msgid "Digits (%s) are higher than expected for number base."
 msgstr ""
+"Los dígitos (%s) son más altos que los esperados por la base numérica."
 
 #: ../libqalculate/Number.cc:623
 msgid ""
 "Assuming the unusual practice of letting a last capital I mean 2 in a roman "
 "numeral."
 msgstr ""
+"Asumiendo la práctica inusual de permitir que una I mayúscula al finar "
+"significar 2 en un número romano."
 
 #: ../libqalculate/Number.cc:707 ../libqalculate/Number.cc:734
 #: ../libqalculate/Number.cc:739
 #, c-format
 msgid "Error in roman numerals: %s."
-msgstr ""
+msgstr "Error en números romanos: %s."
 
 #: ../libqalculate/Number.cc:744
 #, c-format
 msgid "Unknown roman numeral: %c."
-msgstr ""
+msgstr "Número romano desconocido: %c."
 
 #: ../libqalculate/Number.cc:802
 #, c-format
@@ -3493,44 +3705,46 @@ msgid ""
 "Errors in roman numerals: \"%s\". Interpreted as %s, which should be written "
 "as %s."
 msgstr ""
+"Error en números romanos: \"%s\". Interpretado por %s, que debería ser "
+"escrito como %s."
 
 #: ../libqalculate/Number.cc:905
 msgid "Too large exponent."
-msgstr ""
+msgstr "Exponente demasiado grande."
 
 #: ../libqalculate/Number.cc:935
 msgid "Misplaced decimal separator ignored"
-msgstr ""
+msgstr "Se ignoró un separador decimal mal colocado"
 
 #. only allow decimals after last ":"
 #: ../libqalculate/Number.cc:941
 msgid "':' in decimal number ignored (decimal point detected)."
-msgstr ""
+msgstr "\":\" ignorados en el número decimal (se detectó un punto decimal)"
 
 #: ../libqalculate/Number.cc:2066 ../libqalculate/Number.cc:2191
 msgid "Floating point division by zero exception"
-msgstr ""
+msgstr "Excepción de división de punto flotante entre cero"
 
 #: ../libqalculate/Number.cc:2067 ../libqalculate/Number.cc:2194
 msgid "Floating point not a number exception"
-msgstr ""
+msgstr "Excepción de punto flotante no número (NaN)"
 
 #: ../libqalculate/Number.cc:2068 ../libqalculate/Number.cc:2192
 msgid "Floating point range exception"
-msgstr ""
+msgstr "Excepción de rango de punto flotante"
 
 #: ../libqalculate/Number.cc:3678
 msgid "Division by zero."
-msgstr ""
+msgstr "División entre cero."
 
 #. 0^0
 #: ../libqalculate/Number.cc:3684
 msgid "0^0 might be considered undefined"
-msgstr ""
+msgstr "0^0 puede ser considerado indefinido"
 
 #: ../libqalculate/Number.cc:3691
 msgid "The result of 0^i is possibly undefined"
-msgstr ""
+msgstr "El resultado de 0^i es posiblemente indefinido"
 
 #: ../libqalculate/Number.cc:3740 ../libqalculate/Number.cc:6270
 #: ../libqalculate/Number.cc:6381 ../libqalculate/Number.cc:6705
@@ -3538,7 +3752,7 @@ msgstr ""
 #: ../libqalculate/Number.cc:6843 ../libqalculate/Number.cc:6992
 #: ../libqalculate/Number.cc:7104
 msgid "Interval calculated wide."
-msgstr ""
+msgstr "Intervalo calculado ancho."
 
 #: ../libqalculate/Number.cc:5192 ../libqalculate/Number.cc:5418
 #: ../libqalculate/Number.cc:5505 ../libqalculate/Number.cc:5890
@@ -3550,72 +3764,73 @@ msgstr ""
 #: ../libqalculate/Number.cc:8966 ../libqalculate/Number.cc:9361
 #, c-format
 msgid "%s() lacks proper support interval arithmetic."
-msgstr ""
+msgstr "%s() no tiene soporte apropiado de aritmética de intervalo."
 
 #: ../libqalculate/Number.cc:9971
 #, c-format
 msgid "The value is too high for the number of floating point bits (%s)."
 msgstr ""
+"El valor es demasiado alto para el número de bits de punto flotante (%s)."
 
 #: ../libqalculate/Number.cc:10225
 msgid "Unsupported base"
-msgstr ""
+msgstr "Base no soportada"
 
 #: ../libqalculate/Number.cc:10740
 msgid "Can only display rational numbers as roman numerals."
-msgstr ""
+msgstr "Solo se pueden mostrar números racionales como números romanos."
 
 #: ../libqalculate/Number.cc:11227 ../libqalculate/Number.cc:11235
 msgid "infinity"
-msgstr ""
+msgstr "infinidad"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "January"
-msgstr ""
+msgstr "Enero"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "February"
-msgstr ""
+msgstr "Febrero"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "March"
-msgstr ""
+msgstr "Marzo"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "April"
-msgstr ""
+msgstr "Abril"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "May"
-msgstr ""
+msgstr "Mayo"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "June"
-msgstr ""
+msgstr "Junio"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "July"
-msgstr ""
+msgstr "Julio"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "August"
-msgstr ""
+msgstr "Agosto"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "September"
-msgstr ""
+msgstr "Setiembre"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "October"
-msgstr ""
+msgstr "Octubre"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "November"
-msgstr ""
+msgstr "Noviembre"
 
 #: ../libqalculate/QalculateDateTime.cc:29
 msgid "December"
-msgstr ""
+msgstr "Diciembre"
 
 #: ../libqalculate/QalculateDateTime.cc:30
 msgid "Thout"
@@ -3867,121 +4082,121 @@ msgstr ""
 
 #: ../libqalculate/QalculateDateTime.cc:35
 msgid "Wood"
-msgstr ""
+msgstr "Madera"
 
 #: ../libqalculate/QalculateDateTime.cc:35
 msgid "Fire"
-msgstr ""
+msgstr "Fuego"
 
 #: ../libqalculate/QalculateDateTime.cc:35
 msgid "Earth"
-msgstr ""
+msgstr "Tierra"
 
 #: ../libqalculate/QalculateDateTime.cc:35
 msgid "Metal"
-msgstr ""
+msgstr "Metal"
 
 #: ../libqalculate/QalculateDateTime.cc:35
 msgid "Water"
-msgstr ""
+msgstr "Agua"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Rat"
-msgstr ""
+msgstr "Rata"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Ox"
-msgstr ""
+msgstr "Buey"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Tiger"
-msgstr ""
+msgstr "Tigre"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Rabbit"
-msgstr ""
+msgstr "Conejo"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Dragon"
-msgstr ""
+msgstr "Dragón"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Snake"
-msgstr ""
+msgstr "Serpiente"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Horse"
-msgstr ""
+msgstr "Caballo"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Goat"
-msgstr ""
+msgstr "Cabra"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Monkey"
-msgstr ""
+msgstr "Mono"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Rooster"
-msgstr ""
+msgstr "Gallo"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Dog"
-msgstr ""
+msgstr "Perro"
 
 #: ../libqalculate/QalculateDateTime.cc:36
 msgid "Pig"
-msgstr ""
+msgstr "Cerdo"
 
 #: ../libqalculate/QalculateDateTime.cc:360
 msgid "now"
-msgstr ""
+msgstr "ahora"
 
 #: ../libqalculate/QalculateDateTime.cc:364
 msgid "today"
-msgstr ""
+msgstr "hoy"
 
 #: ../libqalculate/QalculateDateTime.cc:368
 msgid "tomorrow"
-msgstr ""
+msgstr "mañana"
 
 #: ../libqalculate/QalculateDateTime.cc:373
 msgid "yesterday"
-msgstr ""
+msgstr "ayer"
 
 #: ../libqalculate/QalculateDateTime.cc:2618
 msgid "leap month"
-msgstr ""
+msgstr "mes bisiesto"
 
 #: ../libqalculate/Unit.cc:1199
 msgid "Error(s) in unitexpression."
-msgstr ""
+msgstr "Error(es) en expresión de unidad."
 
 #: ../libqalculate/Variable.cc:509
 #, c-format
 msgid "Recursive variable: %s = %s"
-msgstr ""
+msgstr "Variable recursiva: %s = %s"
 
 #: ../libqalculate/util.cc:172
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
 #: ../libqalculate/util.cc:173
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: ../libqalculate/util.cc:180
 msgid "True"
-msgstr ""
+msgstr "Verdadero"
 
 #: ../libqalculate/util.cc:181
 msgid "False"
-msgstr ""
+msgstr "Falso"
 
 #: ../libqalculate/util.cc:188
 msgid "On"
-msgstr ""
+msgstr "Encendido"
 
 #: ../libqalculate/util.cc:189
 msgid "Off"
-msgstr ""
+msgstr "Apagado"

--- a/po/fr.po
+++ b/po/fr.po
@@ -1976,7 +1976,7 @@ msgid "Determines how scientific notation is used (e.g. 5 543 000 = 5.543E6)."
 msgstr ""
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr ""
 
 #: ../src/qalc.cc:4456
@@ -2323,7 +2323,7 @@ msgid "- sexa / sexa2 / sexagesimal (show as sexagesimal number)"
 msgstr ""
 
 #: ../src/qalc.cc:4707
-msgid "- latitude / latitude2 (show as sexagesimal longitude)"
+msgid "- latitude / latitude2 (show as sexagesimal latitude)"
 msgstr ""
 
 #: ../src/qalc.cc:4708

--- a/po/libqalculate.pot
+++ b/po/libqalculate.pot
@@ -1916,7 +1916,7 @@ msgid "Determines how scientific notation is used (e.g. 5 543 000 = 5.543E6)."
 msgstr ""
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr ""
 
 #: ../src/qalc.cc:4456
@@ -2251,7 +2251,7 @@ msgid "- sexa / sexa2 / sexagesimal (show as sexagesimal number)"
 msgstr ""
 
 #: ../src/qalc.cc:4707
-msgid "- latitude / latitude2 (show as sexagesimal longitude)"
+msgid "- latitude / latitude2 (show as sexagesimal latitude)"
 msgstr ""
 
 #: ../src/qalc.cc:4708

--- a/po/nl.po
+++ b/po/nl.po
@@ -1980,7 +1980,7 @@ msgid "Determines how scientific notation is used (e.g. 5 543 000 = 5.543E6)."
 msgstr ""
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr ""
 
 #: ../src/qalc.cc:4456
@@ -2346,7 +2346,7 @@ msgid "- sexa / sexa2 / sexagesimal (show as sexagesimal number)"
 msgstr ""
 
 #: ../src/qalc.cc:4707
-msgid "- latitude / latitude2 (show as sexagesimal longitude)"
+msgid "- latitude / latitude2 (show as sexagesimal latitude)"
 msgstr ""
 
 #: ../src/qalc.cc:4708

--- a/po/ru.po
+++ b/po/ru.po
@@ -1996,7 +1996,7 @@ msgstr ""
 "Определяет, как используется научная запись (например, 5 543 000 = 5,543E6)."
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr ""
 "Если этот параметр активирован, в конце приблизительных чисел сохраняются "
 "нули."
@@ -2386,7 +2386,7 @@ msgstr ""
 "- sexa / sexa2 / шестидесятеричное (показать как шестидесятеричное число)"
 
 #: ../src/qalc.cc:4707
-msgid "- latitude / latitude2 (show as sexagesimal longitude)"
+msgid "- latitude / latitude2 (show as sexagesimal latitude)"
 msgstr "- широта / latitude2 (показать шестидесятеричную широту)"
 
 #: ../src/qalc.cc:4708

--- a/po/sv.po
+++ b/po/sv.po
@@ -1965,7 +1965,7 @@ msgid "Determines how scientific notation is used (e.g. 5 543 000 = 5.543E6)."
 msgstr "Avgör hur grundpotensform används (t.ex. 5 543 000 = 5,543E6)."
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr "Om aktiverat behålls nollor i slutet av approximerade tal."
 
 #: ../src/qalc.cc:4456
@@ -2336,7 +2336,7 @@ msgid "- sexa / sexa2 / sexagesimal (show as sexagesimal number)"
 msgstr "- sexa / sexa2 / sexagesimal (visa som sexagecimalt tal)"
 
 #: ../src/qalc.cc:4707
-msgid "- latitude / latitude2 (show as sexagesimal longitude)"
+msgid "- latitude / latitude2 (show as sexagesimal latitude)"
 msgstr "- latitud / latitud2 (visa som sexagecimal latitud)"
 
 #: ../src/qalc.cc:4708

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1937,7 +1937,7 @@ msgid "Determines how scientific notation is used (e.g. 5 543 000 = 5.543E6)."
 msgstr "确定如何使用科学计数法(例: 5 543 000 = 5.543E6)."
 
 #: ../src/qalc.cc:4455
-msgid "If actived, zeroes are kept at the end of approximate numbers."
+msgid "If activated, zeroes are kept at the end of approximate numbers."
 msgstr "如果激活，在近似数字末尾的零将保留。"
 
 #: ../src/qalc.cc:4456

--- a/src/qalc.cc
+++ b/src/qalc.cc
@@ -4452,7 +4452,7 @@ int main(int argc, char *argv[]) {
 				str += ", >= 0)";
 				if(printops.min_exp != EXP_NONE && printops.min_exp != EXP_NONE && printops.min_exp != EXP_PRECISION && printops.min_exp != EXP_BASE_3 && printops.min_exp != EXP_PURE && printops.min_exp != EXP_SCIENTIFIC) {str += " "; str += i2s(printops.min_exp); str += "*";}
 				CHECK_IF_SCREEN_FILLED_PUTS(str.c_str());
-				STR_AND_TABS_BOOL(_("show ending zeroes"), "zeroes", _("If actived, zeroes are kept at the end of approximate numbers."), printops.show_ending_zeroes);
+				STR_AND_TABS_BOOL(_("show ending zeroes"), "zeroes", _("If activated, zeroes are kept at the end of approximate numbers."), printops.show_ending_zeroes);
 				STR_AND_TABS_BOOL(_("two's complement"), "twos", _("Enables two's complement representation for display of negative binary numbers."), printops.twos_complement);
 
 				CHECK_IF_SCREEN_FILLED_HEADING_S(_("Parsing"));
@@ -4704,7 +4704,7 @@ int main(int argc, char *argv[]) {
 				CHECK_IF_SCREEN_FILLED_PUTS(_("- hex / hexadecimal (show as hexadecimal number)"));
 				CHECK_IF_SCREEN_FILLED_PUTS(_("- hex# (show as hexadecimal number with specified number of bits)"));
 				CHECK_IF_SCREEN_FILLED_PUTS(_("- sexa / sexa2 / sexagesimal (show as sexagesimal number)"));
-				CHECK_IF_SCREEN_FILLED_PUTS(_("- latitude / latitude2 (show as sexagesimal longitude)"));
+				CHECK_IF_SCREEN_FILLED_PUTS(_("- latitude / latitude2 (show as sexagesimal latitude)"));
 				CHECK_IF_SCREEN_FILLED_PUTS(_("- longitude / longitude2 (show as sexagesimal longitude)"));
 				CHECK_IF_SCREEN_FILLED_PUTS(_("- bijective (shown in bijective base-26)"));
 				CHECK_IF_SCREEN_FILLED_PUTS(_("- fp16, fp32, fp64, fp80, fp128 (show in binary floating-point format)"));


### PR DESCRIPTION
I also translated some units, the more common ones.

A note about big numbers (the descriptions were inconsistent with the English references):
* Adding "(1E303)" as the reference for centillion made it disappear from qalculate-gtk's menu bar. (README.translate says numbers aren't allowed, so I don't know how well this is handled internally).
* Seeing that,I did the same with other numbers no one uses ("millardo" (billion) exists, but "mil millones" (a thousand million) is way more common, a search for "cuatrillardo" made it clear these terms might be very old or invented, so from that one they are "(1E27)" and so on).
* Of course, these can be left empty again if they are problematic.