### PR TITLE
Explicit check for gmp and mpfr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,11 @@ dnl  --------------------------------
 
 AC_CHECK_LIB(pthread, pthread_create, [LIBS="$LIBS -lpthread"])
 
-AC_CHECK_HEADERS(mpfr.h, [LIBS="$LIBS -lmpfr -lgmp"], [AC_MSG_ERROR([Unable to find mpfr header])])
+AC_CHECK_HEADER(gmp.h, [], [AC_MSG_ERROR([gmp.h can't be found, or is unusable.])])
+AC_CHECK_LIB(gmp, __gmpz_init, [LIBS="-lgmp $LIBS"], [AC_MSG_ERROR([libgmp not found or uses a different ABI.])])
+
+AC_CHECK_HEADERS(mpfr.h, [], [AC_MSG_ERROR([mpfr.h can't be found, or is unusable.])])
+AC_CHECK_LIB(mpfr, mpfr_get_version, [LIBS="-lmpfr $LIBS"], [AC_MSG_ERROR([libmpfr not found or uses a different ABI.])])
 
 AC_LANG([C++])
 


### PR DESCRIPTION
During ./configure, I got a message saying that iconv was not found, while the error was actually that gmp and mpfr were compiled with an incompatible eabi.
To prevent this misleading error, I added an explicit check for both gmp and mpfr into `configure.ac`