### PR TITLE
Variables: Add second Unicode codepoint for µ-sign

### DIFF
--- a/data/variables.xml.in
+++ b/data/variables.xml.in
@@ -159,7 +159,7 @@
       </variable>
       <variable>
         <_title>Magnetic Constant (Permeability of Free Space)</_title>
-        <names>r:magnetic_constant,asu:&#x3BC;_0,vacuum_permeability,aos:mu_0</names>
+        <names>r:magnetic_constant,asu:&#x3BC;_0,asu:&#xB5;_0,vacuum_permeability,aos:mu_0</names>
         <value>(2*planck*fine_structure)/(c*elementary_charge^2)</value>
       </variable>
       <variable>
@@ -192,7 +192,7 @@
       <_title>Electromagnetic Constants</_title>
       <variable>
         <_title>Bohr Magneton</_title>
-        <names>r:bohr_magneton,asu:&#x3BC;_B,aos:mu_B</names>
+        <names>r:bohr_magneton,asu:&#x3BC;_B,asu:&#xB5;_0,aos:mu_B</names>
         <value>(elementary_charge*planck)/(4*electron_mass*pi)</value>
       </variable>
       <variable>
@@ -232,7 +232,7 @@
       </variable>
       <variable>
         <_title>Nuclear Magneton</_title>
-        <names>r:nuclear_magneton,asu:&#x3BC;_N,aos:mu_N</names>
+        <names>r:nuclear_magneton,asu:&#x3BC;_N,asu:&#xB5;_N,aos:mu_N</names>
         <value>elementary_charge*planck2pi/(2*proton_mass)</value>
       </variable>
       <variable>
@@ -406,7 +406,7 @@
       </variable>
       <variable>
         <_title>Muon Mass</_title>
-        <names>rs:muon_mass,asu:m_&#x03BC;,aos:m_mu</names>
+        <names>rs:muon_mass,asu:m_&#x03BC;,asu:m_&#xB5;,aos:m_mu</names>
         <value>nounit(muon_u)*atomic_mass_constant</value>
       </variable>
       <variable>


### PR DESCRIPTION
The greek letter µ can be represented as different Unicode code points: `x3BC`, which is `GREEK SMALL LETTER MU`, and `xB5`, which is `MICRO SIGN`.

Since pressing <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>M</kbd> results in the `MICRO SIGN` (which looks nearly identical), I also added that code point to the shortcuts.