### PR TITLE
Add additional information units

### DIFF
--- a/data/units.xml.in
+++ b/data/units.xml.in
@@ -3938,7 +3938,7 @@
     <_title>Information</_title>
     <unit type="base">
       <_title>Bit</_title>
-      <_names>r:bit,p:bits,binary_digit,p:binary_digits,shannon,p:shannons,a:Sh</_names>
+      <_names>r:bit,p:bits,binary_digit,p:binary_digits,shannon,p:shannons,Sh</_names>
       <use_with_prefixes>true</use_with_prefixes>
     </unit>
     <unit type="alias">

--- a/data/units.xml.in
+++ b/data/units.xml.in
@@ -4042,33 +4042,6 @@
       </part>
     </unit>
     <unit type="composite">
-      <_title>Kibibyte</_title>
-      <names>r:Kibyte_c</names>
-      <part>
-        <unit>byte</unit>
-        <prefix type="binary">10</prefix>
-        <exponent>1</exponent>
-      </part>
-    </unit>
-    <unit type="composite">
-      <_title>Mebibyte</_title>
-      <names>r:Mibyte_c</names>
-      <part>
-        <unit>byte</unit>
-        <prefix type="binary">20</prefix>
-        <exponent>1</exponent>
-      </part>
-    </unit>
-    <unit type="composite">
-      <_title>Gibibyte</_title>
-      <names>r:Gibyte_c</names>
-      <part>
-        <unit>byte</unit>
-        <prefix type="binary">30</prefix>
-        <exponent>1</exponent>
-      </part>
-    </unit>
-    <unit type="composite">
       <_title>Megabyte</_title>
       <names>r:Mbyte_c</names>
       <part>
@@ -4096,11 +4069,119 @@
       </part>
     </unit>
     <unit type="composite">
+      <_title>Petabyte</_title>
+      <names>r:Pbyte_c</names>
+      <part>
+        <unit>byte</unit>
+        <prefix>15</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Exabyte</_title>
+      <names>r:Ebyte_c</names>
+      <part>
+        <unit>byte</unit>
+        <prefix>18</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Kibibyte</_title>
+      <names>r:Kibyte_c</names>
+      <part>
+        <unit>byte</unit>
+        <prefix type="binary">10</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Mebibyte</_title>
+      <names>r:Mibyte_c</names>
+      <part>
+        <unit>byte</unit>
+        <prefix type="binary">20</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Gibibyte</_title>
+      <names>r:Gibyte_c</names>
+      <part>
+        <unit>byte</unit>
+        <prefix type="binary">30</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Tebibyte</_title>
+      <names>r:Tibyte_c</names>
+      <part>
+        <unit>byte</unit>
+        <prefix type="binary">40</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Pebibyte</_title>
+      <names>r:Pibyte_c</names>
+      <part>
+        <unit>byte</unit>
+        <prefix type="binary">50</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Exbibyte</_title>
+      <names>r:Eibyte_c</names>
+      <part>
+        <unit>byte</unit>
+        <prefix type="binary">60</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
       <_title>Kilobit</_title>
       <names>r:kbit_c</names>
       <part>
         <unit>bit</unit>
         <prefix>3</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Megabit</_title>
+      <names>r:Mbit_c</names>
+      <part>
+        <unit>bit</unit>
+        <prefix>6</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Gigabit</_title>
+      <names>r:Gbit_c</names>
+      <part>
+        <unit>bit</unit>
+        <prefix>9</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Terabit</_title>
+      <names>r:Tbit_c</names>
+      <part>
+        <unit>bit</unit>
+        <prefix>12</prefix>
+        <exponent>1</exponent>
+      </part>
+    </unit>
+    <unit type="composite">
+      <_title>Petabit</_title>
+      <names>r:Pbit_c</names>
+      <part>
+        <unit>bit</unit>
+        <prefix>15</prefix>
         <exponent>1</exponent>
       </part>
     </unit>
@@ -4132,29 +4213,20 @@
       </part>
     </unit>
     <unit type="composite">
-      <_title>Megabit</_title>
-      <names>r:Mbit_c</names>
+      <_title>Tebibit</_title>
+      <names>r:Tibit_c</names>
       <part>
         <unit>bit</unit>
-        <prefix>6</prefix>
+        <prefix type="binary">40</prefix>
         <exponent>1</exponent>
       </part>
     </unit>
     <unit type="composite">
-      <_title>Gigabit</_title>
-      <names>r:Gbit_c</names>
+      <_title>Pebibit</_title>
+      <names>r:Pibit_c</names>
       <part>
         <unit>bit</unit>
-        <prefix>9</prefix>
-        <exponent>1</exponent>
-      </part>
-    </unit>
-    <unit type="composite">
-      <_title>Terabit</_title>
-      <names>r:Tbit_c</names>
-      <part>
-        <unit>bit</unit>
-        <prefix>12</prefix>
+        <prefix type="binary">50</prefix>
         <exponent>1</exponent>
       </part>
     </unit>

--- a/data/units.xml.in
+++ b/data/units.xml.in
@@ -3937,8 +3937,8 @@
   <category>
     <_title>Information</_title>
     <unit type="base">
-      <_title>Bit</_title>
-      <_names>r:bit,p:bits,binary_digit,p:binary_digits,shannon,p:shannons,Sh</_names>
+      <_title>Bit (binary digit)</_title>
+      <_names>r:bit,p:bits,binary_digit,p:binary_digits,shannon,p:shannons,c:Sh</_names>
       <use_with_prefixes>true</use_with_prefixes>
     </unit>
     <unit type="alias">
@@ -3951,7 +3951,7 @@
       </base>
     </unit>
     <unit type="alias">
-      <_title>Trit</_title>
+      <_title>Trit (ternary digit)</_title>
       <_names>r:trit,p:trits,trinary_digit,p:trinary_digits,ternary_digit,p:ternary_digits</_names>
       <base>
         <unit>bit</unit>
@@ -3969,8 +3969,8 @@
       </base>
     </unit>
     <unit type="alias">
-      <_title>Hartley</_title>
-      <_names>r:hartley,p:hartleys,a:Hart,decimal_digit,p:decimal_digits</_names>
+      <_title>Dit (decimal digit)</_title>
+      <_names>r:dit,p:dits,hartley,p:hartleys,c:Hart,decimal_digit,p:decimal_digits</_names>
       <base>
         <unit>bit</unit>
         <relation>log2(10)</relation>

--- a/data/units.xml.in
+++ b/data/units.xml.in
@@ -725,7 +725,7 @@
       <base>
         <unit>g</unit>
         <relation>atomic_mass_constant*1000</relation>
-      <exponent>1</exponent>
+        <exponent>1</exponent>
       </base>
     </unit>
     <unit type="composite">
@@ -909,15 +909,15 @@
       <names>planck_p_Ha</names>
       <system>Atomic</system>
       <part>
-          <unit>planck_unit</unit>
-          <prefix>0</prefix>
-          <exponent>1</exponent>
-        </part>
-        <part>
-          <unit>Ha</unit>
-          <prefix>0</prefix>
-          <exponent>-1</exponent>
-        </part>
+        <unit>planck_unit</unit>
+        <prefix>0</prefix>
+        <exponent>1</exponent>
+      </part>
+      <part>
+        <unit>Ha</unit>
+        <prefix>0</prefix>
+        <exponent>-1</exponent>
+      </part>
     </unit>
     <unit type="composite">
       <_title>Natural Unit of Time</_title>
@@ -2969,7 +2969,7 @@
     </category>
     <category>
       <_title>Momentum</_title>
-        <unit type="composite">
+      <unit type="composite">
         <system>SI</system>
         <_title>Kilogram Meter per Second</_title>
         <names>r:kg_m_p_s</names>
@@ -3605,7 +3605,7 @@
           <exponent>-1</exponent>
         </part>
       </unit>
-       <unit type="alias">
+      <unit type="alias">
         <_title>Boltzmann (unit)</_title>
         <names>rs:boltzmann_unit,as:k_Bunit</names>
         <base>
@@ -3938,12 +3938,48 @@
     <_title>Information</_title>
     <unit type="base">
       <_title>Bit</_title>
-      <_names>r:bit,p:bits</_names>
+      <_names>r:bit,p:bits,binary_digit,p:binary_digits,shannon,p:shannons,a:Sh</_names>
       <use_with_prefixes>true</use_with_prefixes>
     </unit>
     <unit type="alias">
+      <_title>Nat</_title>
+      <_names>r:nat,p:nats</_names>
+      <base>
+        <unit>bit</unit>
+        <relation>log2(e)</relation>
+        <exponent>1</exponent>
+      </base>
+    </unit>
+    <unit type="alias">
+      <_title>Trit</_title>
+      <_names>r:trit,p:trits,trinary_digit,p:trinary_digits,ternary_digit,p:ternary_digits</_names>
+      <base>
+        <unit>bit</unit>
+        <relation>log2(3)</relation>
+        <exponent>1</exponent>
+      </base>
+    </unit>
+    <unit type="alias">
+      <_title>Octal digit</_title>
+      <_names>r:octal_digit,p:octal_digits</_names>
+      <base>
+        <unit>bit</unit>
+        <relation>3</relation>
+        <exponent>1</exponent>
+      </base>
+    </unit>
+    <unit type="alias">
+      <_title>Hartley</_title>
+      <_names>r:hartley,p:hartleys,a:Hart,decimal_digit,p:decimal_digits</_names>
+      <base>
+        <unit>bit</unit>
+        <relation>log2(10)</relation>
+        <exponent>1</exponent>
+      </base>
+    </unit>
+    <unit type="alias">
       <_title>Byte (8-bit)</_title>
-      <_names>r:byte,a:B,p:bytes,octet,p:octets</_names>
+      <_names>r:byte,a:B,p:bytes,octet,p:octets,a:o</_names>
       <use_with_prefixes>true</use_with_prefixes>
       <base>
         <unit>bit</unit>
@@ -3953,7 +3989,7 @@
     </unit>
     <unit type="alias">
       <_title>Nibble</_title>
-      <_names>r:nibble,p:nibbles,nybble,p:nybbles,semioctet,p:semioctets</_names>
+      <_names>r:nibble,p:nibbles,nybble,p:nybbles,semioctet,p:semioctets,hexadecimal_digit,p:hexadecimal_digits,hex_digit,p:hex_digits</_names>
       <base>
         <unit>bit</unit>
         <relation>4</relation>
@@ -3966,6 +4002,24 @@
       <base>
         <unit>nibble</unit>
         <relation>3</relation>
+        <exponent>1</exponent>
+      </base>
+    </unit>
+    <unit type="alias">
+      <_title>Nonet</_title>
+      <_names>r:nonet,p:nonets</_names>
+      <base>
+        <unit>bit</unit>
+        <relation>9</relation>
+        <exponent>1</exponent>
+      </base>
+    </unit>
+    <unit type="alias">
+      <_title>Declet</_title>
+      <_names>r:declet,p:declets</_names>
+      <base>
+        <unit>bit</unit>
+        <relation>10</relation>
         <exponent>1</exponent>
       </base>
     </unit>


### PR DESCRIPTION
The [shannon](https://en.wikipedia.org/wiki/Shannon_(unit)) is equivalent to the bit.
One [nat](https://en.wikipedia.org/wiki/Nat_(unit)) is log2(e) bits.
One [trit](https://en.wikipedia.org/wiki/Ternary_numeral_system) is 1 trinary digit (log2(3) bits).
One [hartley](https://en.wikipedia.org/wiki/Hartley_(unit)) is log2(10) bits.
The nonet (9 bits) is defined in [RFC 4042](https://datatracker.ietf.org/doc/html/rfc4042).
The declet (10 bits) is defined in [IEEE 754](https://ieeexplore.ieee.org/document/4610935).