### PR TITLE
Split definition and declaration of `static const` structs in `includes.h`

### DIFF
--- a/libqalculate/includes.h
+++ b/libqalculate/includes.h
@@ -350,13 +350,15 @@ typedef enum {
 } NumberFractionFormat;
 
 /// Options for ordering the parts of a mathematical expression/result before display
-static const struct SortOptions {
+struct SortOptions {
 	/// Put currency units before quantity. Default: true
 	bool prefix_currencies;
 	/// If true, avoid placing negative terms first. Default: true
 	bool minus_last;
 	SortOptions() : prefix_currencies(true), minus_last(true) {}
-} default_sort_options;
+};
+
+static const SortOptions default_sort_options;
 
 typedef enum {
 	MULTIPLICATION_SIGN_ASTERISK,
@@ -405,7 +407,7 @@ typedef enum {
 } TimeZone;
 
 /// Options for formatting and display of mathematical structures/results.
-static const struct PrintOptions {
+struct PrintOptions {
 	int min_exp;
 	/// Number base for displaying numbers. Default: 10
 	int base;
@@ -521,9 +523,11 @@ static const struct PrintOptions {
 	/// Returns the decimal sign used (default sign or decimalpoint_sign)
 	const std::string &decimalpoint() const;
 	/// Returns the digit grouping separator used
-} default_print_options;
+};
 
-static const struct InternalPrintStruct {
+static const PrintOptions default_print_options;
+
+struct InternalPrintStruct {
 	int depth, power_depth, division_depth;
 	bool wrap;
 	std::string *num, *den, *re, *im, *exp;
@@ -532,7 +536,9 @@ static const struct InternalPrintStruct {
 	int parent_precision;
 	long int *iexp;
 	InternalPrintStruct();
-} top_ips;
+};
+
+static const InternalPrintStruct top_ips;
 
 typedef enum {
 	/// Allow only exact results
@@ -624,7 +630,7 @@ typedef enum {
 } IntervalCalculation;
 
 /// Options for parsing expressions.
-static const struct ParseOptions {
+struct ParseOptions {
 	/// If variables will be parsed. Default: true
 	bool variables_enabled;
 	/// If functions will be parsed. Default: true
@@ -667,10 +673,12 @@ static const struct ParseOptions {
 
 	ParseOptions();
 
-} default_parse_options;
+};
+
+static const ParseOptions default_parse_options;
 
 /// Options for calculation.
-static const struct EvaluationOptions {
+struct EvaluationOptions {
 	/// How exact the result must be. Default: TRY_EXACT
 	ApproximationMode approximation;
 	/// If units will be synced/converted to allow evaluation (ex. 1 min + 1 s=60 s+ 1 s = 61 s). Default: true
@@ -729,9 +737,9 @@ static const struct EvaluationOptions {
 	IntervalCalculation interval_calculation;
 
 	EvaluationOptions();
+};
 
-} default_evaluation_options;
-
+static const EvaluationOptions default_evaluation_options;
 static EvaluationOptions default_user_evaluation_options;
 
 extern MathStructure m_undefined, m_empty_vector, m_empty_matrix, m_zero, m_one, m_minus_one, m_one_i;


### PR DESCRIPTION
Dear Hanna, dear Qalculate contributors,

for my [Qalculate anroid app](https://github.com/jherkenhoff/qalculate-android) im generating a java interface for libqalculate using SWIG.
I'm having major trouble generating interfaces for `PrintOptions`, `ParseOptions` etc., because they are defining `static const` variables at the time of declaring the struct. See following example from `includes.h:353`:

```
static const struct SortOptions {
	/// Put currency units before quantity. Default: true
	bool prefix_currencies;
	/// If true, avoid placing negative terms first. Default: true
	bool minus_last;
	SortOptions() : prefix_currencies(true), minus_last(true) {}
} default_sort_options;
```

Is it possible to split declaration and definition into two lines?

```
struct SortOptions {
    ...
};

static const SortOptions default_sort_options;
```

I do not expect this to have any side effects.

Cheers
Jost