### PR TITLE
Add `thou` as synonym for `mil`

### DIFF
--- a/data/units.xml.in
+++ b/data/units.xml.in
@@ -226,7 +226,7 @@
     <unit type="alias">
       <_title>Mil (1/1000 in)</_title>
       <system>Imperial/US</system>
-      <_names>r:mil,p:mils</_names>
+      <_names>r:mil,p:mils,thou</_names>
       <base>
         <unit>in</unit>
         <relation>0.001</relation>

--- a/data/units.xml.in
+++ b/data/units.xml.in
@@ -224,9 +224,9 @@
       </base>
     </unit>
     <unit type="alias">
-      <_title>Mil (1/1000 in)</_title>
+      <_title>Thou (1/1000 in)</_title>
       <system>Imperial/US</system>
-      <_names>r:mil,p:mils,thou</_names>
+      <_names>r:thou,mil,p:mils</_names>
       <base>
         <unit>in</unit>
         <relation>0.001</relation>


### PR DESCRIPTION
Source: https://en.wikipedia.org/wiki/Thousandth_of_an_inch

There may be a case form making "thou" the primary name, and "mil" a synonym.