### PR TITLE
Fix `Number.equals()` when allow_infinite = true

### DIFF
--- a/libqalculate/Number.cc
+++ b/libqalculate/Number.cc
@@ -2574,10 +2574,8 @@ bool Number::equals(const Number &o, bool allow_interval, bool allow_infinite) c
 	} else if(hasImaginaryPart()) {
 		return false;
 	}
-	if(allow_infinite) {
-		if(o.isPlusInfinity()) return isPlusInfinity();
-		if(o.isMinusInfinity()) return isMinusInfinity();
-	}
+	if(allow_infinite && (isInfinite() || o.isInfinite()))
+		return isInfinite() == o.isInfinite() && hasNegativeSign() == o.hasNegativeSign();
 	if(o.isFloatingPoint() && n_type != NUMBER_TYPE_FLOAT) {
 		return mpfr_cmp_q(o.internalLowerFloat(), r_value) == 0 && mpfr_cmp_q(o.internalUpperFloat(), r_value) == 0;
 	} else if(n_type == NUMBER_TYPE_FLOAT) {


### PR DESCRIPTION
`Number.equals()` would previously return different results depending on which value is `this` and which one is `o` when comparing an infinity with a finite value (when the internal rational is the same).