### PR TITLE
Fix a minor typo in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -107,7 +107,7 @@ AS_IF([test "x$enable_compiled_definitions" = "xyes"], [
 ])
 AM_CONDITIONAL(COMPILED_DEFINITIONS, [test "x$enable_compiled_definitions" = "xyes"])
 
-AC_ARG_ENABLE([insecure], AS_HELP_STRING([--disbale-insecure], [disable insecure functions (command) and variables (uptime)]))
+AC_ARG_ENABLE([insecure], AS_HELP_STRING([--disable-insecure], [disable insecure functions (command) and variables (uptime)]))
 AS_IF([test "x$enable_insecure" = "xno"], [
 	AC_DEFINE([DISABLE_INSECURE], [1], [Disable insecure functions and variables])
 ])


### PR DESCRIPTION
Fortunately this only affects the usage screen and not the flag itself (it's `--disable-insecure` even without this patch), so this is not a breaking change.