### PR TITLE
Fix a conditional segfault when deleting DataObject

### DIFF
--- a/libqalculate/DataSet.cc
+++ b/libqalculate/DataSet.cc
@@ -41,7 +41,11 @@ DataObject::DataObject(DataSet *parent_set) {
 	b_uchanged = false;
 }
 DataObject::~DataObject() {
-	for(size_t i = 0; i < m_properties.size(); i++) m_properties[i]->unref();
+	for(size_t i = 0; i < m_properties.size(); i++) {
+		if(m_properties[i]) {
+			m_properties[i]->unref();
+		}
+	}
 }
 
 void DataObject::eraseProperty(DataProperty *property) {


### PR DESCRIPTION
If a `DataSet` is loaded (for example, by evaluating `planet(earth)`), but not all of its properties are initialized, attempting to delete `Calculator` results in a segmentation fault. The following example code triggers this:
```c++
auto* calc = new Calculator(true);
calc->loadGlobalDefinitions();
calc->calculate("planet(earth)");
delete calc;
```
This patch adds a null check before calling MathStructure::unref() in DataObject's destructor.