### PR TITLE
Add load() and export() to the DISABLE_INSECURE list

### DIFF
--- a/libqalculate/Calculator.cc
+++ b/libqalculate/Calculator.cc
@@ -1896,8 +1896,13 @@ void Calculator::addBuiltinFunctions() {
 	addFunction(new ForEachFunction());
 
 	f_save = addFunction(new SaveFunction());
+#ifndef DISABLE_INSECURE
 	f_load = addFunction(new LoadFunction());
 	f_export = addFunction(new ExportFunction());
+#else
+	f_load = NULL;
+	f_export = NULL;
+#endif
 
 	f_register = addFunction(new RegisterFunction());
 	f_stack = addFunction(new StackFunction());


### PR DESCRIPTION
Both of these functions can be used to interact with the filesystem, which is undesirable for remote applications. I currently set `Calculator::f_load` and `Calculator::f_export` to `NULL` if `DISABLE_INSECURE` is defined, let me know if this should be handled differently!