### PR TITLE
Fix memory leak from mpfr library

### DIFF
--- a/libqalculate/Number.cc
+++ b/libqalculate/Number.cc
@@ -456,6 +456,8 @@ Number::~Number() {
 	mpq_clear(r_value);
 	if(n_type == NUMBER_TYPE_FLOAT) mpfr_clears(fu_value, fl_value, NULL);
 	if(i_value) delete i_value;
+	mpfr_free_cache();
+	mpfr_free_cache2(MPFR_FREE_LOCAL_CACHE);
 }
 
 void Number::set(string number, const ParseOptions &po) {


### PR DESCRIPTION
This fixes a memory leak from the mpfr library:
```
=================================================================
==43801==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 392 byte(s) in 18 object(s) allocated from:
    #0 0x7f14e78fb6e2 in realloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:85
    #1 0x7f14e576a958 in __gmp_default_reallocate (/usr/lib/libgmp.so.10+0x11958) (BuildId: 7d4a85294987f7ccba2d4a2e1e9435ed16ca2ae1)

Direct leak of 56 byte(s) in 1 object(s) allocated from:
    #0 0x7f14e78fca31 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f14e576a90d in __gmp_default_allocate (/usr/lib/libgmp.so.10+0x1190d) (BuildId: 7d4a85294987f7ccba2d4a2e1e9435ed16ca2ae1)
    #2 0x7f14e581b5a4  (/usr/lib/libmpfr.so.6+0x1c5a4) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #3 0x7f14e581f270 in mpfr_const_log2_internal (/usr/lib/libmpfr.so.6+0x20270) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #4 0x7f14e5852c14 in mpfr_cache (/usr/lib/libmpfr.so.6+0x53c14) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #5 0x7f14e58208ec in mpfr_log (/usr/lib/libmpfr.so.6+0x218ec) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #6 0x7f14e583fed4 in mpfr_log10 (/usr/lib/libmpfr.so.6+0x40ed4) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #7 0x7f14e706b81f in Number::log(Number const&) /usr/src/debug/libqalculate/libqalculate/libqalculate/Number.cc:7651
    #8 0x100000000  (<unknown module>)

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f14e78fca31 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f14e576a90d in __gmp_default_allocate (/usr/lib/libgmp.so.10+0x1190d) (BuildId: 7d4a85294987f7ccba2d4a2e1e9435ed16ca2ae1)
    #2 0x7f14e58170fa in mpfr_init2 (/usr/lib/libmpfr.so.6+0x180fa) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #3 0x7f14e5852c0b in mpfr_cache (/usr/lib/libmpfr.so.6+0x53c0b) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #4 0x7f14e58208bd in mpfr_log (/usr/lib/libmpfr.so.6+0x218bd) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #5 0x7f14e583fed4 in mpfr_log10 (/usr/lib/libmpfr.so.6+0x40ed4) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #6 0x7f14e706b81f in Number::log(Number const&) /usr/src/debug/libqalculate/libqalculate/libqalculate/Number.cc:7651
    #7 0x100000000  (<unknown module>)

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7f14e78fca31 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f14e576a90d in __gmp_default_allocate (/usr/lib/libgmp.so.10+0x1190d) (BuildId: 7d4a85294987f7ccba2d4a2e1e9435ed16ca2ae1)
    #2 0x7f14e58170fa in mpfr_init2 (/usr/lib/libmpfr.so.6+0x180fa) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #3 0x7f14e5852c0b in mpfr_cache (/usr/lib/libmpfr.so.6+0x53c0b) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #4 0x7f14e58208ec in mpfr_log (/usr/lib/libmpfr.so.6+0x218ec) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #5 0x7f14e583fed4 in mpfr_log10 (/usr/lib/libmpfr.so.6+0x40ed4) (BuildId: 4d244e3e86a7787f3b1a0fbe6b56d4afac4c6038)
    #6 0x7f14e706b81f in Number::log(Number const&) /usr/src/debug/libqalculate/libqalculate/libqalculate/Number.cc:7651
    #7 0x100000000  (<unknown module>)

Direct leak of 16 byte(s) in 2 object(s) allocated from:
    #0 0x7f14e78fca31 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:69
    #1 0x7f14e576a90d in __gmp_default_allocate (/usr/lib/libgmp.so.10+0x1190d) (BuildId: 7d4a85294987f7ccba2d4a2e1e9435ed16ca2ae1)

SUMMARY: AddressSanitizer: 528 byte(s) leaked in 23 allocation(s).
```

Not sure if this is the correct fix, especially when the mpfr cache might be used between multiple Numbers.

Calling
```
	mpfr_free_cache();
	mpfr_free_cache2(MPFR_FREE_LOCAL_CACHE);
	mpfr_free_cache2(MPFR_FREE_GLOBAL_CACHE);
	mpfr_mp_memory_cleanup();
```
in the `Calculator` destructor did *not* fix the issue, I guess this may be because I use the Calculator from a different thread.