### PR TITLE
libqalculate/Variable: fix valgrind warnings

### DIFF
--- a/libqalculate/Variable.cc
+++ b/libqalculate/Variable.cc
@@ -277,6 +277,8 @@ KnownVariable::KnownVariable(string cat_, string name_, const MathStructure &o, 
 KnownVariable::KnownVariable(string cat_, string name_, string expression_, string title_, bool is_local, bool is_builtin, bool is_active) : Variable(cat_, name_, title_, is_local, is_builtin, is_active) {
 	mstruct = NULL; mstruct_alt = NULL;
 	calculated_precision = -1;
+	b_expression = false;
+	sexpression = "";
 	suncertainty = "";
 	b_relative_uncertainty = false;
 	sunit = "";


### PR DESCRIPTION
When attempting to run tests on musl, valgrind outputs warnings about uninitialized values. When comparing the two
KnownVariable::KnownVariable methods, b_expression and sexpression were left out in one of them, leading to undefined values for the two of them in KnownVariables::set.

Valgrind output:

```
$ libtool --mode=execute valgrind  --track-origins=yes --leak-check=full ./src/qalc --test-file ./tests/polynomial.batch ==28000== Memcheck, a memory error detector
==28000== Copyright (C) 2002-2024, and GNU GPL'd, by Julian Seward et al. ==28000== Using Valgrind-3.23.1.GIT and LibVEX; rerun with -h for copyright info ==28000== Command: /var/tmp/portage/sci-libs/libqalculate-5.3.0/work/libqalculate-5.3.0/src/.libs/qalc --test-file ./tests/polynomial.batch ==28000==
==28000== Conditional jump or move depends on uninitialised value(s)
==28000==    at 0x4BF8293: KnownVariable::set(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >) (in /var/tmp/portage/sci-libs/libqalculate-5.3.0/work/libqalculate-5.3.0/libqalculate/.libs/libqalculate.so.23.3.0)
==28000==    by 0x4BF8883: KnownVariable::KnownVariable(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, bool, bool, bool) (in /var/tmp/portage/sci-libs/libqalculate-5.3.0/work/libqalculate-5.3.0/libqalculate/.libs/libqalculate.so.23.3.0)
...
```