### PR TITLE
Change sqrt() translation in ru.po

### DIFF
--- a/po-defs/ru.po
+++ b/po-defs/ru.po
@@ -4604,7 +4604,7 @@ msgstr "Квадратный корень"
 
 #: ../data/functions.xml.in.h:410
 msgid "au:&#x221A;,r:sqrt"
-msgstr "au:&#x221A;,корень"
+msgstr "au:&#x221A;,квк"
 
 #: ../data/functions.xml.in.h:411
 msgid ""


### PR DESCRIPTION
Since cbrt() is already кбк() it's only natural to translate sqrt() as квк()
Fixes #775 