### PR TITLE
Add the two new binary SI Prefixes

### DIFF
--- a/data/prefixes.xml.in
+++ b/data/prefixes.xml.in
@@ -128,4 +128,12 @@
     <_names>ar:Yi,r:yobi</_names>
     <exponent>80</exponent>
   </prefix>
+  <prefix type="binary">
+    <_names>ar:Ri,r:robi</_names>
+    <exponent>90</exponent>
+  </prefix>
+  <prefix type="binary">
+    <_names>ar:Qi,r:quebi</_names>
+    <exponent>100</exponent>
+  </prefix>
 </QALCULATE>


### PR DESCRIPTION
Related to #489 which got resolved in 05bb088, but it seems the binary SI prefixes were forgotten?

This PR adds them.

Naming [according to Wikipedia](https://en.wikipedia.org/wiki/Binary_prefix) differs from the one in the aforementioned issue. Not sure what's up with that. This PR uses the names from Wikipedia.