### PR TITLE
Change optimal decimal prefix code to account for the new si prefixes

### DIFF
--- a/libqalculate/Calculator.cc
+++ b/libqalculate/Calculator.cc
@@ -1148,7 +1148,7 @@ DecimalPrefix *Calculator::getOptimalDecimalPrefix(int exp10, int exp, bool all_
 	int exp10_1, exp10_2;
 	while((exp < 0 && i >= 0) || (exp >= 0 && i < (int) decimal_prefixes.size())) {
 		p = decimal_prefixes[i];
-		if(all_prefixes || (p->exponent() % 3 == 0 && p->exponent() >= -24 && p->exponent() <= 24)) {
+		if(all_prefixes || (p->exponent() % 3 == 0 && p->exponent() >= -30 && p->exponent() <= 30)) {
 			if(p_prev && (p_prev->exponent() >= 0) != (p->exponent() >= 0) && p_prev->exponent() != 0) {
 				if(exp < 0) {
 					i++;
@@ -1161,7 +1161,7 @@ DecimalPrefix *Calculator::getOptimalDecimalPrefix(int exp10, int exp, bool all_
 				if(p == decimal_null_prefix) return NULL;
 				return p;
 			} else if(p->exponent(exp) > exp10) {
-				if((exp < 0 && (i == (int) decimal_prefixes.size() - 1 || (!all_prefixes && p->exponent() == 24))) || (exp >= 0 && (i == 0 || (!all_prefixes && p->exponent() == -24)))) {
+				if((exp < 0 && (i == (int) decimal_prefixes.size() - 1 || (!all_prefixes && p->exponent() == 30))) || (exp >= 0 && (i == 0 || (!all_prefixes && p->exponent() == -30)))) {
 					if(p == decimal_null_prefix) return NULL;
 					return p;
 				}
@@ -1201,7 +1201,7 @@ DecimalPrefix *Calculator::getOptimalDecimalPrefix(const Number &exp10, const Nu
 	Number exp10_1, exp10_2;
 	while((exp.isNegative() && i >= 0) || (!exp.isNegative() && i < (int) decimal_prefixes.size())) {
 		p = decimal_prefixes[i];
-		if(all_prefixes || (p->exponent() % 3 == 0 && p->exponent() >= -24 && p->exponent() <= 24)) {
+		if(all_prefixes || (p->exponent() % 3 == 0 && p->exponent() >= -30 && p->exponent() <= 30)) {
 			if(p_prev && (p_prev->exponent() >= 0) != (p->exponent() >= 0) && p_prev->exponent() != 0) {
 				if(exp.isNegative()) {
 					i++;
@@ -1215,7 +1215,7 @@ DecimalPrefix *Calculator::getOptimalDecimalPrefix(const Number &exp10, const Nu
 				if(p == decimal_null_prefix) return NULL;
 				return p;
 			} else if(c == COMPARISON_RESULT_GREATER) {
-				if((exp.isNegative() && (i == (int) decimal_prefixes.size() - 1 || (!all_prefixes && p->exponent() == 24))) || (!exp.isNegative() && (i == 0 || (!all_prefixes && p->exponent() == -24)))) {
+				if((exp.isNegative() && (i == (int) decimal_prefixes.size() - 1 || (!all_prefixes && p->exponent() == 30))) || (!exp.isNegative() && (i == 0 || (!all_prefixes && p->exponent() == -30)))) {
 					if(p == decimal_null_prefix) return NULL;
 					return p;
 				}


### PR DESCRIPTION
Adjusts the code to compute the optimal decimal code to account for the two new si prefixes.

Makes qalc display `1 QB` as `1 QB` instead of `1000000000000000000000000000000 B`.

Related to #805 and #489.