### PR TITLE
Colorize E and digits following it in scientific notation

### DIFF
--- a/libqalculate/MathStructure-print.cc
+++ b/libqalculate/MathStructure-print.cc
@@ -3737,6 +3737,19 @@ string MathStructure::print(const PrintOptions &po, bool format, int colorize, i
 					i_number_end = print_str.length();
 				}
 			}
+
+			if(po.base == BASE_DECIMAL && colorize) {
+				size_t i = print_str.find_first_of("Ee");
+				if(i != string::npos) {
+					if(tagtype == TAG_TYPE_TERMINAL) {
+						print_str.insert(i, colorize == 2 ? "\033[0;92m" : "\033[0;32m");
+					} else if(tagtype == TAG_TYPE_HTML) {
+						print_str.insert(i, colorize == 2 ? "<span style=\"color:#BBFFBB\">" : "<span style=\"color:#008000\">");
+						print_str += "</span>";
+					}
+				}
+			}
+
 			if(colorize && tagtype == TAG_TYPE_TERMINAL) print_str += "\033[0m";
 			else if(colorize && tagtype == TAG_TYPE_HTML) print_str += "</span>";
 			if(!ips.wrap && ips.depth > 0 && o_number.isRational() && !o_number.isInteger() && po.base != BASE_CUSTOM && po.base != BASE_UNICODE) {

--- a/libqalculate/MathStructure-print.cc
+++ b/libqalculate/MathStructure-print.cc
@@ -3618,7 +3618,10 @@ string MathStructure::print(const PrintOptions &po, bool format, int colorize, i
 						print_str += "</small></sub>";
 					}
 				}
+				bool color_span_unclosed = colorize;
 				if(!exp.empty() && !EXP_MODE_10 && po.base == 10) {
+					if(color_span_unclosed) print_str += "</span>";
+					color_span_unclosed = false;
 					if(po.exp_display == EXP_UPPERCASE_E) print_str += "<small>E</small>";
 					else print_str += "e";
 					if(exp_minus) {
@@ -3662,7 +3665,8 @@ string MathStructure::print(const PrintOptions &po, bool format, int colorize, i
 					if(ips.power_depth <= 0) print_str += "</sup>";
 				} else if(BASE_IS_SEXAGESIMAL(po.base) || po.base == BASE_TIME) {
 					if(po.exp_display == EXP_UPPERCASE_E) {
-						gsub("E", "<small>E</small>", print_str);
+						gsub("E", color_span_unclosed ? "</span><small>E</small>" : "<small>E</small>", print_str);
+						color_span_unclosed = false;
 					} else if(po.exp_display == EXP_POWER_OF_10 && ips.power_depth <= 0) {
 						size_t i = print_str.find("10^");
 						if(i != string::npos) {
@@ -3675,6 +3679,7 @@ string MathStructure::print(const PrintOptions &po, bool format, int colorize, i
 						}
 					}
 				}
+				if(color_span_unclosed) print_str += "</span>";
 			} else {
 				if(po.exp_display == EXP_POWER_OF_10) {
 					PrintOptions po2 = po;
@@ -3736,22 +3741,13 @@ string MathStructure::print(const PrintOptions &po, bool format, int colorize, i
 					print_str += o_number.print(po, ips_n);
 					i_number_end = print_str.length();
 				}
-			}
-
-			if(po.base == BASE_DECIMAL && colorize) {
-				size_t i = print_str.find_first_of("Ee");
-				if(i != string::npos) {
-					if(tagtype == TAG_TYPE_TERMINAL) {
-						print_str.insert(i, colorize == 2 ? "\033[0;92m" : "\033[0;32m");
-					} else if(tagtype == TAG_TYPE_HTML) {
-						print_str.insert(i, colorize == 2 ? "<span style=\"color:#BBFFBB\">" : "<span style=\"color:#008000\">");
-						print_str += "</span>";
-					}
+				if(colorize) {
+					size_t i = po.base == BASE_DECIMAL ? print_str.find_first_of("Ee") : string::npos;
+					if(i != string::npos) print_str.insert(i, "\033[0m");
+					else print_str += "\033[0m";
 				}
 			}
 
-			if(colorize && tagtype == TAG_TYPE_TERMINAL) print_str += "\033[0m";
-			else if(colorize && tagtype == TAG_TYPE_HTML) print_str += "</span>";
 			if(!ips.wrap && ips.depth > 0 && o_number.isRational() && !o_number.isInteger() && po.base != BASE_CUSTOM && po.base != BASE_UNICODE) {
 				for(size_t i = i_number + 1; i + 1 < i_number_end; i++) {
 					if(print_str[i] == DIVISION_CH || ((unsigned char) print_str[i] == 0xE2 && (unsigned char) print_str[i + 1] == 0x88 && i + 2 < print_str.size() && (unsigned char) print_str[i + 2] == 0x95) || ((unsigned char) print_str[i] == 0xC3 && (unsigned char) print_str[i + 1] == 0xB7)) {


### PR DESCRIPTION
Make it easier to spot the magnitude by using a different color than the rest of the number
![image](https://github.com/user-attachments/assets/126a09b4-5e21-47ee-89c7-e1abbb8e2fae)
- I used the same color used as units, which seemed the most appropriate given the current palette. If a different color should be used, let me know.
- The ANSI escape/HTML <span> is `insert`ed similar to how repeating decimals overline is added.