### PR TITLE
Fix segfault when Calculator is destroyed with uninitialized randstate

### DIFF
--- a/libqalculate/Number.cc
+++ b/libqalculate/Number.cc
@@ -84,7 +84,10 @@ void init_randstate() {
 	init_randstate(seed);
 }
 void clear_randstate() {
-	gmp_randclear(randstate);
+	if (randstate_initialized) {
+		gmp_randclear(randstate);
+		randstate_initialized = false;
+	}
 }
 
 Number nr_e;


### PR DESCRIPTION
Previously, we would crash if the destructor of `Calculator` was invoked with the global GMP randstate not being initialized.  For reproduction, this simple program is sufficient:
```cxx
#include <libqalculate/Calculator.h>

int main() {
    Calculator calc{};

    return 0;
}
```
Which used to produce this stack trace:
```
#0  0x00007ffff729f844 in __gmp_randclear () from /nix/store/9q9777l352qfg127kwbfilali7mcynr1-gmp-with-cxx-6.3.0/lib/libgmp.so.10
#1  0x00007ffff79857a6 in Calculator::~Calculator (this=0x7fffffff47b0) at Calculator.cc:701
#2  0x00005555555551ad in main ()
```

This implements a simple check if the state is initialized to avoid attempting to free an uninitialized global variable.