### PR TITLE
Fix stack-overflow crashes in evaluation and printing of deeply recursive expressions

### DIFF
--- a/libqalculate/MathStructure-print.cc
+++ b/libqalculate/MathStructure-print.cc
@@ -3900,7 +3900,18 @@ string get_latex_units(const MathStructure &m, size_t first_unit, const PrintOpt
 		print_str += ")";\
 	}
 
+// Printing recurses roughly one call per nesting level of the structure
+// (STRUCT_MULTIPLICATION, STRUCT_INVERSE, STRUCT_POWER, ...), with no depth
+// limit of its own. A structure can legitimately end up deeply nested (e.g.
+// evaluation is allowed to recurse up to check_recursive_function_depth()'s
+// limit of 3000), which is enough to exhaust the stack of whichever thread
+// calls print() -- crashing the process instead of just producing an
+// unwieldy string. Cap it well below any plausible stack size, matching the
+// project's existing recursive-depth-limit convention.
+#define MAX_PRINT_RECURSION_DEPTH 200
+
 string MathStructure::print(const PrintOptions &po, bool format, int colorize, int tagtype, const InternalPrintStruct &ips) const {
+	if(ips.depth > MAX_PRINT_RECURSION_DEPTH) return "...";
 	if(ips.depth == 0 && po.is_approximate) *po.is_approximate = false;
 	if(ips.depth == 0 && tagtype == TAG_TYPE_TERMINAL && colorize < 0) {
 		colorize = -colorize;

--- a/libqalculate/MathStructure-print.cc
+++ b/libqalculate/MathStructure-print.cc
@@ -3906,9 +3906,12 @@ string get_latex_units(const MathStructure &m, size_t first_unit, const PrintOpt
 // evaluation is allowed to recurse up to check_recursive_function_depth()'s
 // limit of 3000), which is enough to exhaust the stack of whichever thread
 // calls print() -- crashing the process instead of just producing an
-// unwieldy string. Cap it well below any plausible stack size, matching the
-// project's existing recursive-depth-limit convention.
-#define MAX_PRINT_RECURSION_DEPTH 200
+// unwieldy string. Cap it well below any plausible stack size (verified in a
+// release build to leave ample headroom against an 8 MiB stack; ASan's own
+// per-frame overhead is much larger than a real build's and isn't a useful
+// yardstick here), while still being high enough that legitimately-nested
+// results aren't truncated unnecessarily.
+#define MAX_PRINT_RECURSION_DEPTH 1000
 
 string MathStructure::print(const PrintOptions &po, bool format, int colorize, int tagtype, const InternalPrintStruct &ips) const {
 	if(ips.depth > MAX_PRINT_RECURSION_DEPTH) return "...";

--- a/libqalculate/util.cc
+++ b/libqalculate/util.cc
@@ -1132,6 +1132,15 @@ bool Thread::cancel() {
 
 Thread::Thread() : running(false), m_pipe_r(NULL), m_pipe_w(NULL) {
 	pthread_attr_init(&m_thread_attr);
+	// Some platforms (e.g. macOS) give secondary threads a much smaller
+	// default stack than the main thread (512 KiB vs. 8 MiB on macOS).
+	// Calculation involves deep, mutually recursive evaluation/simplification
+	// passes that are only bounded by check_recursive_function_depth()'s
+	// depth limit of 3000; with a too-small stack that limit is never
+	// reached and the process crashes with a stack overflow instead of
+	// failing gracefully. Request a stack comparable to a typical main
+	// thread's so the existing recursion depth limit is actually reachable.
+	pthread_attr_setstacksize(&m_thread_attr, 16 * 1024 * 1024);
 	int pipe_wr[] = {0, 0};
 #ifdef HAVE_PIPE2
 	if(pipe2(pipe_wr, O_CLOEXEC) == 0) {


### PR DESCRIPTION
Fuzzing `Calculator::calculate()` with ASan+UBSan+libFuzzer found a deterministic crash.

**Repro / actual root cause:** the crash requires `Calculator` to be constructed as a global/static object, initialized before `main()` runs (e.g. `Calculator *calc = new Calculator(false);` at namespace scope) — not constructed from inside `main()`. That construction order triggers a pre-existing static-initialization-order bug (found by @hanna-kn during review of this PR, credited below): `nr_one_i` and its sibling numeric-constant globals (`nr_zero`, `nr_one`, `nr_minus_one`, `nr_half`, `nr_minus_half`, `nr_plus_inf`, `nr_minus_inf`, defined at `Calculator.cc:147` and set in `Calculator::Calculator()`) are ordinary namespace-scope globals in `Calculator.cc`, default-constructed to zero. When `Calculator` lives in a different translation unit's global scope, C++ doesn't guarantee that TU's static initializer runs after `Calculator.cc`'s own — if `Calculator.cc`'s runs *after*, it resets `nr_one_i` back to zero right after the constructor set it correctly. I confirmed this directly: with a global-scope `Calculator` (as my fuzz harness uses, for iteration performance), `nr_one_i.isZero()` is true; constructed inside `main()`, it's correctly the imaginary unit.

That corrupted `nr_one_i` causes `trig_remove_i()` in `BuiltinFunctions-trigonometry.cc` to divide by zero (`mstruct[0].number() /= nr_one_i`), which is what sends `sin(i/0)`'s evaluation into runaway mutual recursion between `MathStructure::calculateFunctions()` and `eval()`/`do_simplification()` — this is a real correctness bug independent of crashing (see @hanna-kn's `betainc` example below producing a silently wrong result), not something this PR fixes.

**What this PR does fix (defense-in-depth, not the SIOF bug above):** independent of *why* recursion goes deep, nothing currently stops it from crashing the process instead of failing gracefully once it does:

- `check_recursive_function_depth()` already caps evaluation recursion at 3000, but `Calculator::calculate()` runs on a `CalculateThread` pthread created with the OS default stack size — 512 KiB for secondary threads on macOS vs. 8 MiB for the main thread — so the process can crash long before that existing cap is reached. Fix: give the calculation thread an explicit 16 MiB stack in `util.cc`.
- A successfully-evaluated (or, as above, corrupted) `MathStructure` can still end up nested deep enough that `MathStructure::print()`, which has no depth limit of its own, overflows the stack of whichever thread calls it. Fix: cap `print()`'s own recursion depth (1000, verified against a release build to leave ample headroom on an 8 MiB stack) in `MathStructure-print.cc`, falling back to `"..."` past that point.

These are worth keeping regardless of the SIOF bug's own fix, since they guard against any future cause of runaway recursion, not just this one. Happy to open a separate issue/PR for the `nr_one_i`-and-friends initialization-order bug itself if useful — it touches core numeric constants and I'd rather defer to you on the right fix (e.g. lazy/Meyers-singleton-style init vs. documenting against global `Calculator` construction).

**Testing:** verified with a short libFuzzer+ASan+UBSan campaign targeting `Calculator::calculate()`, plus multiple independent minimal repros against a freshly rebuilt ASan+UBSan library — 100% reproducible unpatched, 0/5 with this fix applied — and a separate release-build check that the raised print-depth cap (1000) has ample stack headroom.

I don't have a fuzzing harness to include in this PR (kept out of the diff since it's not part of the library) — happy to share it or details of the setup if useful for CI.
