### PR TITLE
Fix NULL pointer dereference in Calculator::parseToExpression() with prefix queries

### DIFF
--- a/libqalculate/Calculator-calculate.cc
+++ b/libqalculate/Calculator-calculate.cc
@@ -2921,11 +2921,11 @@ string Calculator::parseToExpression(string to_str, EvaluationOptions &evalops, 
 					if(to_str[0] == 'a') {
 						printops.use_all_prefixes = true;
 					} else if(to_str[0] == 'd') {
-						if(*binary_prefixes) *binary_prefixes = 0;
+						if(binary_prefixes) *binary_prefixes = 0;
 					}
 				} else if(to_str.length() > 1 && to_str[1] == '?' && to_str[0] == 'b') {
 					// b? in front of unit expression: use binary prefixes
-					if(*binary_prefixes) *binary_prefixes = 2;
+					if(binary_prefixes) *binary_prefixes = 2;
 				}
 				// expression after "to" is by default interpreted as unit expression
 				if(!str_conv.empty()) str_conv += " to ";


### PR DESCRIPTION
### Problem
Calling `Calculator::parseToExpression()` with unit prefix queries such as `"d?m"` (request decimal prefix) or `"b?m"` (request binary prefix) using default arguments causes a `SIGSEGV` crash (address 0x0 read) and UBSan `load of null pointer of type 'int'`.

### Reproduction
```cpp
#include <libqalculate/qalculate.h>

int main() {
    new Calculator();
    EvaluationOptions eo;
    PrintOptions po;

    // Crashes with SEGV on address 0x0
    CALCULATOR->parseToExpression("d?m", eo, po);
    CALCULATOR->parseToExpression("b?m", eo, po);
    return 0;
}
```

```bash
clang++ -fsanitize=address,undefined repro.cc -lqalculate
./a.out
# AddressSanitizer: SEGV on unknown address 0x000000000000 in Calculator::parseToExpression() at Calculator-calculate.cc:2924
```

### Root Cause
In `libqalculate/Calculator.h:738`, `parseToExpression()` declares:
```cpp
std::string parseToExpression(
    std::string to_str,
    EvaluationOptions &evalops,
    PrintOptions &printops,
    Number *custom_base = NULL,
    int *binary_prefixes = NULL,
    bool *complex_angle_form = NULL,
    bool *do_factors = NULL,
    bool *do_pfe = NULL,
    bool *do_calendars = NULL,
    bool *do_bases = NULL) const;
```

When callers invoke `parseToExpression(to_str, eo, po)` with default arguments, `binary_prefixes` defaults to `NULL`. While the function checks `if(binary_prefixes)` at entry on line 2702, lines 2924 and 2928 dereference the pointer without verifying it is non-null:
```cpp
} else if(to_str[0] == 'd') {
    if(*binary_prefixes) *binary_prefixes = 0; // NULL pointer dereference
}
} else if(to_str.length() > 1 && to_str[1] == '?' && to_str[0] == 'b') {
    if(*binary_prefixes) *binary_prefixes = 2; // NULL pointer dereference
}
```

### Fix
Check `if(binary_prefixes)` instead of `if(*binary_prefixes)` on lines 2924 and 2928 of `libqalculate/Calculator-calculate.cc`.

### Verification
- Tested with the reproducer under Clang ASan and UBSan: crashes on master, completes cleanly with exit code 0 after this change.
- Tested with an explicit non-null pointer (`int bin_prefixes = -1; CALCULATOR->parseToExpression("d?m", eo, po, NULL, &bin_prefixes);`): properly assigns `0` for `d?` and `2` for `b?`.